### PR TITLE
Updated minimum required version of Java Development Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ For more information on the security details visit [cryptomator.org](https://cry
 
 ### Dependencies
 
-* Java 8 (min. 8u51, we recommend to use the current version)
-* [JCE unlimited strength policy files](http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html) (needed for 256-bit keys)
+* Java 10 (min. 10.0.1, we recommend to use the current version)
 * Maven 3
 * Optional: OS-dependent build tools for native packaging (see [Windows](https://github.com/cryptomator/cryptomator-win), [OS X](https://github.com/cryptomator/cryptomator-osx), [Linux](https://github.com/cryptomator/builder-containers))
 


### PR DESCRIPTION
Updated minimum required version of Java Development Kit, because this has changed since [Cryptomator version 1.4.0](https://community.cryptomator.org/t/how-to-run-cryptomator-1-4-0-beta1-jar/1599/4). Skipping over Java 9, because [its support has already ended](http://www.oracle.com/technetwork/java/javase/downloads/jdk9-downloads-3848520.html). Also, JCE unlimited strength policy files are [now included in the JDK by default](http://www.oracle.com/technetwork/java/javase/documentation/jdk10-readme-4419830.html#jce), so they no longer need to be mentioned separately.