### PR TITLE
Hide startHidden setting when system tray is not supported

### DIFF
--- a/main/ui/src/main/java/org/cryptomator/ui/preferences/GeneralPreferencesController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/preferences/GeneralPreferencesController.java
@@ -15,6 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 @PreferencesScoped
 public class GeneralPreferencesController implements FxController {
@@ -22,6 +23,7 @@ public class GeneralPreferencesController implements FxController {
 	private static final Logger LOG = LoggerFactory.getLogger(GeneralPreferencesController.class);
 
 	private final Settings settings;
+	private final boolean trayMenuSupported;
 	public ChoiceBox<UiTheme> themeChoiceBox;
 	public CheckBox startHiddenCheckbox;
 	public CheckBox debugModeCheckbox;
@@ -30,8 +32,9 @@ public class GeneralPreferencesController implements FxController {
 	public RadioButton nodeOrientationRtl;
 
 	@Inject
-	GeneralPreferencesController(Settings settings) {
+	GeneralPreferencesController(Settings settings, @Named("trayMenuSupported") boolean trayMenuSupported) {
 		this.settings = settings;
+		this.trayMenuSupported = trayMenuSupported;
 	}
 
 	public void initialize() {
@@ -46,6 +49,10 @@ public class GeneralPreferencesController implements FxController {
 		nodeOrientation.selectedToggleProperty().addListener(this::toggleNodeOrientation);
 		nodeOrientationLtr.setSelected(settings.userInterfaceOrientation().get() == NodeOrientation.LEFT_TO_RIGHT);
 		nodeOrientationRtl.setSelected(settings.userInterfaceOrientation().get() == NodeOrientation.RIGHT_TO_LEFT);
+	}
+
+	public boolean isTrayMenuSupported() {
+		return this.trayMenuSupported;
 	}
 
 	private void toggleNodeOrientation(@SuppressWarnings("unused") ObservableValue<? extends Toggle> observable, @SuppressWarnings("unused") Toggle oldValue, Toggle newValue) {

--- a/main/ui/src/main/resources/fxml/preferences_general.fxml
+++ b/main/ui/src/main/resources/fxml/preferences_general.fxml
@@ -30,7 +30,7 @@
 			<RadioButton fx:id="nodeOrientationRtl" text="Right to Left" alignment="CENTER_RIGHT" toggleGroup="${nodeOrientation}"/>
 		</HBox>
 
-		<CheckBox fx:id="startHiddenCheckbox" text="%preferences.general.startHidden"/>
+		<CheckBox fx:id="startHiddenCheckbox" text="%preferences.general.startHidden" visible="${controller.trayMenuSupported}" managed="${controller.trayMenuSupported}"/>
 
 		<CheckBox fx:id="debugModeCheckbox" text="%preferences.general.debugLogging"/>
 	</children>


### PR DESCRIPTION
For platform not supporting system tray, users will have no chance to show
window and modify settings back again if the window is hidden at startup.

This is the revised version according to comments from #1025
Please see if this works for you, thanks!
