### PR TITLE
Added a Cancel button to the graceful shutdown-dialog

### DIFF
--- a/main/ui/src/main/java/org/cryptomator/ui/controllers/MainController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/controllers/MainController.java
@@ -222,7 +222,7 @@ public class MainController implements ViewController {
 			ButtonType forceShutdownButtonType = new ButtonType(localization.getString("main.gracefulShutdown.button.forceShutdown"));
 			Alert gracefulShutdownDialog = DialogBuilderUtil.buildGracefulShutdownDialog(
 					localization.getString("main.gracefulShutdown.dialog.title"), localization.getString("main.gracefulShutdown.dialog.header"), localization.getString("main.gracefulShutdown.dialog.content"),
-					forceShutdownButtonType, forceShutdownButtonType, tryAgainButtonType);
+					forceShutdownButtonType, ButtonType.CANCEL, forceShutdownButtonType, tryAgainButtonType);
 
 			Optional<ButtonType> choice = gracefulShutdownDialog.showAndWait();
 			choice.ifPresent(btnType -> {
@@ -230,6 +230,8 @@ public class MainController implements ViewController {
 					gracefulShutdown();
 				} else if (forceShutdownButtonType.equals(btnType)) {
 					Platform.runLater(Platform::exit);
+				} else {
+					return;
 				}
 			});
 		} else {


### PR DESCRIPTION
Fixed issue #771 by adding a Cancel button to the graceful shutdown dialog, so that the user can abort shutdown in case of an accident.