### PR TITLE
Hide startHidden setting when system tray is not supported

### DIFF
--- a/main/ui/src/main/java/org/cryptomator/ui/preferences/GeneralPreferencesController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/preferences/GeneralPreferencesController.java
@@ -1,5 +1,7 @@
 package org.cryptomator.ui.preferences;
 
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.value.ObservableValue;
 import javafx.geometry.NodeOrientation;
 import javafx.scene.control.CheckBox;
@@ -15,12 +17,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.awt.SystemTray;
 
 @PreferencesScoped
 public class GeneralPreferencesController implements FxController {
 	
 	private static final Logger LOG = LoggerFactory.getLogger(GeneralPreferencesController.class);
 
+	private final BooleanProperty systemTraySupported = new SimpleBooleanProperty(SystemTray.isSupported());
 	private final Settings settings;
 	public ChoiceBox<UiTheme> themeChoiceBox;
 	public CheckBox startHiddenCheckbox;

--- a/main/ui/src/main/resources/fxml/preferences_general.fxml
+++ b/main/ui/src/main/resources/fxml/preferences_general.fxml
@@ -30,7 +30,7 @@
 			<RadioButton fx:id="nodeOrientationRtl" text="Right to Left" alignment="CENTER_RIGHT" toggleGroup="${nodeOrientation}"/>
 		</HBox>
 
-		<CheckBox fx:id="startHiddenCheckbox" text="%preferences.general.startHidden"/>
+		<CheckBox fx:id="startHiddenCheckbox" text="%preferences.general.startHidden" visible="${controller.systemTraySupported}" managed="${controller.systemTraySupported}"/>
 
 		<CheckBox fx:id="debugModeCheckbox" text="%preferences.general.debugLogging"/>
 	</children>


### PR DESCRIPTION
For platform not supporting system tray, users will have no chance to show
window and modify settings back again if the window is hidden at startup.