### PR TITLE
Fixed suppressed "invalid mountpoint" messages

### DIFF
--- a/main/ui/src/main/java/org/cryptomator/ui/unlock/UnlockWorkflow.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/unlock/UnlockWorkflow.java
@@ -204,6 +204,7 @@ public class UnlockWorkflow extends Task<Boolean> {
 	private void showInvalidMountPointScene() {
 		Platform.runLater(() -> {
 			window.setScene(invalidMountPointScene.get());
+			window.show();
 		});
 	}
 


### PR DESCRIPTION
Fixes #1519

Currently clicking "Back" in the `invalidMountPointScene` causes a filled out "Enter Password" Window to appear, even if the password was entered by the keychain and not by the user. Fixing this requires additional refactoring to the `invalidMountPointScene` controller.

I'm under the impression that fully refactoring `invalidMountPointScene` after the example of `ErrorComponent` would be a good solution at this point in time.