### PR TITLE
Update README.md, Security Architecture URL 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Download native binaries of Cryptomator on [cryptomator.org](https://cryptomator
 
 ### Security Architecture
 
-For more information on the security details visit [cryptomator.org](https://cryptomator.org/architecture/).
+For more information on the security details visit [cryptomator.org](https://docs.cryptomator.org/en/latest/security/architecture/).
 
 ## Building
 


### PR DESCRIPTION
Hi, just noticed a link was 404ing on the README, updated the URL with what I thought was equivalent on the new website.