### PR TITLE
Feature/win auto theme

### DIFF
--- a/main/commons/src/main/java/org/cryptomator/common/settings/UiTheme.java
+++ b/main/commons/src/main/java/org/cryptomator/common/settings/UiTheme.java
@@ -8,7 +8,7 @@ public enum UiTheme {
 	AUTOMATIC("preferences.general.theme.automatic");
 
 	public static UiTheme[] applicableValues() {
-		if (SystemUtils.IS_OS_MAC) {
+		if (SystemUtils.IS_OS_MAC || SystemUtils.IS_OS_WINDOWS) {
 			return values();
 		} else {
 			return new UiTheme[]{LIGHT, DARK};

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -25,8 +25,8 @@
 
 		<!-- cryptomator dependencies -->
 		<cryptomator.cryptofs.version>1.9.14</cryptomator.cryptofs.version>
-		<cryptomator.integrations.version>0.1.6</cryptomator.integrations.version>
-		<cryptomator.integrations.win.version>0.2.1</cryptomator.integrations.win.version>
+		<cryptomator.integrations.version>1.0.0-beta2</cryptomator.integrations.version>
+		<cryptomator.integrations.win.version>1.0.0-beta2</cryptomator.integrations.win.version>
 		<cryptomator.integrations.mac.version>0.1.0</cryptomator.integrations.mac.version>
 		<cryptomator.integrations.linux.version>0.1.1</cryptomator.integrations.linux.version>
 		<cryptomator.fuse.version>1.2.9</cryptomator.fuse.version>

--- a/main/ui/src/main/java/org/cryptomator/ui/fxapp/FxApplication.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/fxapp/FxApplication.java
@@ -137,13 +137,13 @@ public class FxApplication extends Application {
 	}
 
 	private void appThemeChanged(@SuppressWarnings("unused") ObservableValue<? extends UiTheme> observable, @SuppressWarnings("unused") UiTheme oldValue, UiTheme newValue) {
-		appearanceProvider.ifPresent(appearanceProvider -> {
+		if (appearanceProvider.isPresent() && oldValue == UiTheme.AUTOMATIC && newValue != UiTheme.AUTOMATIC) {
 			try {
-				appearanceProvider.removeListener(systemInterfaceThemeListener);
+				appearanceProvider.get().removeListener(systemInterfaceThemeListener);
 			} catch (UiAppearanceException e) {
 				LOG.error("Failed to disable automatic theme switching.");
 			}
-		});
+		}
 		loadSelectedStyleSheet(newValue);
 	}
 


### PR DESCRIPTION
Closes #1291 .

The change in a17b416262b9124b5bc7c286203730414097ea18  is due to the fact, that the application always removed a ui appearance listener, even when none was registered. The integrations-api states implicitly that if doing so, the behaviour is undefined.