### PR TITLE
Hide tmp file under Linux

### DIFF
--- a/main/launcher/src/main/java/org/cryptomator/launcher/InterProcessCommunicator.java
+++ b/main/launcher/src/main/java/org/cryptomator/launcher/InterProcessCommunicator.java
@@ -80,7 +80,7 @@ abstract class InterProcessCommunicator implements InterProcessCommunicationProt
 		final String settingsPathProperty = System.getProperty("cryptomator.ipcPortPath");
 		if (settingsPathProperty == null) {
 			LOG.warn("System property cryptomator.ipcPortPath not set.");
-			return Paths.get("ipcPort.tmp");
+			return Paths.get(".ipcPort.tmp");
 		} else {
 			return Paths.get(replaceHomeDir(settingsPathProperty));
 		}


### PR DESCRIPTION
Hey,

the "ipcPort.tmp" is visible by default and disturbs the aesthetics in my home dir ;)

I hope this change won't break anything. I did not test it.

Greetings
