### PR TITLE
shorten FS_TYPE_NAME  to "CryptomatorFS"

### DIFF
--- a/main/commons/src/main/java/org/cryptomator/common/vaults/DokanyVolume.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/DokanyVolume.java
@@ -24,7 +24,7 @@ public class DokanyVolume implements Volume {
 
 	private static final Logger LOG = LoggerFactory.getLogger(DokanyVolume.class);
 
-	private static final String FS_TYPE_NAME = "Cryptomator File System";
+	private static final String FS_TYPE_NAME = "CryptomatorFS";
 
 	private final VaultSettings vaultSettings;
 	private final MountFactory mountFactory;


### PR DESCRIPTION
This fixes part of #1033 by shortening the FS_TYPE_NAME so that it can be returned inside a 48-byte-long FILE_FS_ATTRIBUTE_INFORMATION buffer, which only has room for up to 17 UTF-16 characters in the file system name field.