### PR TITLE
Add Minimize Button

### DIFF
--- a/.idea/runConfigurations/Cryptomator_Linux.xml
+++ b/.idea/runConfigurations/Cryptomator_Linux.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Cryptomator Linux" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.cryptomator.launcher.Cryptomator" />
     <module name="launcher" />
-    <option name="VM_PARAMETERS" value="-Djdk.gtk.version=2 -Duser.language=en -Dcryptomator.settingsPath=&quot;~/.config/Cryptomator/settings.json&quot; -Dcryptomator.ipcPortPath=&quot;~/.config/Cryptomator/ipcPort.bin&quot; -Dcryptomator.logDir=&quot;~/.local/share/Cryptomator/logs&quot; -Dcryptomator.mountPointsDir=&quot;~/.local/share/Cryptomator/mnt&quot; -Xss20m -Xmx512m" />
+    <option name="VM_PARAMETERS" value="-Djdk.gtk.version=2 -Duser.language=en -Dcryptomator.settingsPath=&quot;~/.config/Cryptomator/settings.json&quot; -Dcryptomator.ipcPortPath=&quot;~/.config/Cryptomator/ipcPort.bin&quot; -Dcryptomator.logDir=&quot;~/.local/share/Cryptomator/logs&quot; -Dcryptomator.mountPointsDir=&quot;~/.local/share/Cryptomator/mnt&quot; -Dcryptomator.showTrayIcon=true -Xss20m -Xmx512m" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.idea/runConfigurations/Cryptomator_Linux_Dev.xml
+++ b/.idea/runConfigurations/Cryptomator_Linux_Dev.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Cryptomator Linux Dev" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.cryptomator.launcher.Cryptomator" />
     <module name="launcher" />
-    <option name="VM_PARAMETERS" value="-Djdk.gtk.version=2 -Duser.language=en -Dcryptomator.settingsPath=&quot;~/.config/Cryptomator-Dev/settings.json&quot; -Dcryptomator.ipcPortPath=&quot;~/.config/Cryptomator-Dev/ipcPort.bin&quot; -Dcryptomator.logDir=&quot;~/.local/share/Cryptomator-Dev/logs&quot; -Dcryptomator.mountPointsDir=&quot;~/.local/share/Cryptomator-Dev/mnt&quot; -Dfuse.experimental=&quot;true&quot; -Xss20m -Xmx512m" />
+    <option name="VM_PARAMETERS" value="-Djdk.gtk.version=2 -Duser.language=en -Dcryptomator.settingsPath=&quot;~/.config/Cryptomator-Dev/settings.json&quot; -Dcryptomator.ipcPortPath=&quot;~/.config/Cryptomator-Dev/ipcPort.bin&quot; -Dcryptomator.logDir=&quot;~/.local/share/Cryptomator-Dev/logs&quot; -Dcryptomator.mountPointsDir=&quot;~/.local/share/Cryptomator-Dev/mnt&quot; -Dcryptomator.showTrayIcon=true -Dfuse.experimental=&quot;true&quot; -Xss20m -Xmx512m" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.idea/runConfigurations/Cryptomator_Windows.xml
+++ b/.idea/runConfigurations/Cryptomator_Windows.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Cryptomator Windows" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.cryptomator.launcher.Cryptomator" />
     <module name="launcher" />
-    <option name="VM_PARAMETERS" value="-Duser.language=en -Dcryptomator.settingsPath=&quot;~/AppData/Roaming/Cryptomator/settings.json&quot; -Dcryptomator.ipcPortPath=&quot;~/AppData/Roaming/Cryptomator/ipcPort.bin&quot; -Dcryptomator.logDir=&quot;~/AppData/Roaming/Cryptomator&quot; -Dcryptomator.keychainPath=&quot;~/AppData/Roaming/Cryptomator/keychain.json&quot; -Dcryptomator.mountPointsDir=&quot;~/Cryptomator&quot; -Xss2m -Xmx512m" />
+    <option name="VM_PARAMETERS" value="-Duser.language=en -Dcryptomator.settingsPath=&quot;~/AppData/Roaming/Cryptomator/settings.json&quot; -Dcryptomator.ipcPortPath=&quot;~/AppData/Roaming/Cryptomator/ipcPort.bin&quot; -Dcryptomator.logDir=&quot;~/AppData/Roaming/Cryptomator&quot; -Dcryptomator.keychainPath=&quot;~/AppData/Roaming/Cryptomator/keychain.json&quot; -Dcryptomator.mountPointsDir=&quot;~/Cryptomator&quot; -Dcryptomator.showTrayIcon=true -Xss2m -Xmx512m" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.idea/runConfigurations/Cryptomator_Windows_Dev.xml
+++ b/.idea/runConfigurations/Cryptomator_Windows_Dev.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Cryptomator Windows Dev" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.cryptomator.launcher.Cryptomator" />
     <module name="launcher" />
-    <option name="VM_PARAMETERS" value="-Duser.language=en -Dcryptomator.settingsPath=&quot;~/AppData/Roaming/Cryptomator-Dev/settings.json&quot; -Dcryptomator.ipcPortPath=&quot;~/AppData/Roaming/Cryptomator-Dev/ipcPort.bin&quot; -Dcryptomator.logDir=&quot;~/AppData/Roaming/Cryptomator-Dev&quot; -Dcryptomator.keychainPath=&quot;~/AppData/Roaming/Cryptomator-Dev/keychain.json&quot; -Dcryptomator.mountPointsDir=&quot;~/Cryptomator-Dev&quot; -Dfuse.experimental=&quot;true&quot; -Xss2m -Xmx512m" />
+    <option name="VM_PARAMETERS" value="-Duser.language=en -Dcryptomator.settingsPath=&quot;~/AppData/Roaming/Cryptomator-Dev/settings.json&quot; -Dcryptomator.ipcPortPath=&quot;~/AppData/Roaming/Cryptomator-Dev/ipcPort.bin&quot; -Dcryptomator.logDir=&quot;~/AppData/Roaming/Cryptomator-Dev&quot; -Dcryptomator.keychainPath=&quot;~/AppData/Roaming/Cryptomator-Dev/keychain.json&quot; -Dcryptomator.mountPointsDir=&quot;~/Cryptomator-Dev&quot; -Dfuse.experimental=&quot;true&quot; -Dcryptomator.showTrayIcon=true -Xss2m -Xmx512m" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.idea/runConfigurations/Cryptomator_macOS.xml
+++ b/.idea/runConfigurations/Cryptomator_macOS.xml
@@ -5,7 +5,7 @@
     </envs>
     <option name="MAIN_CLASS_NAME" value="org.cryptomator.launcher.Cryptomator" />
     <module name="launcher" />
-    <option name="VM_PARAMETERS" value="-Duser.language=en -Dcryptomator.settingsPath=&quot;~/Library/Application Support/Cryptomator/settings.json&quot; -Dcryptomator.ipcPortPath=&quot;~/Library/Application Support/Cryptomator/ipcPort.bin&quot; -Dcryptomator.logDir=&quot;~/Library/Logs/Cryptomator&quot; -Xss2m -Xmx512m -ea" />
+    <option name="VM_PARAMETERS" value="-Duser.language=en -Dcryptomator.settingsPath=&quot;~/Library/Application Support/Cryptomator/settings.json&quot; -Dcryptomator.ipcPortPath=&quot;~/Library/Application Support/Cryptomator/ipcPort.bin&quot; -Dcryptomator.logDir=&quot;~/Library/Logs/Cryptomator&quot; -Dcryptomator.showTrayIcon=true -Xss2m -Xmx512m -ea" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.idea/runConfigurations/Cryptomator_macOS_Dev.xml
+++ b/.idea/runConfigurations/Cryptomator_macOS_Dev.xml
@@ -5,7 +5,7 @@
     </envs>
     <option name="MAIN_CLASS_NAME" value="org.cryptomator.launcher.Cryptomator" />
     <module name="launcher" />
