### PR TITLE
Feature/refactor reveal

### DIFF
--- a/main/commons/src/main/java/org/cryptomator/common/vaults/DokanyVolume.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/DokanyVolume.java
@@ -8,6 +8,7 @@ import org.cryptomator.cryptofs.CryptoFileSystem;
 import org.cryptomator.frontend.dokany.Mount;
 import org.cryptomator.frontend.dokany.MountFactory;
 import org.cryptomator.frontend.dokany.MountFailedException;
+import org.cryptomator.frontend.dokany.RevealException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,10 +53,12 @@ public class DokanyVolume extends AbstractVolume {
 	}
 
 	@Override
-	public void reveal() throws VolumeException {
-		boolean success = mount.reveal();
-		if (!success) {
-			throw new VolumeException("Reveal failed.");
+	public void reveal(Revealer r) throws VolumeException {
+		try {
+			mount.reveal(r);
+		} catch (RevealException e) {
+			LOG.debug("Revealing the vault in file manger failed: " + e.getMessage());
+			throw new VolumeException(e);
 		}
 	}
 
@@ -79,6 +82,7 @@ public class DokanyVolume extends AbstractVolume {
 	public boolean supportsForcedUnmount() {
 		return true;
 	}
+
 	@Override
 	public boolean isSupported() {
 		return DokanyVolume.isSupportedStatic();

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/FuseVolume.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/FuseVolume.java
@@ -12,6 +12,7 @@ import org.cryptomator.frontend.fuse.mount.FuseMountFactory;
 import org.cryptomator.frontend.fuse.mount.FuseNotSupportedException;
 import org.cryptomator.frontend.fuse.mount.Mount;
 import org.cryptomator.frontend.fuse.mount.Mounter;
+import org.cryptomator.frontend.fuse.mount.RevealException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,7 +21,6 @@ import javax.inject.Named;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.SortedSet;
 import java.util.regex.Pattern;
 
 public class FuseVolume extends AbstractVolume {
@@ -73,10 +73,10 @@ public class FuseVolume extends AbstractVolume {
 	}
 
 	@Override
-	public void reveal() throws VolumeException {
+	public void reveal(Revealer r) throws VolumeException {
 		try {
-			mount.revealInFileManager();
-		} catch (CommandFailedException e) {
+			mount.reveal(r);
+		} catch (RevealException e) {
 			LOG.debug("Revealing the vault in file manger failed: " + e.getMessage());
 			throw new VolumeException(e);
 		}

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/Vault.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/Vault.java
@@ -148,8 +148,8 @@ public class Vault {
 		}
 	}
 
-	public void reveal() throws VolumeException {
-		volume.reveal();
+	public void reveal(Volume.Revealer vaultRevealer) throws VolumeException {
+		volume.reveal(vaultRevealer);
 	}
 
 	// ******************************************************************************

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/Volume.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/Volume.java
@@ -3,6 +3,8 @@ package org.cryptomator.common.vaults;
 import org.cryptomator.common.mountpoint.InvalidMountPointException;
 import org.cryptomator.common.settings.VolumeImpl;
 import org.cryptomator.cryptofs.CryptoFileSystem;
+import org.cryptomator.frontend.fuse.mount.Revealer;
+import org.cryptomator.frontend.webdav.mount.Mounter;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -34,7 +36,11 @@ public interface Volume {
 	 */
 	void mount(CryptoFileSystem fs, String mountFlags) throws IOException, VolumeException, InvalidMountPointException;
 
-	void reveal() throws VolumeException;
+	/**
+	 * TODO: refactor, such that this method accepts a (new) interface revealer and document that it could be ignored.
+	 * @throws VolumeException
+	 */
+	void reveal(Revealer revealer) throws VolumeException;
 
 	void unmount() throws VolumeException;
 
@@ -76,6 +82,13 @@ public interface Volume {
 		public VolumeException(String message, Throwable cause) {
 			super(message, cause);
 		}
+
+	}
+
+	/**
+	 * Interface to bundle the different revealer interfaces in the used nio-adapters
+	 */
+	interface Revealer extends org.cryptomator.frontend.fuse.mount.Revealer, org.cryptomator.frontend.dokany.Revealer, Mounter.Revealer{
 
 	}
 

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/WebDavVolume.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/WebDavVolume.java
@@ -29,7 +29,6 @@ public class WebDavVolume implements Volume {
 	private WebDavServer server;
 	private WebDavServletController servlet;
 	private Mounter.Mount mount;
-	private Path mountPoint;
 
 	@Inject
 	public WebDavVolume(Provider<WebDavServer> serverProvider, VaultSettings vaultSettings, Settings settings) {
@@ -71,11 +70,10 @@ public class WebDavVolume implements Volume {
 	}
 
 	@Override
-	public void reveal() throws VolumeException {
+	public void reveal(Revealer r) throws VolumeException {
 		try {
-			mount.reveal();
-		} catch (Mounter.CommandFailedException e) {
-			e.printStackTrace();
+			mount.reveal(r);
+		} catch (Mounter.RevealException e) {
 			throw new VolumeException(e);
 		}
 	}
@@ -102,7 +100,7 @@ public class WebDavVolume implements Volume {
 
 	@Override
 	public Optional<Path> getMountPoint() {
-		return Optional.ofNullable(mountPoint); //TODO
+		return mount.getMountPoint();
 	}
 
 	@Override

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/WebDavVolume.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/WebDavVolume.java
@@ -10,6 +10,8 @@ import org.cryptomator.frontend.webdav.WebDavServer;
 import org.cryptomator.frontend.webdav.mount.MountParams;
 import org.cryptomator.frontend.webdav.mount.Mounter;
 import org.cryptomator.frontend.webdav.servlet.WebDavServletController;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -20,6 +22,7 @@ import java.util.Optional;
 
 public class WebDavVolume implements Volume {
 
+	private static final Logger LOG = LoggerFactory.getLogger(WebDavVolume.class);
 	private static final String LOCALHOST_ALIAS = "cryptomator-vault";
 
 	private final Provider<WebDavServer> serverProvider;
@@ -74,6 +77,7 @@ public class WebDavVolume implements Volume {
 		try {
 			mount.reveal(r);
 		} catch (Mounter.RevealException e) {
+			LOG.debug("Revealing the vault in file manger failed: " + e.getMessage());
 			throw new VolumeException(e);
 		}
 	}

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -29,9 +29,9 @@
 		<cryptomator.integrations.win.version>0.2.1</cryptomator.integrations.win.version>
 		<cryptomator.integrations.mac.version>0.1.0-beta3</cryptomator.integrations.mac.version>
 		<cryptomator.integrations.linux.version>0.1.0-beta2</cryptomator.integrations.linux.version>
-		<cryptomator.fuse.version>1.2.6</cryptomator.fuse.version>
-		<cryptomator.dokany.version>1.2.1</cryptomator.dokany.version>
-		<cryptomator.webdav.version>1.0.14</cryptomator.webdav.version>
+		<cryptomator.fuse.version>1.3.0-SNAPSHOT</cryptomator.fuse.version>
+		<cryptomator.dokany.version>1.3.0-SNAPSHOT</cryptomator.dokany.version>
+		<cryptomator.webdav.version>1.1.0-SNAPSHOT</cryptomator.webdav.version>
 
 		<!-- 3rd party dependencies -->
 		<javafx.version>15</javafx.version>

--- a/main/ui/src/main/java/org/cryptomator/ui/fxapp/FxApplication.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/fxapp/FxApplication.java
@@ -68,6 +68,8 @@ public class FxApplication extends Application {
 		this.licenseHolder = licenseHolder;
 		this.visibleWindows = Stage.getWindows().filtered(Window::isShowing);
 		this.hasVisibleWindows = Bindings.isNotEmpty(visibleWindows);
+
+		vaultService.setVaultRevealer(p -> this.getHostServices().showDocument(p.toUri().toString()));
 	}
 
 	public void start() {


### PR DESCRIPTION
This is the finishing PR for the reveal()-Project: https://github.com/orgs/cryptomator/projects/1.

It implements the functionality to reveal the mounted vaults via the JavaFX framework (with the [`HostServices`](https://openjfx.io/javadoc/15/javafx.graphics/javafx/application/HostServices.html#showDocument(java.lang.String)) class) rather than calling special reveal implementations in the upstream libraries.

It is done by bundle all upstream Revealer-Implementations in one interface `Volume.Revealer` and make this interface a parameter in the `reveal()` methods of `Volume` and `Vault`. The parameter is necessary because [`Application::getHostServices`](https://openjfx.io/javadoc/15/javafx.graphics/javafx/application/Application.html#getHostServices()) can only be called from a running Application, which is only present in the ui package. An additional "detour" had to be made with an atomic referene, because `Vault.reveal(Volume.Revealer r)` is called from `VaultService` which gets injected into the runnning applicatio, hence, the revealer cannot be setup before.

The CI currently fails due to missing library releases. These must be made and the PR updated before a successful CI is possible:
[ ] released new version of https://github.com/cryptomator/fuse-nio-adapter
[ ] released new version of https://github.com/cryptomator/dokany-nio-adapter
[ ] released new version of https://github.com/cryptomator/webdav-nio-adapter