### PR TITLE
Handle close request event for main window

### DIFF
--- a/main/ui/src/main/java/org/cryptomator/ui/mainwindow/MainWindowTitleController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/mainwindow/MainWindowTitleController.java
@@ -59,6 +59,7 @@ public class MainWindowTitleController implements FxController {
 		});
 		window.setOnCloseRequest(event -> {
 			close();
+			event.consume();
 		});
 	}
 

--- a/main/ui/src/main/java/org/cryptomator/ui/mainwindow/MainWindowTitleController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/mainwindow/MainWindowTitleController.java
@@ -57,6 +57,9 @@ public class MainWindowTitleController implements FxController {
 			window.setX(event.getScreenX() - xOffset);
 			window.setY(event.getScreenY() - yOffset);
 		});
+		window.setOnCloseRequest(event -> {
+			close();
+		});
 	}
 
 	@FXML


### PR DESCRIPTION
When receiving close request event, main window should quit program if there is no system tray available, and just like the close button was clicked. The window close request event happens when user close window by pressing alt-f4 (Gnome) or when receiving `WM_DELETE_WINDOW` xwindow event. Current behavior is just close the window and let the program keep running, and there is no way to quit program without system tray.

The best place to handle this event should be in `MainWindowController`, but it's pretty much what the close button does in `MainWindowTitleController`. So I think it should be _okay_ to put
the handler at there.