### PR TITLE
Update donation key store uri

### DIFF
--- a/main/ui/src/main/java/org/cryptomator/ui/preferences/DonationKeyPreferencesController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/preferences/DonationKeyPreferencesController.java
@@ -12,7 +12,7 @@ import javax.inject.Inject;
 @PreferencesScoped
 public class DonationKeyPreferencesController implements FxController {
 	
-	private static final String DONATION_URI = "https://store.cryptomator.org/desktop";
+	private static final String DONATION_URI = "https://cryptomator.org/store/desktop/";
 
 	private final Application application;
 	private final LicenseHolder licenseHolder;


### PR DESCRIPTION
The old url returns a 404 error
Also congrats on 1.5.0 :)