### PR TITLE
allows running launcher-linux.sh from any path

### DIFF
--- a/main/buildkit/src/main/resources/launcher-linux.sh
+++ b/main/buildkit/src/main/resources/launcher-linux.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+cd $(dirname $0)
 java \
 	-cp "libs/*" \
 	-Dcryptomator.settingsPath="~/.config/Cryptomator/settings.json" \


### PR DESCRIPTION
Currently, it expects the working path to be the script path (where `libs` is located)

This allows the linux launcher to run from any path