### PR TITLE
Close unlockScene after entering the phrase and unlocking the vault

### DIFF
--- a/main/ui/src/main/java/org/cryptomator/ui/unlock/UnlockWorkflow.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/unlock/UnlockWorkflow.java
@@ -130,19 +130,11 @@ public class UnlockWorkflow extends Task<Boolean> {
 				window.show();
 			});
 			case REVEAL -> {
-				Platform.runLater(() -> {
-					window.setScene(unlockScene.get());
-					window.close();
-				});
+				Platform.runLater(window::close);
 
 				vaultService.reveal(vault);
 			}
-			case IGNORE -> {
-				Platform.runLater(() -> {
-					window.setScene(unlockScene.get());
-					window.close();
-				});
-			}
+			case IGNORE -> { Platform.runLater(window::close); }
 		}
 	}
 

--- a/main/ui/src/main/java/org/cryptomator/ui/unlock/UnlockWorkflow.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/unlock/UnlockWorkflow.java
@@ -100,10 +100,6 @@ public class UnlockWorkflow extends Task<Boolean> {
 		while (proceed) {
 			try {
 				vault.unlock(CharBuffer.wrap(password.get()));
-				Platform.runLater(() -> {
-					window.setScene(unlockScene.get());
-					window.close();
-				});
 				return true;
 			} catch (InvalidPassphraseException e) {
 				proceed = askForPassword(true) == PasswordEntry.PASSWORD_ENTERED;
@@ -133,8 +129,20 @@ public class UnlockWorkflow extends Task<Boolean> {
 				window.setScene(successScene.get());
 				window.show();
 			});
-			case REVEAL -> vaultService.reveal(vault);
-			case IGNORE -> {}
+			case REVEAL -> {
+				Platform.runLater(() -> {
+					window.setScene(unlockScene.get());
+					window.close();
+				});
+
+				vaultService.reveal(vault);
+			}
+			case IGNORE -> {
+				Platform.runLater(() -> {
+					window.setScene(unlockScene.get());
+					window.close();
+				});
+			}
 		}
 	}
 

--- a/main/ui/src/main/java/org/cryptomator/ui/unlock/UnlockWorkflow.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/unlock/UnlockWorkflow.java
@@ -100,6 +100,10 @@ public class UnlockWorkflow extends Task<Boolean> {
 		while (proceed) {
 			try {
 				vault.unlock(CharBuffer.wrap(password.get()));
+				Platform.runLater(() -> {
+					window.setScene(unlockScene.get());
+					window.close();
+				});
 				return true;
 			} catch (InvalidPassphraseException e) {
 				proceed = askForPassword(true) == PasswordEntry.PASSWORD_ENTERED;

--- a/main/ui/src/main/java/org/cryptomator/ui/unlock/UnlockWorkflow.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/unlock/UnlockWorkflow.java
@@ -131,10 +131,9 @@ public class UnlockWorkflow extends Task<Boolean> {
 			});
 			case REVEAL -> {
 				Platform.runLater(window::close);
-
 				vaultService.reveal(vault);
 			}
-			case IGNORE -> { Platform.runLater(window::close); }
+			case IGNORE -> Platform.runLater(window::close);
 		}
 	}
 


### PR DESCRIPTION
To reproduce the issue: do not save the vault password to the keychain ->  set `"actionAfterUnlock": "REVEAL"` -> lock the vault.
From then on, the scene to enter the password stays open on revealing the vault again.
https://github.com/cryptomator/cryptomator/blob/86906d0049d7137b5e28ad71960ec747a6a96dac/main/ui/src/main/java/org/cryptomator/ui/unlock/UnlockWorkflow.java#L100-L101