### PR TITLE
"Save Password" Clarification

### DIFF
--- a/main/ui/src/main/java/org/cryptomator/ui/mainwindow/VaultDetailLockedController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/mainwindow/VaultDetailLockedController.java
@@ -5,6 +5,7 @@ import org.cryptomator.common.keychain.KeychainManager;
 import org.cryptomator.common.vaults.Vault;
 import org.cryptomator.ui.common.FxController;
 import org.cryptomator.ui.fxapp.FxApplication;
+import org.cryptomator.ui.vaultoptions.SelectedVaultOptionsTab;
 import org.cryptomator.ui.vaultoptions.VaultOptionsComponent;
 
 import javax.inject.Inject;
@@ -47,7 +48,12 @@ public class VaultDetailLockedController implements FxController {
 
 	@FXML
 	public void showVaultOptions() {
-		vaultOptionsWindow.vault(vault.get()).build().showVaultOptionsWindow();
+		vaultOptionsWindow.vault(vault.get()).build().showVaultOptionsWindow(SelectedVaultOptionsTab.ANY);
+	}
+
+	@FXML
+	public void showKeyVaultOptions() {
+		vaultOptionsWindow.vault(vault.get()).build().showVaultOptionsWindow(SelectedVaultOptionsTab.KEY);
 	}
 
 	/* Getter/Setter */

--- a/main/ui/src/main/java/org/cryptomator/ui/vaultoptions/SelectedVaultOptionsTab.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/vaultoptions/SelectedVaultOptionsTab.java
@@ -1,0 +1,23 @@
+package org.cryptomator.ui.vaultoptions;
+
+public enum SelectedVaultOptionsTab {
+	/**
+	 * Let the controller decide which tab to show.
+	 */
+	ANY,
+
+	/**
+	 * Show general tab
+	 */
+	GENERAL,
+
+	/**
+	 * Show mounting tab
+	 */
+	MOUNT,
+
+	/**
+	 * Show password tab
+	 */
+	KEY,
+}

--- a/main/ui/src/main/java/org/cryptomator/ui/vaultoptions/VaultOptionsComponent.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/vaultoptions/VaultOptionsComponent.java
@@ -12,6 +12,7 @@ import org.cryptomator.common.vaults.Vault;
 import org.cryptomator.ui.common.FxmlFile;
 import org.cryptomator.ui.common.FxmlScene;
 
+import javafx.beans.property.ObjectProperty;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
@@ -25,7 +26,10 @@ public interface VaultOptionsComponent {
 	@FxmlScene(FxmlFile.VAULT_OPTIONS)
 	Lazy<Scene> scene();
 
-	default void showVaultOptionsWindow() {
+	ObjectProperty<SelectedVaultOptionsTab> selectedTabProperty();
+
+	default void showVaultOptionsWindow(SelectedVaultOptionsTab selectedTab) {
+		selectedTabProperty().set(selectedTab);
 		Stage stage = window();
 		stage.setScene(scene().get());
 		stage.show();

--- a/main/ui/src/main/java/org/cryptomator/ui/vaultoptions/VaultOptionsController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/vaultoptions/VaultOptionsController.java
@@ -1,13 +1,67 @@
 package org.cryptomator.ui.vaultoptions;
 
 import org.cryptomator.ui.common.FxController;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javafx.beans.property.ObjectProperty;
+import javafx.fxml.FXML;
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
+import javafx.stage.Stage;
+import javafx.stage.WindowEvent;
 
 @VaultOptionsScoped
 public class VaultOptionsController implements FxController {
 
+	private static final Logger LOG = LoggerFactory.getLogger(VaultOptionsController.class);
+
+	private final Stage window;
+	private final ObjectProperty<SelectedVaultOptionsTab> selectedTabProperty;
+	public TabPane tabPane;
+	public Tab generalTab;
+	public Tab mountTab;
+	public Tab keyTab;
+
 	@Inject
-	VaultOptionsController() {}
+	VaultOptionsController(@VaultOptionsWindow Stage window, ObjectProperty<SelectedVaultOptionsTab> selectedTabProperty) {
+		this.window = window;
+		this.selectedTabProperty = selectedTabProperty;
+	}
+
+	@FXML
+	public void initialize() {
+		window.setOnShowing(this::windowWillAppear);
+		selectedTabProperty.addListener(observable -> this.selectChosenTab());
+		tabPane.getSelectionModel().selectedItemProperty().addListener(observable -> this.selectedTabChanged());
+	}
+
+	private void selectChosenTab() {
+		Tab toBeSelected = getTabToSelect(selectedTabProperty.get());
+		tabPane.getSelectionModel().select(toBeSelected);
+	}
+
+	private Tab getTabToSelect(SelectedVaultOptionsTab selectedTab) {
+		return switch (selectedTab) {
+			case ANY, GENERAL -> generalTab;
+			case MOUNT -> mountTab;
+			case KEY -> keyTab;
+		};
+	}
+
+	private void selectedTabChanged() {
+		Tab selectedTab = tabPane.getSelectionModel().getSelectedItem();
+		try {
+			SelectedVaultOptionsTab selectedVaultOptionsTab = SelectedVaultOptionsTab.valueOf(selectedTab.getId());
+			selectedTabProperty.set(selectedVaultOptionsTab);
+		} catch (IllegalArgumentException e) {
+			LOG.error("Unknown vault options tab id: {}", selectedTab.getId());
+		}
+	}
+
+	private void windowWillAppear(@SuppressWarnings("unused") WindowEvent windowEvent) {
+		selectChosenTab();
+	}
 
 }

--- a/main/ui/src/main/java/org/cryptomator/ui/vaultoptions/VaultOptionsModule.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/vaultoptions/VaultOptionsModule.java
@@ -7,16 +7,18 @@ import dagger.multibindings.IntoMap;
 import org.cryptomator.common.vaults.Vault;
 import org.cryptomator.ui.changepassword.ChangePasswordComponent;
 import org.cryptomator.ui.common.DefaultSceneFactory;
-import org.cryptomator.ui.common.FxmlLoaderFactory;
 import org.cryptomator.ui.common.FxController;
 import org.cryptomator.ui.common.FxControllerKey;
 import org.cryptomator.ui.common.FxmlFile;
+import org.cryptomator.ui.common.FxmlLoaderFactory;
 import org.cryptomator.ui.common.FxmlScene;
 import org.cryptomator.ui.common.StageFactory;
 import org.cryptomator.ui.mainwindow.MainWindow;
 import org.cryptomator.ui.recoverykey.RecoveryKeyComponent;
 
 import javax.inject.Provider;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.Scene;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
@@ -25,6 +27,12 @@ import java.util.ResourceBundle;
 
 @Module(subcomponents = {ChangePasswordComponent.class, RecoveryKeyComponent.class})
 abstract class VaultOptionsModule {
+
+	@Provides
+	@VaultOptionsScoped
+	static ObjectProperty<SelectedVaultOptionsTab> provideSelectedTabProperty() {
+		return new SimpleObjectProperty<>(SelectedVaultOptionsTab.ANY);
+	}
 
 	@Provides
 	@VaultOptionsWindow

--- a/main/ui/src/main/resources/fxml/vault_detail_locked.fxml
+++ b/main/ui/src/main/resources/fxml/vault_detail_locked.fxml
@@ -2,7 +2,6 @@
 
 <?import org.cryptomator.ui.controls.FontAwesome5IconView?>
 <?import javafx.scene.control.Button?>
-<?import javafx.scene.control.Hyperlink?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>
@@ -25,18 +24,20 @@
 				<FontAwesome5IconView glyph="KEY" glyphSize="15"/>
 			</graphic>
 		</Button>
-		<Hyperlink text="%main.vaultDetail.optionsBtn" onAction="#showVaultOptions">
+		<Label styleClass="label-small,label-muted" text="%main.vaultDetail.passwordSavedInKeychain" visible="${controller.passwordSaved}">
 			<graphic>
-				<FontAwesome5IconView glyph="COG"/>
+				<FontAwesome5IconView styleClass="glyph-icon-muted" glyph="LOCK"/>
 			</graphic>
-		</Hyperlink>
+		</Label>
+
 		<Region VBox.vgrow="ALWAYS"/>
-		<HBox alignment="CENTER_RIGHT" spacing="6">
-			<Label styleClass="label-small,label-muted" text="%main.vaultDetail.passwordSavedInKeychain" visible="${controller.passwordSaved}">
+
+		<HBox alignment="BOTTOM_RIGHT">
+			<Button text="%main.vaultDetail.optionsBtn" minWidth="120" onAction="#showVaultOptions">
 				<graphic>
-					<FontAwesome5IconView styleClass="glyph-icon-muted" glyph="LOCK"/>
+					<FontAwesome5IconView glyph="COG"/>
 				</graphic>
-			</Label>
+			</Button>
 		</HBox>
 	</children>
 </VBox>

--- a/main/ui/src/main/resources/fxml/vault_detail_locked.fxml
+++ b/main/ui/src/main/resources/fxml/vault_detail_locked.fxml
@@ -2,7 +2,7 @@
 
 <?import org.cryptomator.ui.controls.FontAwesome5IconView?>
 <?import javafx.scene.control.Button?>
-<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.Hyperlink?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.VBox?>
@@ -24,11 +24,11 @@
 				<FontAwesome5IconView glyph="KEY" glyphSize="15"/>
 			</graphic>
 		</Button>
-		<Label styleClass="label-small,label-muted" text="%main.vaultDetail.passwordSavedInKeychain" visible="${controller.passwordSaved}">
+		<Hyperlink text="%main.vaultDetail.passwordSavedInKeychain" visible="${controller.passwordSaved}" onAction="#showKeyVaultOptions">
 			<graphic>
-				<FontAwesome5IconView styleClass="glyph-icon-muted" glyph="LOCK"/>
+				<FontAwesome5IconView glyph="LOCK"/>
 			</graphic>
-		</Label>
+		</Hyperlink>
 
 		<Region VBox.vgrow="ALWAYS"/>
 

--- a/main/ui/src/main/resources/fxml/vault_options.fxml
+++ b/main/ui/src/main/resources/fxml/vault_options.fxml
@@ -12,7 +12,7 @@
 		 tabClosingPolicy="UNAVAILABLE"
 		 tabDragPolicy="FIXED">
 	<tabs>
-		<Tab fx:id="generalTab" text="%vaultOptions.general">
+		<Tab fx:id="generalTab" id="GENERAL" text="%vaultOptions.general">
 			<graphic>
 				<FontAwesome5IconView glyph="WRENCH"/>
 			</graphic>
@@ -20,7 +20,7 @@
 				<fx:include source="/fxml/vault_options_general.fxml"/>
 			</content>
 		</Tab>
-		<Tab fx:id="mountTab" text="%vaultOptions.mount">
+		<Tab fx:id="mountTab" id="MOUNT" text="%vaultOptions.mount">
 			<graphic>
 				<FontAwesome5IconView glyph="HDD"/>
 			</graphic>
@@ -28,7 +28,7 @@
 				<fx:include source="/fxml/vault_options_mount.fxml"/>
 			</content>
 		</Tab>
-		<Tab fx:id="keyTab" text="%vaultOptions.masterkey">
+		<Tab fx:id="keyTab" id="KEY" text="%vaultOptions.masterkey">
 			<graphic>
 				<FontAwesome5IconView glyph="KEY"/>
 			</graphic>

--- a/main/ui/src/main/resources/i18n/strings.properties
+++ b/main/ui/src/main/resources/i18n/strings.properties
@@ -96,7 +96,7 @@ forgetPassword.confirmBtn=Forget Password
 # Unlock
 unlock.title=Unlock Vault
 unlock.passwordPrompt=Enter password for "%s":
-unlock.savePassword=Save Password
+unlock.savePassword=Remember Password
 unlock.unlockBtn=Unlock
 ## Success
 unlock.success.message=Unlocked "%s" successfully! Your vault is now accessible.


### PR DESCRIPTION
These are, in my opinion, minimal changes to make the feature "save password" clearer:
- Changed label from "Save Password" to "Remember Password" in unlock dialog.
- Switched placements of "Vault Options" hyperlink (and made it to a button) and "Password saved" label in vault detail locked screen.

Other changes considered but omitted:
- Changing the localization key to `unlock.rememberPassword`. I wasn't sure if this would be helpful or hurtful.
- Making the label "Password saved" to a hyperlink, which would deep-link to the "Password" tab of the "Vault Options". These would require bigger changes, should this be part of this PR?
- Adding a detail text to the "Remember Password" checkbox with something like "Saves the password on this machine, so you don't need to enter it on subsequent unlocks" or "Saves the password in the configured password manager, so ...". Even though it would clarify the checkbox, I'd like to see the effect of the two changes alone because they might already be sufficient.