### PR TITLE
Feature/#1289 introduce vaultname

### DIFF
--- a/main/commons/src/main/java/org/cryptomator/common/settings/VaultSettings.java
+++ b/main/commons/src/main/java/org/cryptomator/common/settings/VaultSettings.java
@@ -42,7 +42,7 @@ public class VaultSettings {
 
 	private final String id;
 	private final ObjectProperty<Path> path = new SimpleObjectProperty();
-	private final StringProperty mountName = new SimpleStringProperty();
+	private final StringProperty displayName = new SimpleStringProperty();
 	private final StringProperty winDriveLetter = new SimpleStringProperty();
 	private final BooleanProperty unlockAfterStartup = new SimpleBooleanProperty(DEFAULT_UNLOCK_AFTER_STARTUP);
 	private final BooleanProperty revealAfterMount = new SimpleBooleanProperty(DEFAULT_REAVEAL_AFTER_MOUNT);
@@ -56,25 +56,25 @@ public class VaultSettings {
 	public VaultSettings(String id) {
 		this.id = Objects.requireNonNull(id);
 
-		EasyBind.subscribe(path, this::deriveMountNameFromPathOrUseDefault);
+		EasyBind.subscribe(path, this::deriveDisplayNameFromPathOrUseDefault);
 	}
 
 	Observable[] observables() {
-		return new Observable[]{path, mountName, winDriveLetter, unlockAfterStartup, revealAfterMount, useCustomMountPath, customMountPath, usesReadOnlyMode, mountFlags, filenameLengthLimit, actionAfterUnlock};
+		return new Observable[]{path, displayName, winDriveLetter, unlockAfterStartup, revealAfterMount, useCustomMountPath, customMountPath, usesReadOnlyMode, mountFlags, filenameLengthLimit, actionAfterUnlock};
 	}
 
-	private void deriveMountNameFromPathOrUseDefault(Path newPath) {
-		final boolean mountNameSet = !StringUtils.isBlank(mountName.get());
+	private void deriveDisplayNameFromPathOrUseDefault(Path newPath) {
+		final boolean mountNameSet = !StringUtils.isBlank(displayName.get());
 		final boolean dirnameExists = (newPath != null) && (newPath.getFileName() != null);
 
 		if (!mountNameSet && dirnameExists) {
-			mountName.set(normalizeMountName(newPath.getFileName().toString()));
+			displayName.set(normalizeMountName(newPath.getFileName().toString()));
 		} else if (!mountNameSet && !dirnameExists) {
-			mountName.set(DEFAULT_MOUNT_NAME + " " +  id);
+			displayName.set(DEFAULT_MOUNT_NAME + " " +  id);
 		} else if (mountNameSet && dirnameExists) {
-			if (mountName.get().equals(DEFAULT_MOUNT_NAME + id)) {
+			if (displayName.get().equals(DEFAULT_MOUNT_NAME + id)) {
 				//this is okay, since this function is only executed if the path changes (aka, the vault is created or added)
-				mountName.set(newPath.getFileName().toString());
+				displayName.set(newPath.getFileName().toString());
 			}
 		}
 	}
@@ -118,8 +118,8 @@ public class VaultSettings {
 		return path;
 	}
 
-	public StringProperty mountName() {
-		return mountName;
+	public StringProperty displayName() {
+		return displayName;
 	}
 
 	public StringProperty winDriveLetter() {

--- a/main/commons/src/main/java/org/cryptomator/common/settings/VaultSettings.java
+++ b/main/commons/src/main/java/org/cryptomator/common/settings/VaultSettings.java
@@ -19,7 +19,6 @@ import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import org.apache.commons.lang3.StringUtils;
-import org.fxmisc.easybind.EasyBind;
 
 import java.nio.file.Path;
 import java.util.Objects;
@@ -60,29 +59,10 @@ public class VaultSettings {
 	public VaultSettings(String id) {
 		this.id = Objects.requireNonNull(id);
 		this.mountName = Bindings.createStringBinding(this::normalizeDisplayName, displayName);
-
-		EasyBind.subscribe(path, this::deriveDisplayNameFromPathOrUseDefault);
 	}
 
 	Observable[] observables() {
 		return new Observable[]{path, displayName, winDriveLetter, unlockAfterStartup, revealAfterMount, useCustomMountPath, customMountPath, usesReadOnlyMode, mountFlags, filenameLengthLimit, actionAfterUnlock};
-	}
-
-	private void deriveDisplayNameFromPathOrUseDefault(Path newPath) {
-		final boolean mountNameSet = !StringUtils.isBlank(displayName.get());
-		final boolean dirnameExists = (newPath != null) && (newPath.getFileName() != null);
-		final String defaultPattern = DEFAULT_MOUNT_NAME + " " + id;
-
-		if (!mountNameSet && dirnameExists) {
-			displayName.set(newPath.getFileName().toString());
-		} else if (!mountNameSet && !dirnameExists) {
-			displayName.set(defaultPattern);
-		} else if (mountNameSet && dirnameExists) {
-			if (displayName.get().equals(defaultPattern)) {
-				//this is okay, since this function is only executed if the path changes (aka, the vault is created or added)
-				displayName.set(newPath.getFileName().toString());
-			}
-		}
 	}
 
 	public static VaultSettings withRandomId() {

--- a/main/commons/src/main/java/org/cryptomator/common/settings/VaultSettings.java
+++ b/main/commons/src/main/java/org/cryptomator/common/settings/VaultSettings.java
@@ -70,7 +70,7 @@ public class VaultSettings {
 		if (!mountNameSet && dirnameExists) {
 			mountName.set(normalizeMountName(newPath.getFileName().toString()));
 		} else if (!mountNameSet && !dirnameExists) {
-			mountName.set(DEFAULT_MOUNT_NAME + id);
+			mountName.set(DEFAULT_MOUNT_NAME + " " +  id);
 		} else if (mountNameSet && dirnameExists) {
 			if (mountName.get().equals(DEFAULT_MOUNT_NAME + id)) {
 				//this is okay, since this function is only executed if the path changes (aka, the vault is created or added)

--- a/main/commons/src/main/java/org/cryptomator/common/settings/VaultSettings.java
+++ b/main/commons/src/main/java/org/cryptomator/common/settings/VaultSettings.java
@@ -35,7 +35,6 @@ public class VaultSettings {
 	public static final boolean DEFAULT_USES_INDIVIDUAL_MOUNTPATH = false;
 	public static final boolean DEFAULT_USES_READONLY_MODE = false;
 	public static final String DEFAULT_MOUNT_FLAGS = "";
-	public static final String DEFAULT_MOUNT_NAME = "Vault";
 	public static final int DEFAULT_FILENAME_LENGTH_LIMIT = -1;
 	public static final WhenUnlocked DEFAULT_ACTION_AFTER_UNLOCK = WhenUnlocked.ASK;
 

--- a/main/commons/src/main/java/org/cryptomator/common/settings/VaultSettingsJsonAdapter.java
+++ b/main/commons/src/main/java/org/cryptomator/common/settings/VaultSettingsJsonAdapter.java
@@ -21,7 +21,7 @@ class VaultSettingsJsonAdapter {
 		out.beginObject();
 		out.name("id").value(value.getId());
 		out.name("path").value(value.path().get().toString());
-		out.name("mountName").value(value.mountName().get());
+		out.name("mountName").value(value.displayName().get());
 		out.name("winDriveLetter").value(value.winDriveLetter().get());
 		out.name("unlockAfterStartup").value(value.unlockAfterStartup().get());
 		out.name("revealAfterMount").value(value.revealAfterMount().get());
@@ -73,7 +73,7 @@ class VaultSettingsJsonAdapter {
 		in.endObject();
 
 		VaultSettings vaultSettings = (id == null) ? VaultSettings.withRandomId() : new VaultSettings(id);
-		vaultSettings.mountName().set(mountName);
+		vaultSettings.displayName().set(mountName);
 		vaultSettings.path().set(Paths.get(path));
 		vaultSettings.winDriveLetter().set(winDriveLetter);
 		vaultSettings.unlockAfterStartup().set(unlockAfterStartup);

--- a/main/commons/src/main/java/org/cryptomator/common/settings/VaultSettingsJsonAdapter.java
+++ b/main/commons/src/main/java/org/cryptomator/common/settings/VaultSettingsJsonAdapter.java
@@ -37,7 +37,7 @@ class VaultSettingsJsonAdapter {
 	public VaultSettings read(JsonReader in) throws IOException {
 		String id = null;
 		String path = null;
-		String mountName = null;
+		String displayName = null;
 		String customMountPath = null;
 		String winDriveLetter = null;
 		boolean unlockAfterStartup = VaultSettings.DEFAULT_UNLOCK_AFTER_STARTUP;
@@ -54,7 +54,7 @@ class VaultSettingsJsonAdapter {
 			switch (name) {
 				case "id" -> id = in.nextString();
 				case "path" -> path = in.nextString();
-				case "mountName" -> mountName = in.nextString();
+				case "mountName" -> displayName = in.nextString(); //YES, this is correct (legacy reasons)
 				case "winDriveLetter" -> winDriveLetter = in.nextString();
 				case "unlockAfterStartup" -> unlockAfterStartup = in.nextBoolean();
 				case "revealAfterMount" -> revealAfterMount = in.nextBoolean();
@@ -73,7 +73,7 @@ class VaultSettingsJsonAdapter {
 		in.endObject();
 
 		VaultSettings vaultSettings = (id == null) ? VaultSettings.withRandomId() : new VaultSettings(id);
-		vaultSettings.displayName().set(mountName);
+		vaultSettings.displayName().set(displayName);
 		vaultSettings.path().set(Paths.get(path));
 		vaultSettings.winDriveLetter().set(winDriveLetter);
 		vaultSettings.unlockAfterStartup().set(unlockAfterStartup);

--- a/main/commons/src/main/java/org/cryptomator/common/settings/VaultSettingsJsonAdapter.java
+++ b/main/commons/src/main/java/org/cryptomator/common/settings/VaultSettingsJsonAdapter.java
@@ -5,7 +5,6 @@
  *******************************************************************************/
 package org.cryptomator.common.settings;
 
-import com.google.common.base.Strings;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import org.slf4j.Logger;
@@ -76,10 +75,10 @@ class VaultSettingsJsonAdapter {
 		in.endObject();
 
 		VaultSettings vaultSettings = (id == null) ? VaultSettings.withRandomId() : new VaultSettings(id);
-		if(Strings.isNullOrEmpty(displayName)){ //see https://github.com/cryptomator/cryptomator/pull/1318
-			vaultSettings.displayName().set(mountName);
-		} else {
+		if (displayName != null) { //see https://github.com/cryptomator/cryptomator/pull/1318
 			vaultSettings.displayName().set(displayName);
+		} else {
+			vaultSettings.displayName().set(mountName);
 		}
 		vaultSettings.path().set(Paths.get(path));
 		vaultSettings.winDriveLetter().set(winDriveLetter);

--- a/main/commons/src/main/java/org/cryptomator/common/settings/VaultSettingsJsonAdapter.java
+++ b/main/commons/src/main/java/org/cryptomator/common/settings/VaultSettingsJsonAdapter.java
@@ -5,6 +5,7 @@
  *******************************************************************************/
 package org.cryptomator.common.settings;
 
+import com.google.common.base.Strings;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import org.slf4j.Logger;
@@ -21,7 +22,7 @@ class VaultSettingsJsonAdapter {
 		out.beginObject();
 		out.name("id").value(value.getId());
 		out.name("path").value(value.path().get().toString());
-		out.name("mountName").value(value.displayName().get());
+		out.name("displayName").value(value.displayName().get());
 		out.name("winDriveLetter").value(value.winDriveLetter().get());
 		out.name("unlockAfterStartup").value(value.unlockAfterStartup().get());
 		out.name("revealAfterMount").value(value.revealAfterMount().get());
@@ -37,6 +38,7 @@ class VaultSettingsJsonAdapter {
 	public VaultSettings read(JsonReader in) throws IOException {
 		String id = null;
 		String path = null;
+		String mountName = null; //see https://github.com/cryptomator/cryptomator/pull/1318
 		String displayName = null;
 		String customMountPath = null;
 		String winDriveLetter = null;
@@ -54,7 +56,8 @@ class VaultSettingsJsonAdapter {
 			switch (name) {
 				case "id" -> id = in.nextString();
 				case "path" -> path = in.nextString();
-				case "mountName" -> displayName = in.nextString(); //YES, this is correct (legacy reasons)
+				case "mountName" -> mountName = in.nextString(); //see https://github.com/cryptomator/cryptomator/pull/1318
+				case "displayName" -> displayName = in.nextString();
 				case "winDriveLetter" -> winDriveLetter = in.nextString();
 				case "unlockAfterStartup" -> unlockAfterStartup = in.nextBoolean();
 				case "revealAfterMount" -> revealAfterMount = in.nextBoolean();
@@ -73,7 +76,11 @@ class VaultSettingsJsonAdapter {
 		in.endObject();
 
 		VaultSettings vaultSettings = (id == null) ? VaultSettings.withRandomId() : new VaultSettings(id);
-		vaultSettings.displayName().set(displayName);
+		if(Strings.isNullOrEmpty(displayName)){ //see https://github.com/cryptomator/cryptomator/pull/1318
+			vaultSettings.displayName().set(mountName);
+		} else {
+			vaultSettings.displayName().set(displayName);
+		}
 		vaultSettings.path().set(Paths.get(path));
 		vaultSettings.winDriveLetter().set(winDriveLetter);
 		vaultSettings.unlockAfterStartup().set(unlockAfterStartup);

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/DokanyVolume.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/DokanyVolume.java
@@ -47,7 +47,7 @@ public class DokanyVolume implements Volume {
 	@Override
 	public void mount(CryptoFileSystem fs, String mountFlags) throws VolumeException, IOException {
 		this.mountPoint = determineMountPoint();
-		String mountName = vaultSettings.mountName().get();
+		String mountName = vaultSettings.displayName().get();
 		try {
 			this.mount = mountFactory.mount(fs.getPath("/"), mountPoint, mountName, FS_TYPE_NAME, mountFlags.strip());
 		} catch (MountFailedException e) {

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/DokanyVolume.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/DokanyVolume.java
@@ -49,7 +49,7 @@ public class DokanyVolume implements Volume {
 		this.mountPoint = determineMountPoint();
 		String mountName = vaultSettings.displayName().get();
 		try {
-			this.mount = mountFactory.mount(fs.getPath("/"), mountPoint, mountName, FS_TYPE_NAME, mountFlags.strip());
+			this.mount = mountFactory.mount(fs.getPath("/"), mountPoint, vaultSettings.mountName().get(), FS_TYPE_NAME, mountFlags.strip());
 		} catch (MountFailedException e) {
 			if (vaultSettings.getCustomMountPath().isPresent()) {
 				LOG.warn("Failed to mount vault into {}. Is this directory currently accessed by another process (e.g. Windows Explorer)?", mountPoint);

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/Vault.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/Vault.java
@@ -78,7 +78,7 @@ public class Vault {
 		this.state = state;
 		this.lastKnownException = lastKnownException;
 		this.stats = stats;
-		this.displayableName = Bindings.createStringBinding(this::getDisplayableName, vaultSettings.mountName());
+		this.displayableName = Bindings.createStringBinding(this::getDisplayableName, vaultSettings.displayName());
 		this.displayablePath = Bindings.createStringBinding(this::getDisplayablePath, vaultSettings.path());
 		this.locked = Bindings.createBooleanBinding(this::isLocked, state);
 		this.processing = Bindings.createBooleanBinding(this::isProcessing, state);
@@ -230,7 +230,7 @@ public class Vault {
 	}
 
 	public String getDisplayableName() {
-		return vaultSettings.mountName().get();
+		return vaultSettings.displayName().get();
 	}
 
 	public StringBinding accessPointProperty() {

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/Vault.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/Vault.java
@@ -78,7 +78,7 @@ public class Vault {
 		this.state = state;
 		this.lastKnownException = lastKnownException;
 		this.stats = stats;
-		this.displayableName = Bindings.createStringBinding(this::getDisplayableName, vaultSettings.path());
+		this.displayableName = Bindings.createStringBinding(this::getDisplayableName, vaultSettings.mountName());
 		this.displayablePath = Bindings.createStringBinding(this::getDisplayablePath, vaultSettings.path());
 		this.locked = Bindings.createBooleanBinding(this::isLocked, state);
 		this.processing = Bindings.createBooleanBinding(this::isProcessing, state);
@@ -230,8 +230,7 @@ public class Vault {
 	}
 
 	public String getDisplayableName() {
-		Path p = vaultSettings.path().get();
-		return p.getFileName().toString();
+		return vaultSettings.mountName().get();
 	}
 
 	public StringBinding accessPointProperty() {

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/Vault.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/Vault.java
@@ -56,7 +56,7 @@ public class Vault {
 	private final ObjectProperty<VaultState> state;
 	private final ObjectProperty<Exception> lastKnownException;
 	private final VaultStats stats;
-	private final StringBinding displayableName;
+	private final StringBinding displayName;
 	private final StringBinding displayablePath;
 	private final BooleanBinding locked;
 	private final BooleanBinding processing;
@@ -78,7 +78,7 @@ public class Vault {
 		this.state = state;
 		this.lastKnownException = lastKnownException;
 		this.stats = stats;
-		this.displayableName = Bindings.createStringBinding(this::getDisplayableName, vaultSettings.displayName());
+		this.displayName = Bindings.createStringBinding(this::getDisplayName, vaultSettings.displayName());
 		this.displayablePath = Bindings.createStringBinding(this::getDisplayablePath, vaultSettings.path());
 		this.locked = Bindings.createBooleanBinding(this::isLocked, state);
 		this.processing = Bindings.createBooleanBinding(this::isProcessing, state);
@@ -225,11 +225,11 @@ public class Vault {
 		return state.get() == VaultState.ERROR;
 	}
 
-	public StringBinding displayableNameProperty() {
-		return displayableName;
+	public StringBinding displayNameProperty() {
+		return displayName;
 	}
 
-	public String getDisplayableName() {
+	public String getDisplayName() {
 		return vaultSettings.displayName().get();
 	}
 

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/VaultListManager.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/VaultListManager.java
@@ -35,13 +35,13 @@ public class VaultListManager {
 	private static final Logger LOG = LoggerFactory.getLogger(VaultListManager.class);
 
 	private final VaultComponent.Builder vaultComponentBuilder;
-	private final ResourceBundle resourceBundle;
 	private final ObservableList<Vault> vaultList;
+	private final String defaultVaultName;
 
 	@Inject
 	public VaultListManager(VaultComponent.Builder vaultComponentBuilder, ResourceBundle resourceBundle, Settings settings) {
 		this.vaultComponentBuilder = vaultComponentBuilder;
-		this.resourceBundle = resourceBundle;
+		this.defaultVaultName = resourceBundle.getString("defaults.vault.vaultName");
 		this.vaultList = FXCollections.observableArrayList(Vault::observables);
 
 		addAll(settings.getDirectories());
@@ -73,7 +73,7 @@ public class VaultListManager {
 		if (path.getFileName() != null) {
 			vaultSettings.displayName().set(path.getFileName().toString());
 		} else {
-			vaultSettings.displayName().set(resourceBundle.getString("defaults.vault.vaultName"));
+			vaultSettings.displayName().set(defaultVaultName);
 		}
 		return vaultSettings;
 	}

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/VaultModule.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/VaultModule.java
@@ -77,7 +77,7 @@ public class VaultModule {
 	@DefaultMountFlags
 	public StringBinding provideDefaultMountFlags(Settings settings, VaultSettings vaultSettings) {
 		ObjectProperty<VolumeImpl> preferredVolumeImpl = settings.preferredVolumeImpl();
-		StringProperty mountName = vaultSettings.mountName();
+		StringProperty mountName = vaultSettings.displayName();
 		BooleanProperty readOnly = vaultSettings.usesReadOnlyMode();
 
 		return Bindings.createStringBinding(() -> {

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/WebDavVolume.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/WebDavVolume.java
@@ -44,7 +44,7 @@ public class WebDavVolume implements Volume {
 		if (!server.isRunning()) {
 			server.start();
 		}
-		servlet = server.createWebDavServlet(fs.getPath("/"), vaultSettings.getId() + "/" + vaultSettings.displayName().get());
+		servlet = server.createWebDavServlet(fs.getPath("/"), vaultSettings.getId() + "/" + vaultSettings.mountName().get());
 		servlet.start();
 		mount();
 	}
@@ -98,7 +98,7 @@ public class WebDavVolume implements Volume {
 
 	@Override
 	public Optional<Path> getMountPoint() {
-		return Optional.ofNullable(mountPoint);
+		return Optional.ofNullable(mountPoint); //TODO
 	}
 
 	private String getLocalhostAliasOrNull() {

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/WebDavVolume.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/WebDavVolume.java
@@ -44,7 +44,7 @@ public class WebDavVolume implements Volume {
 		if (!server.isRunning()) {
 			server.start();
 		}
-		servlet = server.createWebDavServlet(fs.getPath("/"), vaultSettings.getId() + "/" + vaultSettings.mountName().get());
+		servlet = server.createWebDavServlet(fs.getPath("/"), vaultSettings.getId() + "/" + vaultSettings.displayName().get());
 		servlet.start();
 		mount();
 	}

--- a/main/commons/src/test/java/org/cryptomator/common/settings/SettingsTest.java
+++ b/main/commons/src/test/java/org/cryptomator/common/settings/SettingsTest.java
@@ -29,7 +29,7 @@ public class SettingsTest {
 		Mockito.verify(changeListener, Mockito.times(2)).accept(settings);
 
 		// third change (to property of list item):
-		vaultSettings.mountName().set("asd");
+		vaultSettings.displayName().set("asd");
 		Mockito.verify(changeListener, Mockito.times(3)).accept(settings);
 	}
 

--- a/main/commons/src/test/java/org/cryptomator/common/settings/VaultSettingsJsonAdapterTest.java
+++ b/main/commons/src/test/java/org/cryptomator/common/settings/VaultSettingsJsonAdapterTest.java
@@ -29,7 +29,7 @@ public class VaultSettingsJsonAdapterTest {
 		VaultSettings vaultSettings = adapter.read(jsonReader);
 		Assertions.assertEquals("foo", vaultSettings.getId());
 		Assertions.assertEquals(Paths.get("/foo/bar"), vaultSettings.path().get());
-		Assertions.assertEquals("test", vaultSettings.mountName().get());
+		Assertions.assertEquals("test", vaultSettings.displayName().get());
 		Assertions.assertEquals("X", vaultSettings.winDriveLetter().get());
 		Assertions.assertEquals("/home/test/crypto", vaultSettings.customMountPath().get());
 		Assertions.assertEquals("--foo --bar", vaultSettings.mountFlags().get());
@@ -41,7 +41,7 @@ public class VaultSettingsJsonAdapterTest {
 	public void testSerialize() throws IOException {
 		VaultSettings vaultSettings = new VaultSettings("test");
 		vaultSettings.path().set(Paths.get("/foo/bar"));
-		vaultSettings.mountName().set("mountyMcMountFace");
+		vaultSettings.displayName().set("mountyMcMountFace");
 		vaultSettings.mountFlags().set("--foo --bar");
 
 		StringWriter buf = new StringWriter();

--- a/main/commons/src/test/java/org/cryptomator/common/settings/VaultSettingsJsonAdapterTest.java
+++ b/main/commons/src/test/java/org/cryptomator/common/settings/VaultSettingsJsonAdapterTest.java
@@ -23,7 +23,7 @@ public class VaultSettingsJsonAdapterTest {
 
 	@Test
 	public void testDeserialize() throws IOException {
-		String json = "{\"id\": \"foo\", \"path\": \"/foo/bar\", \"mountName\": \"test\", \"winDriveLetter\": \"X\", \"shouldBeIgnored\": true, \"individualMountPath\": \"/home/test/crypto\", \"mountFlags\":\"--foo --bar\"}";
+		String json = "{\"id\": \"foo\", \"path\": \"/foo/bar\", \"displayName\": \"test\", \"winDriveLetter\": \"X\", \"shouldBeIgnored\": true, \"individualMountPath\": \"/home/test/crypto\", \"mountFlags\":\"--foo --bar\"}";
 		JsonReader jsonReader = new JsonReader(new StringReader(json));
 
 		VaultSettings vaultSettings = adapter.read(jsonReader);
@@ -55,7 +55,7 @@ public class VaultSettingsJsonAdapterTest {
 		} else {
 			MatcherAssert.assertThat(result, CoreMatchers.containsString("\"path\":\"/foo/bar\""));
 		}
-		MatcherAssert.assertThat(result, CoreMatchers.containsString("\"mountName\":\"mountyMcMountFace\""));
+		MatcherAssert.assertThat(result, CoreMatchers.containsString("\"displayName\":\"mountyMcMountFace\""));
 		MatcherAssert.assertThat(result, CoreMatchers.containsString("\"mountFlags\":\"--foo --bar\""));
 	}
 

--- a/main/commons/src/test/java/org/cryptomator/common/settings/VaultSettingsTest.java
+++ b/main/commons/src/test/java/org/cryptomator/common/settings/VaultSettingsTest.java
@@ -15,12 +15,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class VaultSettingsTest {
 
 	@Test
-	public void testNormalize() throws Exception {
-		assertEquals("_", VaultSettings.normalizeMountName(" "));
-		assertEquals("a", VaultSettings.normalizeMountName("ä"));
-		assertEquals("C", VaultSettings.normalizeMountName("Ĉ"));
-		assertEquals("_", VaultSettings.normalizeMountName(":"));
-		assertEquals("_", VaultSettings.normalizeMountName("汉语"));
+	public void testNormalize() {
+		VaultSettings settings = new VaultSettings("id");
+		settings.displayName().setValue(" ");
+		assertEquals("_", settings.normalizeDisplayName());
+
+		settings.displayName().setValue("ä");
+		assertEquals("a", settings.normalizeDisplayName());
+		settings.displayName().setValue("Ĉ");
+		assertEquals("C", settings.normalizeDisplayName());
+		settings.displayName().setValue(":");
+		assertEquals("_", settings.normalizeDisplayName());
+		settings.displayName().setValue("汉语");
+		assertEquals("_", settings.normalizeDisplayName());
 	}
 
 }

--- a/main/commons/src/test/java/org/cryptomator/common/settings/VaultSettingsTest.java
+++ b/main/commons/src/test/java/org/cryptomator/common/settings/VaultSettingsTest.java
@@ -8,26 +8,19 @@
  *******************************************************************************/
 package org.cryptomator.common.settings;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class VaultSettingsTest {
 
-	@Test
-	public void testNormalize() {
+	@ParameterizedTest
+	@CsvSource({"a a,a_a", "ä,a", "Ĉ,C", ":,_", "汉语,_"})
+	public void testNormalize(String test, String expected) {
 		VaultSettings settings = new VaultSettings("id");
-		settings.displayName().setValue(" ");
-		assertEquals("_", settings.normalizeDisplayName());
-
-		settings.displayName().setValue("ä");
-		assertEquals("a", settings.normalizeDisplayName());
-		settings.displayName().setValue("Ĉ");
-		assertEquals("C", settings.normalizeDisplayName());
-		settings.displayName().setValue(":");
-		assertEquals("_", settings.normalizeDisplayName());
-		settings.displayName().setValue("汉语");
-		assertEquals("_", settings.normalizeDisplayName());
+		settings.displayName().setValue(test);
+		assertEquals(expected, settings.normalizeDisplayName());
 	}
 
 }

--- a/main/commons/src/test/java/org/cryptomator/common/vaults/VaultModuleTest.java
+++ b/main/commons/src/test/java/org/cryptomator/common/vaults/VaultModuleTest.java
@@ -28,7 +28,7 @@ public class VaultModuleTest {
 
 	@BeforeEach
 	public void setup(@TempDir Path tmpDir) {
-		Mockito.when(vaultSettings.mountName()).thenReturn(new SimpleStringProperty("TEST"));
+		Mockito.when(vaultSettings.displayName()).thenReturn(new SimpleStringProperty("TEST"));
 		Mockito.when(vaultSettings.usesReadOnlyMode()).thenReturn(new SimpleBooleanProperty(true));
 		System.setProperty("user.home", tmpDir.toString());
 	}

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -28,7 +28,7 @@
 		<cryptomator.jni.version>2.2.2</cryptomator.jni.version>
 		<cryptomator.fuse.version>1.2.3</cryptomator.fuse.version>
 		<cryptomator.dokany.version>1.1.15</cryptomator.dokany.version>
-		<cryptomator.webdav.version>1.0.11</cryptomator.webdav.version>
+		<cryptomator.webdav.version>1.0.12</cryptomator.webdav.version>
 
 		<!-- 3rd party dependencies -->
 		<javafx.version>14</javafx.version>

--- a/main/ui/src/main/java/org/cryptomator/ui/changepassword/ChangePasswordController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/changepassword/ChangePasswordController.java
@@ -67,7 +67,7 @@ public class ChangePasswordController implements FxController {
 	public void finish() {
 		try {
 			CryptoFileSystemProvider.changePassphrase(vault.getPath(), MASTERKEY_FILENAME, oldPasswordField.getCharacters(), newPassword.get());
-			LOG.info("Successfully changed password for {}", vault.getDisplayableName());
+			LOG.info("Successfully changed password for {}", vault.getDisplayName());
 			window.close();
 			updatePasswordInSystemkeychain();
 		} catch (IOException e) {
@@ -84,7 +84,7 @@ public class ChangePasswordController implements FxController {
 		if (keychain.isPresent()) {
 			try {
 				keychain.get().changePassphrase(vault.getId(), CharBuffer.wrap(newPassword.get()));
-				LOG.info("Successfully updated password in system keychain for {}", vault.getDisplayableName());
+				LOG.info("Successfully updated password in system keychain for {}", vault.getDisplayName());
 			} catch (KeychainAccessException e) {
 				LOG.error("Failed to update password in system keychain.", e);
 			}

--- a/main/ui/src/main/java/org/cryptomator/ui/common/VaultService.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/common/VaultService.java
@@ -44,8 +44,8 @@ public class VaultService {
 	 */
 	public Task<Vault> createRevealTask(Vault vault) {
 		Task<Vault> task = new RevealVaultTask(vault);
-		task.setOnSucceeded(evt -> LOG.info("Revealed {}", vault.getDisplayableName()));
-		task.setOnFailed(evt -> LOG.error("Failed to reveal " + vault.getDisplayableName(), evt.getSource().getException()));
+		task.setOnSucceeded(evt -> LOG.info("Revealed {}", vault.getDisplayName()));
+		task.setOnFailed(evt -> LOG.error("Failed to reveal " + vault.getDisplayName(), evt.getSource().getException()));
 		return task;
 	}
 
@@ -68,8 +68,8 @@ public class VaultService {
 	 */
 	public Task<Vault> createLockTask(Vault vault, boolean forced) {
 		Task<Vault> task = new LockVaultTask(vault, forced);
-		task.setOnSucceeded(evt -> LOG.info("Locked {}", vault.getDisplayableName()));
-		task.setOnFailed(evt -> LOG.error("Failed to lock " + vault.getDisplayableName(), evt.getSource().getException()));
+		task.setOnSucceeded(evt -> LOG.info("Locked {}", vault.getDisplayName()));
+		task.setOnFailed(evt -> LOG.error("Failed to lock " + vault.getDisplayName(), evt.getSource().getException()));
 		return task;
 	}
 
@@ -94,7 +94,7 @@ public class VaultService {
 		List<Task<Vault>> lockTasks = vaults.stream().map(v -> new LockVaultTask(v, forced)).collect(Collectors.toUnmodifiableList());
 		lockTasks.forEach(executorService::execute);
 		Task<Collection<Vault>> task = new WaitForTasksTask(lockTasks);
-		String vaultNames = vaults.stream().map(Vault::getDisplayableName).collect(Collectors.joining(", "));
+		String vaultNames = vaults.stream().map(Vault::getDisplayName).collect(Collectors.joining(", "));
 		task.setOnSucceeded(evt -> LOG.info("Locked {}", vaultNames));
 		task.setOnFailed(evt -> LOG.error("Failed to lock vaults " + vaultNames, evt.getSource().getException()));
 		return task;

--- a/main/ui/src/main/java/org/cryptomator/ui/forgetPassword/ForgetPasswordController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/forgetPassword/ForgetPasswordController.java
@@ -41,7 +41,7 @@ public class ForgetPasswordController implements FxController {
 		if (keychain.isPresent()) {
 			try {
 				keychain.get().deletePassphrase(vault.getId());
-				LOG.debug("Forgot password for vault {}.", vault.getDisplayableName());
+				LOG.debug("Forgot password for vault {}.", vault.getDisplayName());
 				confirmedResult.setValue(true);
 			} catch (KeychainAccessException e) {
 				LOG.error("Failed to remove entry from system keychain.", e);

--- a/main/ui/src/main/java/org/cryptomator/ui/fxapp/FxApplication.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/fxapp/FxApplication.java
@@ -6,7 +6,6 @@ import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.value.ObservableValue;
-import javafx.collections.FXCollections;
 import javafx.collections.ObservableSet;
 import javafx.stage.Stage;
 import org.cryptomator.common.LicenseHolder;
@@ -99,7 +98,7 @@ public class FxApplication extends Application {
 	public void startUnlockWorkflow(Vault vault, Optional<Stage> owner) {
 		Platform.runLater(() -> {
 			unlockWindowBuilderProvider.get().vault(vault).owner(owner).build().startUnlockWorkflow();
-			LOG.debug("Showing UnlockWindow for {}", vault.getDisplayableName());
+			LOG.debug("Showing UnlockWindow for {}", vault.getDisplayName());
 		});
 	}
 

--- a/main/ui/src/main/java/org/cryptomator/ui/migration/MigrationRunController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/migration/MigrationRunController.java
@@ -116,10 +116,10 @@ public class MigrationRunController implements FxController {
 			return migrators.needsMigration(vault.getPath(), MASTERKEY_FILENAME);
 		}).onSuccess(needsAnotherMigration -> {
 			if (needsAnotherMigration) {
-				LOG.info("Migration of '{}' succeeded, but another migration is required.", vault.getDisplayableName());
+				LOG.info("Migration of '{}' succeeded, but another migration is required.", vault.getDisplayName());
 				vault.setState(VaultState.NEEDS_MIGRATION);
 			} else {
-				LOG.info("Migration of '{}' succeeded.", vault.getDisplayableName());
+				LOG.info("Migration of '{}' succeeded.", vault.getDisplayName());
 				vault.setState(VaultState.LOCKED);
 				passwordField.wipe();
 				window.setScene(successScene.get());

--- a/main/ui/src/main/java/org/cryptomator/ui/quit/QuitController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/quit/QuitController.java
@@ -53,7 +53,7 @@ public class QuitController implements FxController {
 
 		Task<Collection<Vault>> lockAllTask = vaultService.createLockAllTask(unlockedVaults, false);
 		lockAllTask.setOnSucceeded(evt -> {
-			LOG.info("Locked {}", lockAllTask.getValue().stream().map(Vault::getDisplayableName).collect(Collectors.joining(", ")));
+			LOG.info("Locked {}", lockAllTask.getValue().stream().map(Vault::getDisplayName).collect(Collectors.joining(", ")));
 			if (unlockedVaults.isEmpty()) {
 				window.close();
 				response.performQuit();

--- a/main/ui/src/main/java/org/cryptomator/ui/recoverykey/RecoveryKeyModule.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/recoverykey/RecoveryKeyModule.java
@@ -9,7 +9,6 @@ import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.scene.Scene;
-import javafx.scene.image.Image;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
 import org.cryptomator.common.vaults.Vault;
@@ -25,7 +24,6 @@ import org.cryptomator.ui.common.StageFactory;
 
 import javax.inject.Named;
 import javax.inject.Provider;
-import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
 
@@ -107,7 +105,7 @@ abstract class RecoveryKeyModule {
 	@IntoMap
 	@FxControllerKey(RecoveryKeyDisplayController.class)
 	static FxController provideRecoveryKeyDisplayController(@RecoveryKeyWindow Stage window, @RecoveryKeyWindow Vault vault, @RecoveryKeyWindow StringProperty recoveryKey, ResourceBundle localization) {
-		return new RecoveryKeyDisplayController(window, vault.getDisplayableName(), recoveryKey.get(), localization);
+		return new RecoveryKeyDisplayController(window, vault.getDisplayName(), recoveryKey.get(), localization);
 	}
 
 	@Binds

--- a/main/ui/src/main/java/org/cryptomator/ui/removevault/RemoveVaultController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/removevault/RemoveVaultController.java
@@ -34,7 +34,7 @@ public class RemoveVaultController implements FxController {
 	@FXML
 	public void finish() {
 		vaults.remove(vault);
-		LOG.debug("Removing vault {}.", vault.getDisplayableName());
+		LOG.debug("Removing vault {}.", vault.getDisplayName());
 		window.close();
 	}
 }

--- a/main/ui/src/main/java/org/cryptomator/ui/traymenu/TrayMenuController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/traymenu/TrayMenuController.java
@@ -80,7 +80,7 @@ class TrayMenuController {
 	}
 
 	private Menu buildSubmenu(Vault vault) {
-		Menu submenu = new Menu(vault.getDisplayableName());
+		Menu submenu = new Menu(vault.getDisplayName());
 
 		if (vault.isLocked()) {
 			MenuItem unlockItem = new MenuItem(resourceBundle.getString("traymenu.vault.unlock"));

--- a/main/ui/src/main/java/org/cryptomator/ui/unlock/UnlockController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/unlock/UnlockController.java
@@ -77,7 +77,7 @@ public class UnlockController implements FxController {
 		this.unlockButtonContentDisplay = Bindings.createObjectBinding(this::getUnlockButtonContentDisplay, passwordEntryLock.awaitingInteraction());
 		this.userInteractionDisabled = passwordEntryLock.awaitingInteraction().not();
 		this.unlockButtonDisabled = new SimpleBooleanProperty();
-		this.vaultName = WeakBindings.bindString(vault.displayableNameProperty());
+		this.vaultName = WeakBindings.bindString(vault.displayNameProperty());
 		this.window.setOnCloseRequest(windowEvent -> cancel());
 	}
 

--- a/main/ui/src/main/java/org/cryptomator/ui/unlock/UnlockModule.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/unlock/UnlockModule.java
@@ -82,7 +82,7 @@ abstract class UnlockModule {
 	@UnlockScoped
 	static Stage provideStage(StageFactory factory, @UnlockWindow Vault vault, @Named("unlockWindowOwner") Optional<Stage> owner) {
 		Stage stage = factory.create();
-		stage.setTitle(vault.getDisplayableName());
+		stage.setTitle(vault.getDisplayName());
 		stage.setResizable(false);
 		if (owner.isPresent()) {
 			stage.initOwner(owner.get());

--- a/main/ui/src/main/java/org/cryptomator/ui/unlock/UnlockWorkflow.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/unlock/UnlockWorkflow.java
@@ -128,7 +128,7 @@ public class UnlockWorkflow extends Task<Boolean> {
 	}
 
 	private void handleSuccess() {
-		LOG.info("Unlock of '{}' succeeded.", vault.getDisplayableName());
+		LOG.info("Unlock of '{}' succeeded.", vault.getDisplayName());
 		if (savePassword.get()) {
 			savePasswordToSystemkeychain();
 		}

--- a/main/ui/src/main/java/org/cryptomator/ui/vaultoptions/GeneralVaultOptionsController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/vaultoptions/GeneralVaultOptionsController.java
@@ -3,6 +3,7 @@ package org.cryptomator.ui.vaultoptions;
 import javafx.fxml.FXML;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ChoiceBox;
+import javafx.scene.control.TextField;
 import javafx.util.StringConverter;
 import org.cryptomator.common.settings.UiTheme;
 import org.cryptomator.common.settings.WhenUnlocked;
@@ -18,6 +19,7 @@ public class GeneralVaultOptionsController implements FxController {
 	private final Vault vault;
 	private final ResourceBundle resourceBundle;
 
+	public TextField vaultName;
 	public CheckBox unlockOnStartupCheckbox;
 	public ChoiceBox<WhenUnlocked> actionAfterUnlockChoiceBox;
 
@@ -29,6 +31,7 @@ public class GeneralVaultOptionsController implements FxController {
 
 	@FXML
 	public void initialize() {
+		vaultName.textProperty().bindBidirectional(vault.getVaultSettings().displayName());
 		unlockOnStartupCheckbox.selectedProperty().bindBidirectional(vault.getVaultSettings().unlockAfterStartup());
 		actionAfterUnlockChoiceBox.getItems().addAll(WhenUnlocked.values());
 		actionAfterUnlockChoiceBox.valueProperty().bindBidirectional(vault.getVaultSettings().actionAfterUnlock());

--- a/main/ui/src/main/java/org/cryptomator/ui/vaultoptions/MountOptionsController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/vaultoptions/MountOptionsController.java
@@ -42,7 +42,6 @@ public class MountOptionsController implements FxController {
 	private final BooleanBinding webDavAndWindows;
 	private final WindowsDriveLetters windowsDriveLetters;
 	private final ResourceBundle resourceBundle;
-	public TextField driveName;
 	public CheckBox readOnlyCheckbox;
 	public CheckBox customMountFlagsCheckbox;
 	public TextField mountFlags;
@@ -63,7 +62,6 @@ public class MountOptionsController implements FxController {
 
 	@FXML
 	public void initialize() {
-		driveName.textProperty().bindBidirectional(vault.getVaultSettings().displayName());
 
 		// readonly:
 		readOnlyCheckbox.selectedProperty().bindBidirectional(vault.getVaultSettings().usesReadOnlyMode());

--- a/main/ui/src/main/java/org/cryptomator/ui/vaultoptions/MountOptionsController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/vaultoptions/MountOptionsController.java
@@ -63,7 +63,7 @@ public class MountOptionsController implements FxController {
 
 	@FXML
 	public void initialize() {
-		driveName.textProperty().bindBidirectional(vault.getVaultSettings().mountName());
+		driveName.textProperty().bindBidirectional(vault.getVaultSettings().displayName());
 
 		// readonly:
 		readOnlyCheckbox.selectedProperty().bindBidirectional(vault.getVaultSettings().usesReadOnlyMode());

--- a/main/ui/src/main/java/org/cryptomator/ui/vaultoptions/VaultOptionsModule.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/vaultoptions/VaultOptionsModule.java
@@ -5,7 +5,6 @@ import dagger.Module;
 import dagger.Provides;
 import dagger.multibindings.IntoMap;
 import javafx.scene.Scene;
-import javafx.scene.image.Image;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
 import org.cryptomator.common.vaults.Vault;
@@ -20,9 +19,7 @@ import org.cryptomator.ui.common.StageFactory;
 import org.cryptomator.ui.mainwindow.MainWindow;
 import org.cryptomator.ui.recoverykey.RecoveryKeyComponent;
 
-import javax.inject.Named;
 import javax.inject.Provider;
-import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
 
@@ -41,7 +38,7 @@ abstract class VaultOptionsModule {
 	@VaultOptionsScoped
 	static Stage provideStage(StageFactory factory, @MainWindow Stage owner, @VaultOptionsWindow Vault vault) {
 		Stage stage = factory.create();
-		stage.setTitle(vault.getDisplayableName());
+		stage.setTitle(vault.getDisplayName());
 		stage.setResizable(true);
 		stage.setMinWidth(400);
 		stage.setMinHeight(300);

--- a/main/ui/src/main/resources/fxml/addvault_success.fxml
+++ b/main/ui/src/main/resources/fxml/addvault_success.fxml
@@ -30,7 +30,7 @@
 
 		<Region VBox.vgrow="ALWAYS"/>
 
-		<FormattedLabel format="%addvaultwizard.success.nextStepsInstructions" arg1="${controller.vault.displayableName}" wrapText="true" HBox.hgrow="ALWAYS"/>
+		<FormattedLabel format="%addvaultwizard.success.nextStepsInstructions" arg1="${controller.vault.displayName}" wrapText="true" HBox.hgrow="ALWAYS"/>
 
 		<Region VBox.vgrow="ALWAYS"/>
 

--- a/main/ui/src/main/resources/fxml/changepassword.fxml
+++ b/main/ui/src/main/resources/fxml/changepassword.fxml
@@ -19,7 +19,7 @@
 	</padding>
 	<children>
 		<VBox spacing="6">
-			<FormattedLabel format="%changepassword.enterOldPassword" arg1="${controller.vault.displayableName}" wrapText="true"/>
+			<FormattedLabel format="%changepassword.enterOldPassword" arg1="${controller.vault.displayName}" wrapText="true"/>
 			<NiceSecurePasswordField fx:id="oldPasswordField"/>
 		</VBox>
 

--- a/main/ui/src/main/resources/fxml/migration_run.fxml
+++ b/main/ui/src/main/resources/fxml/migration_run.fxml
@@ -21,7 +21,7 @@
 	</padding>
 	<children>
 		<VBox spacing="6" visible="${!controller.vault.processing}" managed="${!controller.vault.processing}">
-			<FormattedLabel format="%migration.run.enterPassword" arg1="${controller.vault.displayableName}" wrapText="true"/>
+			<FormattedLabel format="%migration.run.enterPassword" arg1="${controller.vault.displayName}" wrapText="true"/>
 			<NiceSecurePasswordField fx:id="passwordField"/>
 		</VBox>
 

--- a/main/ui/src/main/resources/fxml/migration_start.fxml
+++ b/main/ui/src/main/resources/fxml/migration_start.fxml
@@ -28,7 +28,7 @@
 			</StackPane>
 
 			<VBox spacing="6" HBox.hgrow="ALWAYS">
-				<FormattedLabel format="%migration.start.prompt" arg1="${controller.vault.displayableName}" wrapText="true" />
+				<FormattedLabel format="%migration.start.prompt" arg1="${controller.vault.displayName}" wrapText="true" />
 				<CheckBox fx:id="confirmSyncDone" text="%migration.start.confirm"/>
 			</VBox>
 		</HBox>

--- a/main/ui/src/main/resources/fxml/migration_success.fxml
+++ b/main/ui/src/main/resources/fxml/migration_success.fxml
@@ -25,7 +25,7 @@
 				<Circle styleClass="glyph-icon-primary" radius="24"/>
 				<FontAwesome5IconView styleClass="glyph-icon-white" glyph="CHECK" glyphSize="24"/>
 			</StackPane>
-			<FormattedLabel format="%migration.success.nextStepsInstructions" arg1="${controller.vault.displayableName}" wrapText="true" HBox.hgrow="ALWAYS"/>
+			<FormattedLabel format="%migration.success.nextStepsInstructions" arg1="${controller.vault.displayName}" wrapText="true" HBox.hgrow="ALWAYS"/>
 		</HBox>
 
 		<VBox alignment="BOTTOM_CENTER" VBox.vgrow="ALWAYS">

--- a/main/ui/src/main/resources/fxml/recoverykey_create.fxml
+++ b/main/ui/src/main/resources/fxml/recoverykey_create.fxml
@@ -20,7 +20,7 @@
 	</padding>
 	<children>
 		<VBox spacing="6">
-			<FormattedLabel format="%recoveryKey.enterPassword.prompt" arg1="${controller.vault.displayableName}" wrapText="true"/>
+			<FormattedLabel format="%recoveryKey.enterPassword.prompt" arg1="${controller.vault.displayName}" wrapText="true"/>
 			<NiceSecurePasswordField fx:id="passwordField" HBox.hgrow="ALWAYS"/>
 		</VBox>
 

--- a/main/ui/src/main/resources/fxml/recoverykey_recover.fxml
+++ b/main/ui/src/main/resources/fxml/recoverykey_recover.fxml
@@ -21,7 +21,7 @@
 		<Insets topRightBottomLeft="12"/>
 	</padding>
 	<children>
-		<FormattedLabel format="%recoveryKey.recover.prompt" arg1="${controller.vault.displayableName}" wrapText="true"/>
+		<FormattedLabel format="%recoveryKey.recover.prompt" arg1="${controller.vault.displayName}" wrapText="true"/>
 
 		<TextArea wrapText="true" prefRowCount="4" fx:id="textarea" textFormatter="${controller.recoveryKeyTextFormatter}" onKeyPressed="#onKeyPressed"/>
 		

--- a/main/ui/src/main/resources/fxml/unlock_success.fxml
+++ b/main/ui/src/main/resources/fxml/unlock_success.fxml
@@ -28,7 +28,7 @@
 				<FontAwesome5IconView styleClass="glyph-icon-white" glyph="CHECK" glyphSize="24"/>
 			</StackPane>
 			<VBox spacing="6">
-				<FormattedLabel format="%unlock.success.message" arg1="${controller.vault.displayableName}" wrapText="true" HBox.hgrow="ALWAYS"/>
+				<FormattedLabel format="%unlock.success.message" arg1="${controller.vault.displayName}" wrapText="true" HBox.hgrow="ALWAYS"/>
 				<CheckBox text="%unlock.success.rememberChoice" fx:id="rememberChoiceCheckbox"/>
 			</VBox>
 		</HBox>

--- a/main/ui/src/main/resources/fxml/vault_detail.fxml
+++ b/main/ui/src/main/resources/fxml/vault_detail.fxml
@@ -26,9 +26,9 @@
 			</StackPane>
 			<VBox spacing="4" HBox.hgrow="ALWAYS">
 				<HBox spacing="12">
-					<Label styleClass="label-large" text="${controller.vault.displayableName}">
+					<Label styleClass="label-large" text="${controller.vault.displayName}">
 						<tooltip>
-							<Tooltip text="${controller.vault.displayableName}"/>
+							<Tooltip text="${controller.vault.displayName}"/>
 						</tooltip>
 					</Label>
 					<Region HBox.hgrow="ALWAYS"/>

--- a/main/ui/src/main/resources/fxml/vault_list_cell.fxml
+++ b/main/ui/src/main/resources/fxml/vault_list_cell.fxml
@@ -20,7 +20,7 @@
 			<FontAwesome5IconView glyph="${controller.glyph}" HBox.hgrow="NEVER" glyphSize="16"/>
 		</VBox>
 		<VBox spacing="4" HBox.hgrow="ALWAYS">
-			<Label styleClass="header-label" text="${controller.vault.displayableName}"/>
+			<Label styleClass="header-label" text="${controller.vault.displayName}"/>
 			<Label styleClass="detail-label" text="${controller.vault.displayablePath}" textOverrun="CENTER_ELLIPSIS"/>
 		</VBox>
 	</children>

--- a/main/ui/src/main/resources/fxml/vault_options_general.fxml
+++ b/main/ui/src/main/resources/fxml/vault_options_general.fxml
@@ -6,6 +6,7 @@
 <?import javafx.scene.control.ChoiceBox?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.control.Label?>
+<?import org.cryptomator.ui.controls.AlphanumericTextField?>
 <VBox xmlns="http://javafx.com/javafx"
 	  xmlns:fx="http://javafx.com/fxml"
 	  fx:controller="org.cryptomator.ui.vaultoptions.GeneralVaultOptionsController"
@@ -14,6 +15,11 @@
 		<Insets topRightBottomLeft="12"/>
 	</padding>
 	<children>
+		<HBox spacing="6" alignment="CENTER_LEFT">
+			<Label text="%vaultOptions.general.vaultName"/>
+			<AlphanumericTextField fx:id="vaultName"/>
+		</HBox>
+
 		<CheckBox text="%vaultOptions.general.unlockAfterStartup" fx:id="unlockOnStartupCheckbox"/>
 
 		<HBox spacing="6" alignment="CENTER_LEFT">

--- a/main/ui/src/main/resources/fxml/vault_options_general.fxml
+++ b/main/ui/src/main/resources/fxml/vault_options_general.fxml
@@ -2,11 +2,11 @@
 
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.CheckBox?>
-<?import javafx.scene.layout.VBox?>
 <?import javafx.scene.control.ChoiceBox?>
-<?import javafx.scene.layout.HBox?>
 <?import javafx.scene.control.Label?>
-<?import org.cryptomator.ui.controls.AlphanumericTextField?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
 <VBox xmlns="http://javafx.com/javafx"
 	  xmlns:fx="http://javafx.com/fxml"
 	  fx:controller="org.cryptomator.ui.vaultoptions.GeneralVaultOptionsController"
@@ -17,7 +17,7 @@
 	<children>
 		<HBox spacing="6" alignment="CENTER_LEFT">
 			<Label text="%vaultOptions.general.vaultName"/>
-			<AlphanumericTextField fx:id="vaultName"/>
+			<TextField fx:id="vaultName"/>
 		</HBox>
 
 		<CheckBox text="%vaultOptions.general.unlockAfterStartup" fx:id="unlockOnStartupCheckbox"/>

--- a/main/ui/src/main/resources/fxml/vault_options_mount.fxml
+++ b/main/ui/src/main/resources/fxml/vault_options_mount.fxml
@@ -23,11 +23,6 @@
 		<Insets topRightBottomLeft="12"/>
 	</padding>
 	<children>
-		<HBox spacing="6" alignment="CENTER_LEFT">
-			<Label text="%vaultOptions.mount.driveName"/>
-			<AlphanumericTextField fx:id="driveName"/>
-		</HBox>
-
 		<CheckBox fx:id="readOnlyCheckbox" text="%vaultOptions.mount.readonly"/>
 
 		<CheckBox fx:id="customMountFlagsCheckbox" text="%vaultOptions.mount.customMountFlags" onAction="#toggleUseCustomMountFlags" visible="${!controller.webDavAndWindows}" managed="${!controller.webDavAndWindows}"/>

--- a/main/ui/src/main/resources/i18n/strings.properties
+++ b/main/ui/src/main/resources/i18n/strings.properties
@@ -17,6 +17,9 @@ generic.button.print=Print
 generic.error.title=An unexpected error occured
 generic.error.instruction=This should not have happened. Please report the error text below and include a description of what steps did lead to this error.
 
+# Defaults
+defaults.vault.vaultName=Vault
+
 # Tray Menu
 traymenu.showMainWindow=Show
 traymenu.showPreferencesWindow=Preferences

--- a/main/ui/src/main/resources/i18n/strings.properties
+++ b/main/ui/src/main/resources/i18n/strings.properties
@@ -213,6 +213,7 @@ wrongFileAlert.link=For further assistance, visit
 # Vault Options
 ## General
 vaultOptions.general=General
+vaultOptions.general.vaultName=Vault Name
 vaultOptions.general.unlockAfterStartup=Unlock vault when starting Cryptomator
 vaultOptions.general.actionAfterUnlock=After successful unlock
 vaultOptions.general.actionAfterUnlock.ignore=Do nothing
@@ -221,7 +222,6 @@ vaultOptions.general.actionAfterUnlock.ask=Ask
 ## Mount
 vaultOptions.mount=Mounting
 vaultOptions.mount.readonly=Read-Only
-vaultOptions.mount.driveName=Drive Name
 vaultOptions.mount.customMountFlags=Custom Mount Flags
 vaultOptions.mount.winDriveLetterOccupied=occupied
 vaultOptions.mount.mountPoint=Mount Point


### PR DESCRIPTION
This PR decouples the vault name from its storage path, make it an independet, (so to say) third basic attribute of a vault and restores with it functionality which was given with 1.4.x versions of Cryptomator.

Formerly in 1.5.x versions, the vault name was set as the folder containing the vault. But this caused problems for older setups, where the folder content was mirrored at a root directory. (JDKs `Path::getFileName()` returns null)

When a vault is added to the overview, the default vault name is still set to the folder containing it or, if this doesn't exists, to a localizable String expressing "Vault". But now the user can also change the vault name to _any_ Unicode-String which is supported by JavaFX and the used font.

The setting for it is displayed in the general vault options.

![VaultName](https://user-images.githubusercontent.com/9036915/91294833-685b1180-e79a-11ea-801b-c1584d4a52a8.gif)

The TextField "mountName" was removed, and now the vault name is just slugifyed to mount the vault.

This setting is persisted over the "mountName" filed in the JSON file, to prevent legacy conflicts and conversions.