### PR TITLE
Implemented graceful shutdown confirmation dialog

### DIFF
--- a/main/ui/src/main/java/org/cryptomator/ui/controllers/MainController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/controllers/MainController.java
@@ -224,13 +224,13 @@ public class MainController implements ViewController {
 					forceShutdownButtonType, forceShutdownButtonType, tryAgainButtonType);
 
 			Optional<ButtonType> choice = gracefulShutdownDialog.showAndWait();
-			if (choice.isPresent()) {
-				if (tryAgainButtonType.equals(choice.get())) {
+			choice.ifPresent(btnType -> {
+				if (tryAgainButtonType.equals(btnType)) {
 					gracefulShutdown();
-				} else if (forceShutdownButtonType.equals(choice.get())) {
+				} else if (forceShutdownButtonType.equals(btnType)) {
 					Platform.runLater(Platform::exit);
 				}
-			}
+			});
 		}
 	}
 

--- a/main/ui/src/main/java/org/cryptomator/ui/controllers/MainController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/controllers/MainController.java
@@ -217,16 +217,11 @@ public class MainController implements ViewController {
 	private void gracefulShutdown() {
 		vaults.filtered(Vault.NOT_LOCKED).forEach(Vault::prepareForShutdown);
 		if (!vaults.filtered(Vault.NOT_LOCKED).isEmpty()) {
-			ButtonType tryAgainButtonType = new ButtonType(
-					localization.getString("main.gracefulShutdown.button.tryAgain"));
-			ButtonType forceShutdownButtonType = new ButtonType(
-					localization.getString("main.gracefulShutdown.button.forceShutdown"));
+			ButtonType tryAgainButtonType = new ButtonType(localization.getString("main.gracefulShutdown.button.tryAgain"));
+			ButtonType forceShutdownButtonType = new ButtonType(localization.getString("main.gracefulShutdown.button.forceShutdown"));
 			Alert gracefulShutdownDialog = DialogBuilderUtil.buildGracefulShutdownDialog(
-					localization.getString("main.gracefulShutdown.dialog.title"),
-					localization.getString("main.gracefulShutdown.dialog.header"),
-					localization.getString("main.gracefulShutdown.dialog.content"),
-					tryAgainButtonType,
-					forceShutdownButtonType);
+					localization.getString("main.gracefulShutdown.dialog.title"), localization.getString("main.gracefulShutdown.dialog.header"), localization.getString("main.gracefulShutdown.dialog.content"),
+					forceShutdownButtonType, forceShutdownButtonType, tryAgainButtonType);
 
 			Optional<ButtonType> choice = gracefulShutdownDialog.showAndWait();
 			if (choice.isPresent()) {

--- a/main/ui/src/main/java/org/cryptomator/ui/controllers/MainController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/controllers/MainController.java
@@ -216,7 +216,27 @@ public class MainController implements ViewController {
 
 	private void gracefulShutdown() {
 		vaults.filtered(Vault.NOT_LOCKED).forEach(Vault::prepareForShutdown);
-		Platform.runLater(Platform::exit);
+		if (!vaults.filtered(Vault.NOT_LOCKED).isEmpty()) {
+			ButtonType tryAgainButtonType = new ButtonType(
+					localization.getString("main.gracefulShutdown.button.tryAgain"));
+			ButtonType forceShutdownButtonType = new ButtonType(
+					localization.getString("main.gracefulShutdown.button.forceShutdown"));
+			Alert gracefulShutdownDialog = DialogBuilderUtil.buildGracefulShutdownDialog(
+					localization.getString("main.gracefulShutdown.dialog.title"),
+					localization.getString("main.gracefulShutdown.dialog.header"),
+					localization.getString("main.gracefulShutdown.dialog.content"),
+					tryAgainButtonType,
+					forceShutdownButtonType);
+
+			Optional<ButtonType> choice = gracefulShutdownDialog.showAndWait();
+			if (choice.isPresent()) {
+				if (tryAgainButtonType.equals(choice.get())) {
+					gracefulShutdown();
+				} else if (forceShutdownButtonType.equals(choice.get())) {
+					Platform.runLater(Platform::exit);
+				}
+			}
+		}
 	}
 
 	private void loadFont(String resourcePath) {

--- a/main/ui/src/main/java/org/cryptomator/ui/util/DialogBuilderUtil.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/util/DialogBuilderUtil.java
@@ -38,8 +38,8 @@ public class DialogBuilderUtil {
 		return buildDialog(title, header, content, Alert.AlertType.CONFIRMATION, defaultButton, ButtonType.YES, ButtonType.NO);
 	}
 
-	public static Alert buildGracefulShutdownDialog(String title, String header, String content, ButtonType tryAgainButton, ButtonType forceShutdownButton) {
-		return buildDialog(title, header, content, Alert.AlertType.WARNING, tryAgainButton, tryAgainButton, forceShutdownButton);
+	public static Alert buildGracefulShutdownDialog(String title, String header, String content, ButtonType defaultButton, ButtonType... buttons) {
+		return buildDialog(title, header, content, Alert.AlertType.WARNING, defaultButton, buttons);
 	}
 
 	private static Alert buildDialog(String title, String header, String content, Alert.AlertType type, ButtonType defaultButton, ButtonType... buttons) {

--- a/main/ui/src/main/java/org/cryptomator/ui/util/DialogBuilderUtil.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/util/DialogBuilderUtil.java
@@ -38,6 +38,10 @@ public class DialogBuilderUtil {
 		return buildDialog(title, header, content, Alert.AlertType.CONFIRMATION, defaultButton, ButtonType.YES, ButtonType.NO);
 	}
 
+	public static Alert buildGracefulShutdownDialog(String title, String header, String content, ButtonType tryAgainButton, ButtonType forceShutdownButton) {
+		return buildDialog(title, header, content, Alert.AlertType.WARNING, tryAgainButton, tryAgainButton, forceShutdownButton);
+	}
+
 	private static Alert buildDialog(String title, String header, String content, Alert.AlertType type, ButtonType defaultButton, ButtonType... buttons) {
 		Text contentText = new Text(content);
 		contentText.setWrappingWidth(360.0);

--- a/main/ui/src/main/resources/localization/en.txt
+++ b/main/ui/src/main/resources/localization/en.txt
@@ -19,6 +19,11 @@ main.directoryList.remove.confirmation.content=The vault will only be removed fr
 main.createVault.nonEmptyDir.title=Creating vault failed
 main.createVault.nonEmptyDir.header=Chosen directory is not empty
 main.createVault.nonEmptyDir.content=The selected directory already contains files (possibly hidden). A vault can only be created in an empty directory.
+main.gracefulShutdown.dialog.title=Locking vault(s) failed
+main.gracefulShutdown.dialog.header=Vault(s) in use
+main.gracefulShutdown.dialog.content=One or more vaults are still in use by other programs. Please close them to allow Cryptomator to shut down properly, then try again.\n\nIf this doesn't work, Cryptomator can shut down forcefully, but this can incur data loss and is not recommended.
+main.gracefulShutdown.button.tryAgain=Try again
+main.gracefulShutdown.button.forceShutdown=Force shutdown
 
 # welcome.fxml
 welcome.checkForUpdates.label.currentlyChecking=Checking for Updates...


### PR DESCRIPTION
Implemented confirmation dialog when graceful shutdown of Cryptomator fails, so that the user can try again or opt to shutdown forcefully. Implements issue #230.