### PR TITLE
Show only one quit dialogue at a time

### DIFF
--- a/main/ui/src/main/java/org/cryptomator/ui/fxapp/FxApplication.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/fxapp/FxApplication.java
@@ -31,7 +31,6 @@ import javafx.collections.ObservableSet;
 import javafx.stage.Stage;
 import java.awt.desktop.QuitResponse;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 
 @FxApplicationScoped
 public class FxApplication extends Application {
@@ -49,10 +48,9 @@ public class FxApplication extends Application {
 	private final LicenseHolder licenseHolder;
 	private final BooleanBinding hasVisibleStages;
 	private final UiAppearanceListener systemInterfaceThemeListener = this::systemInterfaceThemeChanged;
-	private final AtomicReference<QuitResponse> quitResponse;
 
 	@Inject
-	FxApplication(Settings settings, Lazy<MainWindowComponent> mainWindow, Lazy<PreferencesComponent> preferencesWindow, Provider<UnlockComponent.Builder> unlockWindowBuilderProvider, Lazy<QuitComponent> quitWindow, Optional<TrayIntegrationProvider> trayIntegration, Optional<UiAppearanceProvider> appearanceProvider, VaultService vaultService, LicenseHolder licenseHolder, ObservableSet<Stage> visibleStages, AtomicReference<QuitResponse> quitResponse) {
+	FxApplication(Settings settings, Lazy<MainWindowComponent> mainWindow, Lazy<PreferencesComponent> preferencesWindow, Provider<UnlockComponent.Builder> unlockWindowBuilderProvider, Lazy<QuitComponent> quitWindow, Optional<TrayIntegrationProvider> trayIntegration, Optional<UiAppearanceProvider> appearanceProvider, VaultService vaultService, LicenseHolder licenseHolder, ObservableSet<Stage> visibleStages) {
 		this.settings = settings;
 		this.mainWindow = mainWindow;
 		this.preferencesWindow = preferencesWindow;
@@ -63,7 +61,6 @@ public class FxApplication extends Application {
 		this.vaultService = vaultService;
 		this.licenseHolder = licenseHolder;
 		this.hasVisibleStages = Bindings.isNotEmpty(visibleStages);
-		this.quitResponse = quitResponse;
 	}
 
 	public void start() {
@@ -111,9 +108,8 @@ public class FxApplication extends Application {
 	}
 
 	public void showQuitWindow(QuitResponse response) {
-		quitResponse.set(response);
 		Platform.runLater(() -> {
-			quitWindow.get().showQuitWindow();
+			quitWindow.get().showQuitWindow(response);
 			LOG.debug("Showing QuitWindow");
 		});
 	}

--- a/main/ui/src/main/java/org/cryptomator/ui/fxapp/FxApplicationModule.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/fxapp/FxApplicationModule.java
@@ -22,22 +22,14 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableSet;
 import javafx.scene.image.Image;
 import javafx.stage.Stage;
-import java.awt.desktop.QuitResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 
 @Module(includes = {UpdateCheckerModule.class}, subcomponents = {MainWindowComponent.class, PreferencesComponent.class, UnlockComponent.class, QuitComponent.class, ErrorComponent.class})
 abstract class FxApplicationModule {
-
-	@Provides
-	@FxApplicationScoped
-	static AtomicReference<QuitResponse> provideQuitResponse() {
-		return new AtomicReference<>();
-	}
 
 	@Provides
 	@FxApplicationScoped

--- a/main/ui/src/main/java/org/cryptomator/ui/fxapp/FxApplicationModule.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/fxapp/FxApplicationModule.java
@@ -22,14 +22,22 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableSet;
 import javafx.scene.image.Image;
 import javafx.stage.Stage;
+import java.awt.desktop.QuitResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 @Module(includes = {UpdateCheckerModule.class}, subcomponents = {MainWindowComponent.class, PreferencesComponent.class, UnlockComponent.class, QuitComponent.class, ErrorComponent.class})
 abstract class FxApplicationModule {
+
+	@Provides
+	@FxApplicationScoped
+	static AtomicReference<QuitResponse> provideQuitResponse() {
+		return new AtomicReference<>();
+	}
 
 	@Provides
 	@FxApplicationScoped
@@ -88,4 +96,8 @@ abstract class FxApplicationModule {
 		return builder.build();
 	}
 
+	@Provides
+	static QuitComponent provideQuitComponent(QuitComponent.Builder builder) {
+		return builder.build();
+	}
 }

--- a/main/ui/src/main/java/org/cryptomator/ui/quit/QuitComponent.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/quit/QuitComponent.java
@@ -10,9 +10,9 @@ import dagger.Subcomponent;
 import org.cryptomator.ui.common.FxmlFile;
 import org.cryptomator.ui.common.FxmlScene;
 
-import javafx.beans.property.ObjectProperty;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
+import java.awt.desktop.QuitResponse;
 
 @QuitScoped
 @Subcomponent(modules = {QuitModule.class})
@@ -24,18 +24,12 @@ public interface QuitComponent {
 	@FxmlScene(FxmlFile.QUIT)
 	Lazy<Scene> scene();
 
-	ObjectProperty<Stage> provideStageProperty();
+	QuitController controller();
 
-	default Stage showQuitWindow() {
-		var stageProperty = provideStageProperty();
-		Stage stage;
-		if (stageProperty.isNull().get()) {
-			stage = window();
-			stage.setScene(scene().get());
-			stageProperty.set(stage);
-		} else {
-			stage = stageProperty.get();
-		}
+	default Stage showQuitWindow(QuitResponse response) {
+		controller().updateQuitRequest(response);
+		Stage stage = window();
+		stage.setScene(scene().get());
 		stage.show();
 		stage.requestFocus();
 		return stage;

--- a/main/ui/src/main/java/org/cryptomator/ui/quit/QuitComponent.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/quit/QuitComponent.java
@@ -5,15 +5,14 @@
  *******************************************************************************/
 package org.cryptomator.ui.quit;
 
-import dagger.BindsInstance;
 import dagger.Lazy;
 import dagger.Subcomponent;
 import org.cryptomator.ui.common.FxmlFile;
 import org.cryptomator.ui.common.FxmlScene;
 
+import javafx.beans.property.ObjectProperty;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
-import java.awt.desktop.QuitResponse;
 
 @QuitScoped
 @Subcomponent(modules = {QuitModule.class})
@@ -25,9 +24,18 @@ public interface QuitComponent {
 	@FxmlScene(FxmlFile.QUIT)
 	Lazy<Scene> scene();
 
+	ObjectProperty<Stage> provideStageProperty();
+
 	default Stage showQuitWindow() {
-		Stage stage = window();
-		stage.setScene(scene().get());
+		var stageProperty = provideStageProperty();
+		Stage stage;
+		if (stageProperty.isNull().get()) {
+			stage = window();
+			stage.setScene(scene().get());
+			stageProperty.set(stage);
+		} else {
+			stage = stageProperty.get();
+		}
 		stage.show();
 		stage.requestFocus();
 		return stage;
@@ -35,9 +43,6 @@ public interface QuitComponent {
 
 	@Subcomponent.Builder
 	interface Builder {
-
-		@BindsInstance
-		Builder quitResponse(QuitResponse response);
 
 		QuitComponent build();
 	}

--- a/main/ui/src/main/java/org/cryptomator/ui/quit/QuitModule.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/quit/QuitModule.java
@@ -25,12 +25,6 @@ import java.util.ResourceBundle;
 abstract class QuitModule {
 
 	@Provides
-	@QuitScoped
-	static ObjectProperty<Stage> provideStageProperty() {
-		return new SimpleObjectProperty<>();
-	}
-
-	@Provides
 	@QuitWindow
 	@QuitScoped
 	static FXMLLoaderFactory provideFxmlLoaderFactory(Map<Class<? extends FxController>, Provider<FxController>> factories, DefaultSceneFactory sceneFactory, ResourceBundle resourceBundle) {

--- a/main/ui/src/main/java/org/cryptomator/ui/quit/QuitModule.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/quit/QuitModule.java
@@ -13,6 +13,8 @@ import org.cryptomator.ui.common.FxmlScene;
 import org.cryptomator.ui.common.StageFactory;
 
 import javax.inject.Provider;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.Scene;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
@@ -21,6 +23,12 @@ import java.util.ResourceBundle;
 
 @Module
 abstract class QuitModule {
+
+	@Provides
+	@QuitScoped
+	static ObjectProperty<Stage> provideStageProperty() {
+		return new SimpleObjectProperty<>();
+	}
 
 	@Provides
 	@QuitWindow

--- a/main/ui/src/main/java/org/cryptomator/ui/quit/QuitModule.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/quit/QuitModule.java
@@ -13,8 +13,6 @@ import org.cryptomator.ui.common.FxmlScene;
 import org.cryptomator.ui.common.StageFactory;
 
 import javax.inject.Provider;
-import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.Scene;
 import javafx.stage.Modality;
 import javafx.stage.Stage;


### PR DESCRIPTION
This fixes #1323 

It is implementing by adding a check mechanism in the quit dialogue creation method of the `FxApplication` class.

A considered alternative was create a singleton object between the `FxApplication` and the `QuitComponent`, which preserves the state of the quit window, and inject this object into FxApplication.