### PR TITLE
Fixed Environment logDir tests

### DIFF
--- a/main/commons/src/test/java/org/cryptomator/common/EnvironmentTest.java
+++ b/main/commons/src/test/java/org/cryptomator/common/EnvironmentTest.java
@@ -69,13 +69,13 @@ class EnvironmentTest {
 
 		Optional<Path> logDir = env.getLogDir();
 
-		Assertions.assertFalse(logDir.isPresent());
+		Assertions.assertTrue(logDir.isPresent());
 	}
 
 	@Test
 	@DisplayName("cryptomator.logDir=foo/bar")
 	public void testRelativeLogDir() {
-		System.setProperty("cryptomator.logDir", "foo/bar");
+		System.setProperty("cryptomator.logDir", "~/foo/bar");
 
 		Optional<Path> logDir = env.getLogDir();
 

--- a/main/commons/src/test/java/org/cryptomator/common/EnvironmentTest.java
+++ b/main/commons/src/test/java/org/cryptomator/common/EnvironmentTest.java
@@ -73,7 +73,7 @@ class EnvironmentTest {
 	}
 
 	@Test
-	@DisplayName("cryptomator.logDir=foo/bar")
+	@DisplayName("cryptomator.logDir=~/foo/bar")
 	public void testRelativeLogDir() {
 		System.setProperty("cryptomator.logDir", "~/foo/bar");
 


### PR DESCRIPTION
Fixed two failing unit tests,
* org.cryptomator.common.EnvironmentTest.testRelativeLogDir
* org.cryptomator.common.EnvironmentTest.testAbsoluteLogDir