-    <option name="VM_PARAMETERS" value="-Duser.language=en -Dcryptomator.settingsPath=&quot;~/Library/Application Support/Cryptomator-Dev/settings.json&quot; -Dcryptomator.ipcPortPath=&quot;~/Library/Application Support/Cryptomator-Dev/ipcPort.bin&quot; -Dcryptomator.logDir=&quot;~/Library/Logs/Cryptomator-Dev&quot; -Xss2m -Xmx512m -ea" />
+    <option name="VM_PARAMETERS" value="-Duser.language=en -Dcryptomator.settingsPath=&quot;~/Library/Application Support/Cryptomator-Dev/settings.json&quot; -Dcryptomator.ipcPortPath=&quot;~/Library/Application Support/Cryptomator-Dev/ipcPort.bin&quot; -Dcryptomator.logDir=&quot;~/Library/Logs/Cryptomator-Dev&quot; -Dcryptomator.showTrayIcon=true -Xss2m -Xmx512m -ea" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/main/commons/src/main/java/org/cryptomator/common/Environment.java
+++ b/main/commons/src/main/java/org/cryptomator/common/Environment.java
@@ -21,14 +21,13 @@ import java.util.stream.StreamSupport;
 public class Environment {
 
 	private static final Logger LOG = LoggerFactory.getLogger(Environment.class);
-	private static final String USER_HOME = System.getProperty("user.home");
 	private static final Path RELATIVE_HOME_DIR = Paths.get("~");
-	private static final Path ABSOLUTE_HOME_DIR = Paths.get(USER_HOME);
 	private static final char PATH_LIST_SEP = ':';
 	private static final int DEFAULT_MIN_PW_LENGTH = 8;
 
 	@Inject
 	public Environment() {
+		LOG.debug("user.home: {}", System.getProperty("user.home"));
 		LOG.debug("java.library.path: {}", System.getProperty("java.library.path"));
 		LOG.debug("user.language: {}", System.getProperty("user.language"));
 		LOG.debug("user.region: {}", System.getProperty("user.region"));
@@ -40,6 +39,7 @@ public class Environment {
 		LOG.debug("cryptomator.mountPointsDir: {}", System.getProperty("cryptomator.mountPointsDir"));
 		LOG.debug("cryptomator.minPwLength: {}", System.getProperty("cryptomator.minPwLength"));
 		LOG.debug("cryptomator.buildNumber: {}", System.getProperty("cryptomator.buildNumber"));
+		LOG.debug("cryptomator.showTrayIcon: {}", System.getProperty("cryptomator.showTrayIcon"));
 		LOG.debug("fuse.experimental: {}", Boolean.getBoolean("fuse.experimental"));
 	}
 
@@ -75,6 +75,10 @@ public class Environment {
 		return getInt("cryptomator.minPwLength", DEFAULT_MIN_PW_LENGTH);
 	}
 
+	public boolean showTrayIcon() {
+		return Boolean.getBoolean("cryptomator.showTrayIcon");
+	}
+
 	@Deprecated // TODO: remove as soon as custom mount path works properly on Win+Fuse
 	public boolean useExperimentalFuse() {
 		return Boolean.getBoolean("fuse.experimental");
@@ -93,8 +97,13 @@ public class Environment {
 		String value = System.getProperty(propertyName);
 		return Optional.ofNullable(value).map(Paths::get);
 	}
-	// visible for testing
 
+	// visible for testing
+	Path getHomeDir() {
+		return getPath("user.home").orElseThrow();
+	}
+
+	// visible for testing
 	Stream<Path> getPaths(String propertyName) {
 		Stream<String> rawSettingsPaths = getRawList(propertyName, PATH_LIST_SEP);
 		return rawSettingsPaths.filter(Predicate.not(Strings::isNullOrEmpty)).map(Paths::get).map(this::replaceHomeDir);
@@ -102,7 +111,7 @@ public class Environment {
 
 	private Path replaceHomeDir(Path path) {
 		if (path.startsWith(RELATIVE_HOME_DIR)) {
-			return ABSOLUTE_HOME_DIR.resolve(RELATIVE_HOME_DIR.relativize(path));
+			return getHomeDir().resolve(RELATIVE_HOME_DIR.relativize(path));
 		} else {
 			return path;
 		}

--- a/main/commons/src/main/java/org/cryptomator/common/settings/Settings.java
+++ b/main/commons/src/main/java/org/cryptomator/common/settings/Settings.java
@@ -9,6 +9,7 @@
 package org.cryptomator.common.settings;
 
 import org.apache.commons.lang3.SystemUtils;
+import org.cryptomator.common.Environment;
 
 import javafx.beans.Observable;
 import javafx.beans.property.BooleanProperty;
@@ -54,13 +55,16 @@ public class Settings {
 	private final ObjectProperty<KeychainBackend> keychainBackend = new SimpleObjectProperty<>(DEFAULT_KEYCHAIN_BACKEND);
 	private final ObjectProperty<NodeOrientation> userInterfaceOrientation = new SimpleObjectProperty<>(DEFAULT_USER_INTERFACE_ORIENTATION);
 	private final StringProperty licenseKey = new SimpleStringProperty(DEFAULT_LICENSE_KEY);
+	private final BooleanProperty showTrayIcon;
 
 	private Consumer<Settings> saveCmd;
 
 	/**
 	 * Package-private constructor; use {@link SettingsProvider}.
 	 */
-	Settings() {
+	Settings(Environment env) {
+		this.showTrayIcon = new SimpleBooleanProperty(env.showTrayIcon());
+
 		directories.addListener(this::somethingChanged);
 		askedForUpdateCheck.addListener(this::somethingChanged);
 		checkForUpdates.addListener(this::somethingChanged);
@@ -74,6 +78,7 @@ public class Settings {
 		keychainBackend.addListener(this::somethingChanged);
 		userInterfaceOrientation.addListener(this::somethingChanged);
 		licenseKey.addListener(this::somethingChanged);
+		showTrayIcon.addListener(this::somethingChanged);
 	}
 
 	void setSaveCmd(Consumer<Settings> saveCmd) {
@@ -140,5 +145,9 @@ public class Settings {
 
 	public StringProperty licenseKey() {
 		return licenseKey;
+	}
+
+	public BooleanProperty showTrayIcon() {
+		return showTrayIcon;
 	}
 }

--- a/main/commons/src/main/java/org/cryptomator/common/settings/Settings.java
+++ b/main/commons/src/main/java/org/cryptomator/common/settings/Settings.java
@@ -40,7 +40,8 @@ public class Settings {
 	public static final UiTheme DEFAULT_THEME = UiTheme.LIGHT;
 	public static final KeychainBackend DEFAULT_KEYCHAIN_BACKEND = SystemUtils.IS_OS_WINDOWS ? KeychainBackend.WIN_SYSTEM_KEYCHAIN : SystemUtils.IS_OS_MAC ? KeychainBackend.MAC_SYSTEM_KEYCHAIN : KeychainBackend.GNOME;
 	public static final NodeOrientation DEFAULT_USER_INTERFACE_ORIENTATION = NodeOrientation.LEFT_TO_RIGHT;
-	private static final String DEFAULT_LICENSE_KEY = "";
+	public static final String DEFAULT_LICENSE_KEY = "";
+	public static final boolean DEFAULT_SHOW_MINIMIZE_BUTTON = false;
 
 	private final ObservableList<VaultSettings> directories = FXCollections.observableArrayList(VaultSettings::observables);
 	private final BooleanProperty askedForUpdateCheck = new SimpleBooleanProperty(DEFAULT_ASKED_FOR_UPDATE_CHECK);
@@ -55,6 +56,7 @@ public class Settings {
 	private final ObjectProperty<KeychainBackend> keychainBackend = new SimpleObjectProperty<>(DEFAULT_KEYCHAIN_BACKEND);
 	private final ObjectProperty<NodeOrientation> userInterfaceOrientation = new SimpleObjectProperty<>(DEFAULT_USER_INTERFACE_ORIENTATION);
 	private final StringProperty licenseKey = new SimpleStringProperty(DEFAULT_LICENSE_KEY);
+	private final BooleanProperty showMinimizeButton = new SimpleBooleanProperty(DEFAULT_SHOW_MINIMIZE_BUTTON);
 	private final BooleanProperty showTrayIcon;
 
 	private Consumer<Settings> saveCmd;
@@ -78,6 +80,7 @@ public class Settings {
 		keychainBackend.addListener(this::somethingChanged);
 		userInterfaceOrientation.addListener(this::somethingChanged);
 		licenseKey.addListener(this::somethingChanged);
+		showMinimizeButton.addListener(this::somethingChanged);
 		showTrayIcon.addListener(this::somethingChanged);
 	}
 
@@ -145,6 +148,10 @@ public class Settings {
 
 	public StringProperty licenseKey() {
 		return licenseKey;
+	}
+
+	public BooleanProperty showMinimizeButton() {
+		return showMinimizeButton;
 	}
 
 	public BooleanProperty showTrayIcon() {

--- a/main/commons/src/main/java/org/cryptomator/common/settings/SettingsJsonAdapter.java
+++ b/main/commons/src/main/java/org/cryptomator/common/settings/SettingsJsonAdapter.java
@@ -50,6 +50,7 @@ public class SettingsJsonAdapter extends TypeAdapter<Settings> {
 		out.name("uiOrientation").value(value.userInterfaceOrientation().get().name());
 		out.name("keychainBackend").value(value.keychainBackend().get().name());
 		out.name("licenseKey").value(value.licenseKey().get());
+		out.name("showMinimizeButton").value(value.showMinimizeButton().get());
 		out.name("showTrayIcon").value(value.showTrayIcon().get());
 		out.endObject();
 	}
@@ -83,6 +84,7 @@ public class SettingsJsonAdapter extends TypeAdapter<Settings> {
 				case "uiOrientation" -> settings.userInterfaceOrientation().set(parseUiOrientation(in.nextString()));
 				case "keychainBackend" -> settings.keychainBackend().set(parseKeychainBackend(in.nextString()));
 				case "licenseKey" -> settings.licenseKey().set(in.nextString());
+				case "showMinimizeButton" -> settings.showMinimizeButton().set(in.nextBoolean());
 				case "showTrayIcon" -> settings.showTrayIcon().set(in.nextBoolean());
 				default -> {
 					LOG.warn("Unsupported vault setting found in JSON: " + name);

--- a/main/commons/src/main/java/org/cryptomator/common/settings/SettingsJsonAdapter.java
+++ b/main/commons/src/main/java/org/cryptomator/common/settings/SettingsJsonAdapter.java
@@ -9,19 +9,29 @@ import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
+import org.cryptomator.common.Environment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import javafx.geometry.NodeOrientation;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+@Singleton
 public class SettingsJsonAdapter extends TypeAdapter<Settings> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(SettingsJsonAdapter.class);
 
 	private final VaultSettingsJsonAdapter vaultSettingsJsonAdapter = new VaultSettingsJsonAdapter();
+	private final Environment env;
+
+	@Inject
+	public SettingsJsonAdapter(Environment env) {
+		this.env = env;
+	}
 
 	@Override
 	public void write(JsonWriter out, Settings value) throws IOException {
@@ -40,6 +50,7 @@ public class SettingsJsonAdapter extends TypeAdapter<Settings> {
 		out.name("uiOrientation").value(value.userInterfaceOrientation().get().name());
 		out.name("keychainBackend").value(value.keychainBackend().get().name());
 		out.name("licenseKey").value(value.licenseKey().get());
+		out.name("showTrayIcon").value(value.showTrayIcon().get());
 		out.endObject();
 	}
 
@@ -53,7 +64,7 @@ public class SettingsJsonAdapter extends TypeAdapter<Settings> {
 
 	@Override
 	public Settings read(JsonReader in) throws IOException {
-		Settings settings = new Settings();
+		Settings settings = new Settings(env);
 
 		in.beginObject();
 		while (in.hasNext()) {
@@ -72,6 +83,7 @@ public class SettingsJsonAdapter extends TypeAdapter<Settings> {
 				case "uiOrientation" -> settings.userInterfaceOrientation().set(parseUiOrientation(in.nextString()));
 				case "keychainBackend" -> settings.keychainBackend().set(parseKeychainBackend(in.nextString()));
 				case "licenseKey" -> settings.licenseKey().set(in.nextString());
+				case "showTrayIcon" -> settings.showTrayIcon().set(in.nextBoolean());
 				default -> {
 					LOG.warn("Unsupported vault setting found in JSON: " + name);
 					in.skipValue();
@@ -137,5 +149,4 @@ public class SettingsJsonAdapter extends TypeAdapter<Settings> {
 		in.endArray();
 		return result;
 	}
-
 }

--- a/main/commons/src/main/java/org/cryptomator/common/settings/SettingsProvider.java
+++ b/main/commons/src/main/java/org/cryptomator/common/settings/SettingsProvider.java
@@ -49,13 +49,14 @@ public class SettingsProvider implements Supplier<Settings> {
 
 	private final AtomicReference<ScheduledFuture<?>> scheduledSaveCmd = new AtomicReference<>();
 	private final Supplier<Settings> settings = Suppliers.memoize(this::load);
-	private final SettingsJsonAdapter settingsJsonAdapter = new SettingsJsonAdapter();
+	private final SettingsJsonAdapter settingsJsonAdapter;
 	private final Environment env;
 	private final ScheduledExecutorService scheduler;
 	private final Gson gson;
 
 	@Inject
-	public SettingsProvider(Environment env, ScheduledExecutorService scheduler) {
+	public SettingsProvider(SettingsJsonAdapter settingsJsonAdapter, Environment env, ScheduledExecutorService scheduler) {
+		this.settingsJsonAdapter = settingsJsonAdapter;
 		this.env = env;
 		this.scheduler = scheduler;
 		this.gson = new GsonBuilder() //
@@ -70,7 +71,7 @@ public class SettingsProvider implements Supplier<Settings> {
 	}
 
 	private Settings load() {
-		Settings settings = env.getSettingsPath().flatMap(this::tryLoad).findFirst().orElse(new Settings());
+		Settings settings = env.getSettingsPath().flatMap(this::tryLoad).findFirst().orElse(new Settings(env));
 		settings.setSaveCmd(this::scheduleSave);
 		return settings;
 	}

--- a/main/commons/src/test/java/org/cryptomator/common/EnvironmentTest.java
+++ b/main/commons/src/test/java/org/cryptomator/common/EnvironmentTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -20,14 +21,10 @@ class EnvironmentTest {
 
 	private Environment env;
 
-	@BeforeAll
-	static void init() {
-		System.setProperty("user.home", "/home/testuser");
-	}
-
 	@BeforeEach
-	void initEach() {
-		env = new Environment();
+	void init() {
+		env = Mockito.spy(new Environment());
+		Mockito.when(env.getHomeDir()).thenReturn(Path.of("/home/testuser"));
 	}
 
 	@Test

--- a/main/commons/src/test/java/org/cryptomator/common/settings/SettingsJsonAdapterTest.java
+++ b/main/commons/src/test/java/org/cryptomator/common/settings/SettingsJsonAdapterTest.java
@@ -5,16 +5,19 @@
  *******************************************************************************/
 package org.cryptomator.common.settings;
 
+import org.cryptomator.common.Environment;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 
 public class SettingsJsonAdapterTest {
 
-	private final SettingsJsonAdapter adapter = new SettingsJsonAdapter();
+	private final Environment env = Mockito.mock(Environment.class);
+	private final SettingsJsonAdapter adapter = new SettingsJsonAdapter(env);
 
 	@Test
 	public void testDeserialize() throws IOException {

--- a/main/commons/src/test/java/org/cryptomator/common/settings/SettingsTest.java
+++ b/main/commons/src/test/java/org/cryptomator/common/settings/SettingsTest.java
@@ -5,6 +5,7 @@
  *******************************************************************************/
 package org.cryptomator.common.settings;
 
+import org.cryptomator.common.Environment;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -14,8 +15,10 @@ public class SettingsTest {
 
 	@Test
 	public void testAutoSave() {
+		Environment env = Mockito.mock(Environment.class);
 		@SuppressWarnings("unchecked") Consumer<Settings> changeListener = Mockito.mock(Consumer.class);
-		Settings settings = new Settings();
+
+		Settings settings = new Settings(env);
 		settings.setSaveCmd(changeListener);
 		VaultSettings vaultSettings = VaultSettings.withRandomId();
 		Mockito.verify(changeListener, Mockito.times(0)).accept(settings);

--- a/main/ui/src/main/java/org/cryptomator/ui/fxapp/FxApplication.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/fxapp/FxApplication.java
@@ -32,6 +32,8 @@ import javafx.stage.Stage;
 import javafx.stage.Window;
 import java.awt.desktop.QuitResponse;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 @FxApplicationScoped
 public class FxApplication extends Application {
@@ -99,11 +101,14 @@ public class FxApplication extends Application {
 		});
 	}
 
-	public void showMainWindow() {
+	public CompletionStage<Stage> showMainWindow() {
+		CompletableFuture<Stage> future = new CompletableFuture<>();
 		Platform.runLater(() -> {
-			mainWindow.get().showMainWindow();
+			var win = mainWindow.get().showMainWindow();
 			LOG.debug("Showing MainWindow");
+			future.complete(win);
 		});
+		return future;
 	}
 
 	public void startUnlockWorkflow(Vault vault, Optional<Stage> owner) {

--- a/main/ui/src/main/java/org/cryptomator/ui/fxapp/FxApplicationComponent.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/fxapp/FxApplicationComponent.java
@@ -5,10 +5,7 @@
  *******************************************************************************/
 package org.cryptomator.ui.fxapp;
 
-import dagger.BindsInstance;
 import dagger.Subcomponent;
-
-import javax.inject.Named;
 
 @FxApplicationScoped
 @Subcomponent(modules = FxApplicationModule.class)
@@ -18,9 +15,6 @@ public interface FxApplicationComponent {
 
 	@Subcomponent.Builder
 	interface Builder {
-
-		@BindsInstance
-		Builder trayMenuSupported(@Named("trayMenuSupported") boolean trayMenuSupported);
 
 		FxApplicationComponent build();
 	}

--- a/main/ui/src/main/java/org/cryptomator/ui/launcher/AppLaunchEventHandler.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/launcher/AppLaunchEventHandler.java
@@ -34,15 +34,15 @@ class AppLaunchEventHandler {
 		this.vaultListManager = vaultListManager;
 	}
 
-	public void startHandlingLaunchEvents(boolean hasTrayIcon) {
-		executorService.submit(() -> handleLaunchEvents(hasTrayIcon));
+	public void startHandlingLaunchEvents() {
+		executorService.submit(this::handleLaunchEvents);
 	}
 
-	private void handleLaunchEvents(boolean hasTrayIcon) {
+	private void handleLaunchEvents() {
 		try {
 			while (!Thread.interrupted()) {
 				AppLaunchEvent event = launchEventQueue.take();
-				handleLaunchEvent(hasTrayIcon, event);
+				handleLaunchEvent(event);
 			}
 		} catch (InterruptedException e) {
 			LOG.warn("Interrupted launch event handler.");
@@ -50,10 +50,10 @@ class AppLaunchEventHandler {
 		}
 	}
 
-	private void handleLaunchEvent(boolean hasTrayIcon, AppLaunchEvent event) {
+	private void handleLaunchEvent(AppLaunchEvent event) {
 		switch (event.getType()) {
-			case REVEAL_APP -> fxApplicationStarter.get(hasTrayIcon).thenAccept(FxApplication::showMainWindow);
-			case OPEN_FILE -> fxApplicationStarter.get(hasTrayIcon).thenRun(() -> {
+			case REVEAL_APP -> fxApplicationStarter.get().thenAccept(FxApplication::showMainWindow);
+			case OPEN_FILE -> fxApplicationStarter.get().thenRun(() -> {
 				Platform.runLater(() -> {
 					event.getPathsToOpen().forEach(this::addVault);
 				});

--- a/main/ui/src/main/java/org/cryptomator/ui/launcher/AppLifecycleListener.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/launcher/AppLifecycleListener.java
@@ -83,7 +83,7 @@ public class AppLifecycleListener {
 		if (allowQuitWithoutPrompt.get()) {
 			decoratedQuitResponse.performQuit();
 		} else {
-			fxApplicationStarter.get(true).thenAccept(app -> app.showQuitWindow(decoratedQuitResponse));
+			fxApplicationStarter.get().thenAccept(app -> app.showQuitWindow(decoratedQuitResponse));
 		}
 	}
 
@@ -113,11 +113,11 @@ public class AppLifecycleListener {
 	}
 
 	private void showPreferencesWindow(@SuppressWarnings("unused") EventObject actionEvent) {
-		fxApplicationStarter.get(true).thenAccept(app -> app.showPreferencesWindow(SelectedPreferencesTab.ANY));
+		fxApplicationStarter.get().thenAccept(app -> app.showPreferencesWindow(SelectedPreferencesTab.ANY));
 	}
 
 	private void showAboutWindow(@SuppressWarnings("unused") AboutEvent aboutEvent) {
-		fxApplicationStarter.get(true).thenAccept(app -> app.showPreferencesWindow(SelectedPreferencesTab.ABOUT));
+		fxApplicationStarter.get().thenAccept(app -> app.showPreferencesWindow(SelectedPreferencesTab.ABOUT));
 	}
 
 	private void forceUnmountRemainingVaults() {

--- a/main/ui/src/main/java/org/cryptomator/ui/launcher/FxApplicationStarter.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/launcher/FxApplicationStarter.java
@@ -1,7 +1,6 @@
 package org.cryptomator.ui.launcher;
 
 import dagger.Lazy;
-import org.cryptomator.common.settings.Settings;
 import org.cryptomator.ui.fxapp.FxApplication;
 import org.cryptomator.ui.fxapp.FxApplicationComponent;
 import org.slf4j.Logger;
@@ -10,7 +9,6 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javafx.application.Platform;
-import java.awt.SystemTray;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
@@ -27,7 +25,7 @@ public class FxApplicationStarter {
 	private final CompletableFuture<FxApplication> future;
 
 	@Inject
-	public FxApplicationStarter(Lazy<FxApplicationComponent> fxAppComponent, ExecutorService executor, Settings settings) {
+	public FxApplicationStarter(Lazy<FxApplicationComponent> fxAppComponent, ExecutorService executor) {
 		this.fxAppComponent = fxAppComponent;
 		this.executor = executor;
 		this.started = new AtomicBoolean();

--- a/main/ui/src/main/java/org/cryptomator/ui/launcher/FxApplicationStarter.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/launcher/FxApplicationStarter.java
@@ -1,5 +1,6 @@
 package org.cryptomator.ui.launcher;
 
+import dagger.Lazy;
 import org.cryptomator.common.settings.Settings;
 import org.cryptomator.ui.fxapp.FxApplication;
 import org.cryptomator.ui.fxapp.FxApplicationComponent;
@@ -20,19 +21,17 @@ public class FxApplicationStarter {
 
 	private static final Logger LOG = LoggerFactory.getLogger(FxApplicationStarter.class);
 
-	private final FxApplicationComponent.Builder fxAppComponent;
+	private final Lazy<FxApplicationComponent> fxAppComponent;
 	private final ExecutorService executor;
 	private final AtomicBoolean started;
 	private final CompletableFuture<FxApplication> future;
-	private final boolean hasTrayIcon;
 
 	@Inject
-	public FxApplicationStarter(FxApplicationComponent.Builder fxAppComponent, ExecutorService executor, Settings settings) {
+	public FxApplicationStarter(Lazy<FxApplicationComponent> fxAppComponent, ExecutorService executor, Settings settings) {
 		this.fxAppComponent = fxAppComponent;
 		this.executor = executor;
 		this.started = new AtomicBoolean();
 		this.future = new CompletableFuture<>();
-		this.hasTrayIcon = SystemTray.isSupported() && settings.showTrayIcon().get();
 	}
 
 	public CompletionStage<FxApplication> get() {
@@ -48,7 +47,7 @@ public class FxApplicationStarter {
 			Platform.startup(() -> {
 				assert Platform.isFxApplicationThread();
 				LOG.info("JavaFX Runtime started.");
-				FxApplication app = fxAppComponent.trayMenuSupported(hasTrayIcon).build().application();
+				FxApplication app = fxAppComponent.get().application();
 				app.start();
 				future.complete(app);
 			});

--- a/main/ui/src/main/java/org/cryptomator/ui/launcher/FxApplicationStarter.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/launcher/FxApplicationStarter.java
@@ -1,5 +1,6 @@
 package org.cryptomator.ui.launcher;
 
+import org.cryptomator.common.settings.Settings;
 import org.cryptomator.ui.fxapp.FxApplication;
 import org.cryptomator.ui.fxapp.FxApplicationComponent;
 import org.slf4j.Logger;
@@ -8,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javafx.application.Platform;
+import java.awt.SystemTray;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
@@ -22,23 +24,25 @@ public class FxApplicationStarter {
 	private final ExecutorService executor;
 	private final AtomicBoolean started;
 	private final CompletableFuture<FxApplication> future;
+	private final boolean hasTrayIcon;
 
 	@Inject
-	public FxApplicationStarter(FxApplicationComponent.Builder fxAppComponent, ExecutorService executor) {
+	public FxApplicationStarter(FxApplicationComponent.Builder fxAppComponent, ExecutorService executor, Settings settings) {
 		this.fxAppComponent = fxAppComponent;
 		this.executor = executor;
 		this.started = new AtomicBoolean();
 		this.future = new CompletableFuture<>();
+		this.hasTrayIcon = SystemTray.isSupported() && settings.showTrayIcon().get();
 	}
 
-	public CompletionStage<FxApplication> get(boolean hasTrayIcon) {
+	public CompletionStage<FxApplication> get() {
 		if (!started.getAndSet(true)) {
-			start(hasTrayIcon);
+			start();
 		}
 		return future;
 	}
 
-	private void start(boolean hasTrayIcon) {
+	private void start() {
 		executor.submit(() -> {
 			LOG.debug("Starting JavaFX runtime...");
 			Platform.startup(() -> {
@@ -50,5 +54,4 @@ public class FxApplicationStarter {
 			});
 		});
 	}
-
 }

--- a/main/ui/src/main/java/org/cryptomator/ui/launcher/UiLauncher.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/launcher/UiLauncher.java
@@ -1,5 +1,6 @@
 package org.cryptomator.ui.launcher;
 
+import dagger.Lazy;
 import org.cryptomator.common.settings.Settings;
 import org.cryptomator.common.vaults.Vault;
 import org.cryptomator.integrations.tray.TrayIntegrationProvider;
@@ -24,16 +25,16 @@ public class UiLauncher {
 
 	private final Settings settings;
 	private final ObservableList<Vault> vaults;
-	private final TrayMenuComponent.Builder trayComponent;
+	private final Lazy<TrayMenuComponent> trayMenu;
 	private final FxApplicationStarter fxApplicationStarter;
 	private final AppLaunchEventHandler launchEventHandler;
 	private final Optional<TrayIntegrationProvider> trayIntegration;
 
 	@Inject
-	public UiLauncher(Settings settings, ObservableList<Vault> vaults, TrayMenuComponent.Builder trayComponent, FxApplicationStarter fxApplicationStarter, AppLaunchEventHandler launchEventHandler, Optional<TrayIntegrationProvider> trayIntegration) {
+	public UiLauncher(Settings settings, ObservableList<Vault> vaults, Lazy<TrayMenuComponent> trayMenu, FxApplicationStarter fxApplicationStarter, AppLaunchEventHandler launchEventHandler, Optional<TrayIntegrationProvider> trayIntegration) {
 		this.settings = settings;
 		this.vaults = vaults;
-		this.trayComponent = trayComponent;
+		this.trayMenu = trayMenu;
 		this.fxApplicationStarter = fxApplicationStarter;
 		this.launchEventHandler = launchEventHandler;
 		this.trayIntegration = trayIntegration;
@@ -42,7 +43,7 @@ public class UiLauncher {
 	public void launch() {
 		boolean hidden = settings.startHidden().get();
 		if (SystemTray.isSupported() && settings.showTrayIcon().get()) {
-			trayComponent.build().addIconToSystemTray();
+			trayMenu.get().addIconToSystemTray();
 			launch(true, hidden);
 		} else {
 			launch(false, hidden);

--- a/main/ui/src/main/java/org/cryptomator/ui/launcher/UiLauncherModule.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/launcher/UiLauncherModule.java
@@ -21,6 +21,18 @@ public abstract class UiLauncherModule {
 
 	@Provides
 	@Singleton
+	static TrayMenuComponent provideTrayMenuComponent(TrayMenuComponent.Builder builder) {
+		return builder.build();
+	}
+
+	@Provides
+	@Singleton
+	static FxApplicationComponent provideFxApplicationComponent(FxApplicationComponent.Builder builder) {
+		return builder.build();
+	}
+
+	@Provides
+	@Singleton
 	static Optional<UiAppearanceProvider> provideAppearanceProvider() {
 		return ServiceLoader.load(UiAppearanceProvider.class).findFirst();
 	}

--- a/main/ui/src/main/java/org/cryptomator/ui/mainwindow/MainWindowComponent.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/mainwindow/MainWindowComponent.java
@@ -26,7 +26,6 @@ public interface MainWindowComponent {
 	default Stage showMainWindow() {
 		Stage stage = window();
 		stage.setScene(scene().get());
-		stage.setIconified(false);
 		stage.show();
 		stage.toFront();
 		stage.requestFocus();

--- a/main/ui/src/main/java/org/cryptomator/ui/mainwindow/MainWindowTitleController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/mainwindow/MainWindowTitleController.java
@@ -34,6 +34,7 @@ public class MainWindowTitleController implements FxController {
 	private final BooleanBinding updateAvailable;
 	private final LicenseHolder licenseHolder;
 	private final Settings settings;
+	private final BooleanBinding showMinimizeButton;
 
 	private double xOffset;
 	private double yOffset;
@@ -49,6 +50,7 @@ public class MainWindowTitleController implements FxController {
 		this.updateAvailable = updateChecker.latestVersionProperty().isNotNull();
 		this.licenseHolder = licenseHolder;
 		this.settings = settings;
+		this.showMinimizeButton = Bindings.createBooleanBinding(this::isShowMinimizeButton, settings.showMinimizeButton(), settings.showTrayIcon());
 	}
 
 	@FXML
@@ -122,5 +124,14 @@ public class MainWindowTitleController implements FxController {
 
 	public boolean isDebugModeEnabled() {
 		return debugModeEnabledProperty().get();
+	}
+
+	public BooleanBinding showMinimizeButtonProperty() {
+		return showMinimizeButton;
+	}
+
+	public boolean isShowMinimizeButton() {
+		// always show the minimize button if no tray icon is present OR it is explicitily enabled
+		return !trayMenuInitialized || settings.showMinimizeButton().get();
 	}
 }

--- a/main/ui/src/main/java/org/cryptomator/ui/mainwindow/MainWindowTitleController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/mainwindow/MainWindowTitleController.java
@@ -28,7 +28,7 @@ public class MainWindowTitleController implements FxController {
 	private final AppLifecycleListener appLifecycle;
 	private final Stage window;
 	private final FxApplication application;
-	private final boolean minimizeToSysTray;
+	private final boolean isTrayIconPresent;
 	private final UpdateChecker updateChecker;
 	private final BooleanBinding updateAvailable;
 	private final LicenseHolder licenseHolder;
@@ -39,11 +39,11 @@ public class MainWindowTitleController implements FxController {
 	private double yOffset;
 
 	@Inject
-	MainWindowTitleController(AppLifecycleListener appLifecycle, @MainWindow Stage window, FxApplication application, @Named("trayMenuSupported") boolean minimizeToSysTray, UpdateChecker updateChecker, LicenseHolder licenseHolder, Settings settings) {
+	MainWindowTitleController(AppLifecycleListener appLifecycle, @MainWindow Stage window, FxApplication application, @Named("trayMenuSupported") boolean isTrayIconPresent, UpdateChecker updateChecker, LicenseHolder licenseHolder, Settings settings) {
 		this.appLifecycle = appLifecycle;
 		this.window = window;
 		this.application = application;
-		this.minimizeToSysTray = minimizeToSysTray;
+		this.isTrayIconPresent = isTrayIconPresent;
 		this.updateChecker = updateChecker;
 		this.updateAvailable = updateChecker.latestVersionProperty().isNotNull();
 		this.licenseHolder = licenseHolder;
@@ -71,7 +71,7 @@ public class MainWindowTitleController implements FxController {
 
 	@FXML
 	public void close() {
-		if (minimizeToSysTray) {
+		if (isTrayIconPresent) {
 			window.close();
 		} else {
 			appLifecycle.quit();
@@ -112,8 +112,8 @@ public class MainWindowTitleController implements FxController {
 		return updateAvailable.get();
 	}
 
-	public boolean isMinimizeToSysTray() {
-		return minimizeToSysTray;
+	public boolean isTrayIconPresent() {
+		return isTrayIconPresent;
 	}
 
 	public BooleanBinding debugModeEnabledProperty() {

--- a/main/ui/src/main/java/org/cryptomator/ui/mainwindow/MainWindowTitleController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/mainwindow/MainWindowTitleController.java
@@ -7,13 +7,14 @@ import org.cryptomator.ui.fxapp.FxApplication;
 import org.cryptomator.ui.fxapp.UpdateChecker;
 import org.cryptomator.ui.launcher.AppLifecycleListener;
 import org.cryptomator.ui.preferences.SelectedPreferencesTab;
+import org.cryptomator.ui.traymenu.TrayMenuComponent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
+import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.fxml.FXML;
 import javafx.scene.layout.HBox;
 import javafx.stage.Stage;
@@ -28,27 +29,26 @@ public class MainWindowTitleController implements FxController {
 	private final AppLifecycleListener appLifecycle;
 	private final Stage window;
 	private final FxApplication application;
-	private final boolean isTrayIconPresent;
+	private final boolean trayMenuInitialized;
 	private final UpdateChecker updateChecker;
 	private final BooleanBinding updateAvailable;
 	private final LicenseHolder licenseHolder;
 	private final Settings settings;
-	private final BooleanBinding debugModeEnabled;
 
 	private double xOffset;
 	private double yOffset;
 
+
 	@Inject
-	MainWindowTitleController(AppLifecycleListener appLifecycle, @MainWindow Stage window, FxApplication application, @Named("trayMenuSupported") boolean isTrayIconPresent, UpdateChecker updateChecker, LicenseHolder licenseHolder, Settings settings) {
+	MainWindowTitleController(AppLifecycleListener appLifecycle, @MainWindow Stage window, FxApplication application, TrayMenuComponent trayMenu, UpdateChecker updateChecker, LicenseHolder licenseHolder, Settings settings) {
 		this.appLifecycle = appLifecycle;
 		this.window = window;
 		this.application = application;
-		this.isTrayIconPresent = isTrayIconPresent;
+		this.trayMenuInitialized = trayMenu.isInitialized();
 		this.updateChecker = updateChecker;
 		this.updateAvailable = updateChecker.latestVersionProperty().isNotNull();
 		this.licenseHolder = licenseHolder;
 		this.settings = settings;
-		this.debugModeEnabled = Bindings.createBooleanBinding(this::isDebugModeEnabled, settings.debugMode());
 	}
 
 	@FXML
@@ -71,7 +71,7 @@ public class MainWindowTitleController implements FxController {
 
 	@FXML
 	public void close() {
-		if (isTrayIconPresent) {
+		if (trayMenuInitialized) {
 			window.close();
 		} else {
 			appLifecycle.quit();
@@ -113,14 +113,14 @@ public class MainWindowTitleController implements FxController {
 	}
 
 	public boolean isTrayIconPresent() {
-		return isTrayIconPresent;
+		return trayMenuInitialized;
 	}
 
-	public BooleanBinding debugModeEnabledProperty() {
-		return debugModeEnabled;
+	public ReadOnlyBooleanProperty debugModeEnabledProperty() {
+		return settings.debugMode();
 	}
 
 	public boolean isDebugModeEnabled() {
-		return settings.debugMode().get();
+		return debugModeEnabledProperty().get();
 	}
 }

--- a/main/ui/src/main/java/org/cryptomator/ui/preferences/GeneralPreferencesController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/preferences/GeneralPreferencesController.java
@@ -27,6 +27,7 @@ import javafx.scene.control.Toggle;
 import javafx.scene.control.ToggleGroup;
 import javafx.stage.Stage;
 import javafx.util.StringConverter;
+import java.awt.SystemTray;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.ResourceBundle;
@@ -41,7 +42,6 @@ public class GeneralPreferencesController implements FxController {
 
 	private final Stage window;
 	private final Settings settings;
-	private final boolean trayMenuSupported;
 	private final Optional<AutoStartProvider> autoStartProvider;
 	private final ObjectProperty<SelectedPreferencesTab> selectedTabProperty;
 	private final LicenseHolder licenseHolder;
@@ -53,6 +53,7 @@ public class GeneralPreferencesController implements FxController {
 	private final ErrorComponent.Builder errorComponent;
 	public ChoiceBox<UiTheme> themeChoiceBox;
 	public ChoiceBox<KeychainBackend> keychainBackendChoiceBox;
+	public CheckBox showTrayIconCheckbox;
 	public CheckBox startHiddenCheckbox;
 	public CheckBox debugModeCheckbox;
 	public CheckBox autoStartCheckbox;
@@ -61,10 +62,9 @@ public class GeneralPreferencesController implements FxController {
 	public RadioButton nodeOrientationRtl;
 
 	@Inject
-	GeneralPreferencesController(@PreferencesWindow Stage window, Settings settings, @Named("trayMenuSupported") boolean trayMenuSupported, Optional<AutoStartProvider> autoStartProvider, Set<KeychainAccessProvider> keychainAccessProviders, ObjectProperty<SelectedPreferencesTab> selectedTabProperty, LicenseHolder licenseHolder, ExecutorService executor, ResourceBundle resourceBundle, Application application, Environment environment, ErrorComponent.Builder errorComponent) {
+	GeneralPreferencesController(@PreferencesWindow Stage window, Settings settings, Optional<AutoStartProvider> autoStartProvider, Set<KeychainAccessProvider> keychainAccessProviders, ObjectProperty<SelectedPreferencesTab> selectedTabProperty, LicenseHolder licenseHolder, ExecutorService executor, ResourceBundle resourceBundle, Application application, Environment environment, ErrorComponent.Builder errorComponent) {
 		this.window = window;
 		this.settings = settings;
-		this.trayMenuSupported = trayMenuSupported;
 		this.autoStartProvider = autoStartProvider;
 		this.keychainAccessProviders = keychainAccessProviders;
 		this.selectedTabProperty = selectedTabProperty;
@@ -84,6 +84,8 @@ public class GeneralPreferencesController implements FxController {
 		}
 		themeChoiceBox.valueProperty().bindBidirectional(settings.theme());
 		themeChoiceBox.setConverter(new UiThemeConverter(resourceBundle));
+
+		showTrayIconCheckbox.selectedProperty().bindBidirectional(settings.showTrayIcon());
 
 		startHiddenCheckbox.selectedProperty().bindBidirectional(settings.startHidden());
 
@@ -106,7 +108,7 @@ public class GeneralPreferencesController implements FxController {
 	}
 
 	public boolean isTrayMenuSupported() {
-		return this.trayMenuSupported;
+		return SystemTray.isSupported();
 	}
 
 	public boolean isAutoStartSupported() {

--- a/main/ui/src/main/java/org/cryptomator/ui/preferences/GeneralPreferencesController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/preferences/GeneralPreferencesController.java
@@ -52,6 +52,7 @@ public class GeneralPreferencesController implements FxController {
 	private final ErrorComponent.Builder errorComponent;
 	public ChoiceBox<UiTheme> themeChoiceBox;
 	public ChoiceBox<KeychainBackend> keychainBackendChoiceBox;
+	public CheckBox showMinimizeButtonCheckbox;
 	public CheckBox showTrayIconCheckbox;
 	public CheckBox startHiddenCheckbox;
 	public CheckBox debugModeCheckbox;
@@ -85,6 +86,8 @@ public class GeneralPreferencesController implements FxController {
 		}
 		themeChoiceBox.valueProperty().bindBidirectional(settings.theme());
 		themeChoiceBox.setConverter(new UiThemeConverter(resourceBundle));
+
+		showMinimizeButtonCheckbox.selectedProperty().bindBidirectional(settings.showMinimizeButton());
 
 		showTrayIconCheckbox.selectedProperty().bindBidirectional(settings.showTrayIcon());
 

--- a/main/ui/src/main/java/org/cryptomator/ui/preferences/GeneralPreferencesController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/preferences/GeneralPreferencesController.java
@@ -10,11 +10,11 @@ import org.cryptomator.integrations.autostart.ToggleAutoStartFailedException;
 import org.cryptomator.integrations.keychain.KeychainAccessProvider;
 import org.cryptomator.ui.common.ErrorComponent;
 import org.cryptomator.ui.common.FxController;
+import org.cryptomator.ui.traymenu.TrayMenuComponent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javafx.application.Application;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.value.ObservableValue;
@@ -27,12 +27,10 @@ import javafx.scene.control.Toggle;
 import javafx.scene.control.ToggleGroup;
 import javafx.stage.Stage;
 import javafx.util.StringConverter;
-import java.awt.SystemTray;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.ResourceBundle;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
 @PreferencesScoped
@@ -42,10 +40,11 @@ public class GeneralPreferencesController implements FxController {
 
 	private final Stage window;
 	private final Settings settings;
+	private final boolean trayMenuInitialized;
+	private final boolean trayMenuSupported;
 	private final Optional<AutoStartProvider> autoStartProvider;
 	private final ObjectProperty<SelectedPreferencesTab> selectedTabProperty;
 	private final LicenseHolder licenseHolder;
-	private final ExecutorService executor;
 	private final ResourceBundle resourceBundle;
 	private final Application application;
 	private final Environment environment;
@@ -61,15 +60,17 @@ public class GeneralPreferencesController implements FxController {
 	public RadioButton nodeOrientationLtr;
 	public RadioButton nodeOrientationRtl;
 
+
 	@Inject
-	GeneralPreferencesController(@PreferencesWindow Stage window, Settings settings, Optional<AutoStartProvider> autoStartProvider, Set<KeychainAccessProvider> keychainAccessProviders, ObjectProperty<SelectedPreferencesTab> selectedTabProperty, LicenseHolder licenseHolder, ExecutorService executor, ResourceBundle resourceBundle, Application application, Environment environment, ErrorComponent.Builder errorComponent) {
+	GeneralPreferencesController(@PreferencesWindow Stage window, Settings settings, TrayMenuComponent trayMenu, Optional<AutoStartProvider> autoStartProvider, Set<KeychainAccessProvider> keychainAccessProviders, ObjectProperty<SelectedPreferencesTab> selectedTabProperty, LicenseHolder licenseHolder, ResourceBundle resourceBundle, Application application, Environment environment, ErrorComponent.Builder errorComponent) {
 		this.window = window;
 		this.settings = settings;
+		this.trayMenuInitialized = trayMenu.isInitialized();
+		this.trayMenuSupported = trayMenu.isSupported();
 		this.autoStartProvider = autoStartProvider;
 		this.keychainAccessProviders = keychainAccessProviders;
 		this.selectedTabProperty = selectedTabProperty;
 		this.licenseHolder = licenseHolder;
-		this.executor = executor;
 		this.resourceBundle = resourceBundle;
 		this.application = application;
 		this.environment = environment;
@@ -107,8 +108,12 @@ public class GeneralPreferencesController implements FxController {
 		return Arrays.stream(KeychainBackend.values()).filter(value -> namesOfAvailableProviders.contains(value.getProviderClass())).toArray(KeychainBackend[]::new);
 	}
 
+	public boolean isTrayMenuInitialized() {
+		return trayMenuInitialized;
+	}
+
 	public boolean isTrayMenuSupported() {
-		return SystemTray.isSupported();
+		return trayMenuSupported;
 	}
 
 	public boolean isAutoStartSupported() {
@@ -177,6 +182,7 @@ public class GeneralPreferencesController implements FxController {
 		public UiTheme fromString(String string) {
 			throw new UnsupportedOperationException();
 		}
+
 	}
 
 	private static class KeychainBackendConverter extends StringConverter<KeychainBackend> {
@@ -196,6 +202,6 @@ public class GeneralPreferencesController implements FxController {
 		public KeychainBackend fromString(String string) {
 			throw new UnsupportedOperationException();
 		}
-	}
 
+	}
 }

--- a/main/ui/src/main/java/org/cryptomator/ui/traymenu/TrayIconController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/traymenu/TrayIconController.java
@@ -23,8 +23,7 @@ public class TrayIconController {
 	private final Optional<UiAppearanceProvider> appearanceProvider;
 	private final TrayMenuController trayMenuController;
 	private final TrayIcon trayIcon;
-	private boolean initialized;
-
+	private volatile boolean initialized;
 
 	@Inject
 	TrayIconController(TrayImageFactory imageFactory, TrayMenuController trayMenuController, Optional<UiAppearanceProvider> appearanceProvider) {

--- a/main/ui/src/main/java/org/cryptomator/ui/traymenu/TrayIconController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/traymenu/TrayIconController.java
@@ -1,5 +1,6 @@
 package org.cryptomator.ui.traymenu;
 
+import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.SystemUtils;
 import org.cryptomator.integrations.uiappearance.Theme;
 import org.cryptomator.integrations.uiappearance.UiAppearanceException;
@@ -22,6 +23,8 @@ public class TrayIconController {
 	private final Optional<UiAppearanceProvider> appearanceProvider;
 	private final TrayMenuController trayMenuController;
 	private final TrayIcon trayIcon;
+	private boolean initialized;
+
 
 	@Inject
 	TrayIconController(TrayImageFactory imageFactory, TrayMenuController trayMenuController, Optional<UiAppearanceProvider> appearanceProvider) {
@@ -31,7 +34,9 @@ public class TrayIconController {
 		this.trayIcon = new TrayIcon(imageFactory.loadImage(), "Cryptomator", trayMenuController.getMenu());
 	}
 
-	public void initializeTrayIcon() {
+	public synchronized void initializeTrayIcon() throws IllegalStateException {
+		Preconditions.checkState(!initialized);
+
 		appearanceProvider.ifPresent(appearanceProvider -> {
 			try {
 				appearanceProvider.addListener(this::systemInterfaceThemeChanged);
@@ -53,10 +58,15 @@ public class TrayIconController {
 		}
 
 		trayMenuController.initTrayMenu();
+
+		this.initialized = true;
 	}
 
 	private void systemInterfaceThemeChanged(Theme theme) {
 		trayIcon.setImage(imageFactory.loadImage()); // TODO refactor "theme" is re-queried in loadImage()
 	}
 
+	public boolean isInitialized() {
+		return initialized;
+	}
 }

--- a/main/ui/src/main/java/org/cryptomator/ui/traymenu/TrayMenuComponent.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/traymenu/TrayMenuComponent.java
@@ -15,8 +15,27 @@ public interface TrayMenuComponent {
 
 	TrayIconController trayIconController();
 
-	default void addIconToSystemTray() {
-		assert SystemTray.isSupported();
+	/**
+	 * @return <code>true</code> if a tray icon can be installed
+	 */
+	default boolean isSupported() {
+		return SystemTray.isSupported();
+	}
+
+	/**
+	 * @return <code>true</code> if a tray icon has been installed
+	 */
+	default boolean isInitialized() {
+		return trayIconController().isInitialized();
+	}
+
+	/**
+	 * Installs a tray icon to the system tray.
+	 *
+	 * @throws IllegalStateException If already added
+	 */
+	default void addIconToSystemTray() throws IllegalStateException {
+		assert isSupported();
 		trayIconController().initializeTrayIcon();
 	}
 

--- a/main/ui/src/main/java/org/cryptomator/ui/traymenu/TrayMenuController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/traymenu/TrayMenuController.java
@@ -1,6 +1,7 @@
 package org.cryptomator.ui.traymenu;
 
 import org.cryptomator.common.vaults.Vault;
+import org.cryptomator.ui.fxapp.FxApplication;
 import org.cryptomator.ui.launcher.AppLifecycleListener;
 import org.cryptomator.ui.launcher.FxApplicationStarter;
 import org.cryptomator.ui.preferences.SelectedPreferencesTab;
@@ -103,32 +104,36 @@ class TrayMenuController {
 		return actionEvent -> consumer.accept(vault);
 	}
 
+	private void quitApplication(EventObject actionEvent) {
+		appLifecycle.quit();
+	}
+
 	private void unlockVault(Vault vault) {
-		fxApplicationStarter.get(true).thenAccept(app -> app.startUnlockWorkflow(vault, Optional.empty()));
+		showMainAppAndThen(app -> app.startUnlockWorkflow(vault, Optional.empty()));
 	}
 
 	private void lockVault(Vault vault) {
-		fxApplicationStarter.get(true).thenAccept(app -> app.startLockWorkflow(vault, Optional.empty()));
+		showMainAppAndThen(app -> app.startLockWorkflow(vault, Optional.empty()));
 	}
 
 	private void lockAllVaults(ActionEvent actionEvent) {
-		fxApplicationStarter.get(true).thenAccept(app -> app.getVaultService().lockAll(vaults.filtered(Vault::isUnlocked), false));
+		showMainAppAndThen(app -> app.getVaultService().lockAll(vaults.filtered(Vault::isUnlocked), false));
 	}
 
 	private void revealVault(Vault vault) {
-		fxApplicationStarter.get(true).thenAccept(app -> app.getVaultService().reveal(vault));
+		showMainAppAndThen(app -> app.getVaultService().reveal(vault));
 	}
 
 	void showMainWindow(@SuppressWarnings("unused") ActionEvent actionEvent) {
-		fxApplicationStarter.get(true).thenAccept(app -> app.showMainWindow());
+		showMainAppAndThen(app -> app.showMainWindow());
 	}
 
 	private void showPreferencesWindow(@SuppressWarnings("unused") EventObject actionEvent) {
-		fxApplicationStarter.get(true).thenAccept(app -> app.showPreferencesWindow(SelectedPreferencesTab.ANY));
+		showMainAppAndThen(app -> app.showPreferencesWindow(SelectedPreferencesTab.ANY));
 	}
 
-	private void quitApplication(EventObject actionEvent) {
-		appLifecycle.quit();
+	private void showMainAppAndThen(Consumer<FxApplication> action) {
+		fxApplicationStarter.get().thenAccept(action);
 	}
 
 }

--- a/main/ui/src/main/resources/fxml/main_window_title.fxml
+++ b/main/ui/src/main/resources/fxml/main_window_title.fxml
@@ -54,7 +54,7 @@
 				<Tooltip text="%main.preferencesBtn.tooltip"/>
 			</tooltip>
 		</Button>
-		<Button contentDisplay="GRAPHIC_ONLY" mnemonicParsing="false" onAction="#minimize" focusTraversable="false" visible="${!controller.trayIconPresent}" managed="${!controller.trayIconPresent}">
+		<Button contentDisplay="GRAPHIC_ONLY" mnemonicParsing="false" onAction="#minimize" focusTraversable="false" visible="${controller.showMinimizeButton}" managed="${controller.showMinimizeButton}">
 			<graphic>
 				<FontAwesome5IconView glyph="WINDOW_MINIMIZE" glyphSize="12"/>
 			</graphic>

--- a/main/ui/src/main/resources/fxml/main_window_title.fxml
+++ b/main/ui/src/main/resources/fxml/main_window_title.fxml
@@ -54,7 +54,7 @@
 				<Tooltip text="%main.preferencesBtn.tooltip"/>
 			</tooltip>
 		</Button>
-		<Button contentDisplay="GRAPHIC_ONLY" mnemonicParsing="false" onAction="#minimize" focusTraversable="false" visible="${!controller.minimizeToSysTray}" managed="${!controller.minimizeToSysTray}">
+		<Button contentDisplay="GRAPHIC_ONLY" mnemonicParsing="false" onAction="#minimize" focusTraversable="false" visible="${!controller.trayIconPresent}" managed="${!controller.trayIconPresent}">
 			<graphic>
 				<FontAwesome5IconView glyph="WINDOW_MINIMIZE" glyphSize="12"/>
 			</graphic>

--- a/main/ui/src/main/resources/fxml/preferences_general.fxml
+++ b/main/ui/src/main/resources/fxml/preferences_general.fxml
@@ -32,7 +32,9 @@
 			<RadioButton fx:id="nodeOrientationRtl" text="%preferences.general.interfaceOrientation.rtl" alignment="CENTER_RIGHT" toggleGroup="${nodeOrientation}"/>
 		</HBox>
 
-		<CheckBox fx:id="startHiddenCheckbox" text="%preferences.general.startHidden" visible="${controller.trayMenuSupported}" managed="${controller.trayMenuSupported}"/>
+		<CheckBox fx:id="showTrayIconCheckbox" text="%preferences.general.showTrayIcon" visible="${controller.trayMenuSupported}" managed="${controller.trayMenuSupported}"/>
+
+		<CheckBox fx:id="startHiddenCheckbox" text="%preferences.general.startHidden" />
 
 		<HBox spacing="6" alignment="CENTER_LEFT">
 			<CheckBox fx:id="debugModeCheckbox" text="%preferences.general.debugLogging"/>

--- a/main/ui/src/main/resources/fxml/preferences_general.fxml
+++ b/main/ui/src/main/resources/fxml/preferences_general.fxml
@@ -32,6 +32,8 @@
 			<RadioButton fx:id="nodeOrientationRtl" text="%preferences.general.interfaceOrientation.rtl" alignment="CENTER_RIGHT" toggleGroup="${nodeOrientation}"/>
 		</HBox>
 
+		<CheckBox fx:id="showMinimizeButtonCheckbox" text="%preferences.general.showMinimizeButton" visible="${controller.trayMenuInitialized}" managed="${controller.trayMenuInitialized}"/>
+
 		<CheckBox fx:id="showTrayIconCheckbox" text="%preferences.general.showTrayIcon" visible="${controller.trayMenuSupported}" managed="${controller.trayMenuSupported}"/>
 
 		<CheckBox fx:id="startHiddenCheckbox" text="%preferences.general.startHidden" />

--- a/main/ui/src/main/resources/i18n/strings.properties
+++ b/main/ui/src/main/resources/i18n/strings.properties
@@ -150,6 +150,7 @@ preferences.general.theme.automatic=Automatic
 preferences.general.theme.light=Light
 preferences.general.theme.dark=Dark
 preferences.general.unlockThemes=Unlock dark mode
+preferences.general.showMinimizeButton=Show minimize button
 preferences.general.showTrayIcon=Show tray icon (requires restart)
 preferences.general.startHidden=Hide window when starting Cryptomator
 preferences.general.debugLogging=Enable debug logging

--- a/main/ui/src/main/resources/i18n/strings.properties
+++ b/main/ui/src/main/resources/i18n/strings.properties
@@ -150,6 +150,7 @@ preferences.general.theme.automatic=Automatic
 preferences.general.theme.light=Light
 preferences.general.theme.dark=Dark
 preferences.general.unlockThemes=Unlock dark mode
+preferences.general.showTrayIcon=Show tray icon (requires restart)
 preferences.general.startHidden=Hide window when starting Cryptomator
 preferences.general.debugLogging=Enable debug logging
 preferences.general.debugDirectory=Reveal log files


### PR DESCRIPTION
Basically this adds two more options to the general Preferences:

* Control whether a tray icon should be installed, which should relax the situation where the Desktop environment doesn't necessarily act in favour of AWT tray icons, thus causing problems such as #1113, #1078, #1079
* Control whether the main window should show a minimize button (which fixes #1179)
* Also, it is now possible to start with the Window minimized by disabling the tray icon and asking to start hidden at the same time. This may also solve #1344

<img width="612" alt="Screenshot 2020-12-17 at 14 53 28" src="https://user-images.githubusercontent.com/1204330/102496407-a779df00-4077-11eb-996d-456c4d8f76e2.png">

It is worth mentioning, that the minimize button is still obligatory when no tray icon exists, in which case the corresponding checkbox will be invisible.

This also rewires interactions between the Dagger components Launcher, TrayMenu and FxApplication.