### PR TITLE
Rename Donation Key to Supporter Certificate

### DIFF
--- a/main/ui/src/main/java/org/cryptomator/ui/mainwindow/MainWindowTitleController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/mainwindow/MainWindowTitleController.java
@@ -95,7 +95,7 @@ public class MainWindowTitleController implements FxController {
 
 	@FXML
 	public void showDonationKeyPreferences() {
-		application.showPreferencesWindow(SelectedPreferencesTab.DONATION_KEY);
+		application.showPreferencesWindow(SelectedPreferencesTab.CONTRIBUTE);
 	}
 
 	/* Getter/Setter */

--- a/main/ui/src/main/java/org/cryptomator/ui/preferences/GeneralPreferencesController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/preferences/GeneralPreferencesController.java
@@ -158,7 +158,7 @@ public class GeneralPreferencesController implements FxController {
 
 	@FXML
 	public void showDonationTab() {
-		selectedTabProperty.set(SelectedPreferencesTab.DONATION_KEY);
+		selectedTabProperty.set(SelectedPreferencesTab.CONTRIBUTE);
 	}
 
 	@FXML

--- a/main/ui/src/main/java/org/cryptomator/ui/preferences/GeneralPreferencesController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/preferences/GeneralPreferencesController.java
@@ -157,7 +157,7 @@ public class GeneralPreferencesController implements FxController {
 
 
 	@FXML
-	public void showDonationTab() {
+	public void showContributeTab() {
 		selectedTabProperty.set(SelectedPreferencesTab.CONTRIBUTE);
 	}
 

--- a/main/ui/src/main/java/org/cryptomator/ui/preferences/PreferencesController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/preferences/PreferencesController.java
@@ -26,7 +26,7 @@ public class PreferencesController implements FxController {
 	public Tab generalTab;
 	public Tab volumeTab;
 	public Tab updatesTab;
-	public Tab donationKeyTab;
+	public Tab contributeTab;
 	public Tab aboutTab;
 
 	@Inject
@@ -52,7 +52,7 @@ public class PreferencesController implements FxController {
 		return switch (selectedTab) {
 			case UPDATES -> updatesTab;
 			case VOLUME -> volumeTab;
-			case DONATION_KEY -> donationKeyTab;
+			case CONTRIBUTE -> contributeTab;
 			case GENERAL -> generalTab;
 			case ABOUT -> aboutTab;
 			case ANY -> updateAvailable.get() ? updatesTab : generalTab;

--- a/main/ui/src/main/java/org/cryptomator/ui/preferences/PreferencesModule.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/preferences/PreferencesModule.java
@@ -77,8 +77,8 @@ abstract class PreferencesModule {
 
 	@Binds
 	@IntoMap
-	@FxControllerKey(DonationKeyPreferencesController.class)
-	abstract FxController bindDonationKeyPreferencesController(DonationKeyPreferencesController controller);
+	@FxControllerKey(SupporterCertificateController.class)
+	abstract FxController bindSupporterCertificatePreferencesController(SupporterCertificateController controller);
 
 	@Binds
 	@IntoMap

--- a/main/ui/src/main/java/org/cryptomator/ui/preferences/SelectedPreferencesTab.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/preferences/SelectedPreferencesTab.java
@@ -22,9 +22,9 @@ public enum SelectedPreferencesTab {
 	UPDATES,
 
 	/**
-	 * Show donation key tab
+	 * Show contribute tab
 	 */
-	DONATION_KEY,
+	CONTRIBUTE,
 
 	/**
 	 * Show about tab

--- a/main/ui/src/main/java/org/cryptomator/ui/preferences/SupporterCertificateController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/preferences/SupporterCertificateController.java
@@ -14,17 +14,17 @@ import javafx.scene.control.TextArea;
 import javafx.scene.control.TextFormatter;
 
 @PreferencesScoped
-public class DonationKeyPreferencesController implements FxController {
+public class SupporterCertificateController implements FxController {
 
-	private static final String DONATION_URI = "https://store.cryptomator.org/desktop";
+	private static final String SUPPORTER_URI = "https://store.cryptomator.org/desktop";
 
 	private final Application application;
 	private final LicenseHolder licenseHolder;
 	private final Settings settings;
-	public TextArea donationKeyField;
+	public TextArea supporterCertificateField;
 
 	@Inject
-	DonationKeyPreferencesController(Application application, LicenseHolder licenseHolder, Settings settings) {
+	SupporterCertificateController(Application application, LicenseHolder licenseHolder, Settings settings) {
 		this.application = application;
 		this.licenseHolder = licenseHolder;
 		this.settings = settings;
@@ -32,9 +32,9 @@ public class DonationKeyPreferencesController implements FxController {
 
 	@FXML
 	public void initialize() {
-		donationKeyField.setText(licenseHolder.getLicenseKey().orElse(null));
-		donationKeyField.textProperty().addListener(this::registrationKeyChanged);
-		donationKeyField.setTextFormatter(new TextFormatter<>(this::checkVaultNameLength));
+		supporterCertificateField.setText(licenseHolder.getLicenseKey().orElse(null));
+		supporterCertificateField.textProperty().addListener(this::registrationKeyChanged);
+		supporterCertificateField.setTextFormatter(new TextFormatter<>(this::checkVaultNameLength));
 	}
 
 	private TextFormatter.Change checkVaultNameLength(TextFormatter.Change change) {
@@ -53,8 +53,8 @@ public class DonationKeyPreferencesController implements FxController {
 	}
 
 	@FXML
-	public void getDonationKey() {
-		application.getHostServices().showDocument(DONATION_URI);
+	public void getSupporterCertificate() {
+		application.getHostServices().showDocument(SUPPORTER_URI);
 	}
 
 	public LicenseHolder getLicenseHolder() {

--- a/main/ui/src/main/resources/fxml/preferences.fxml
+++ b/main/ui/src/main/resources/fxml/preferences.fxml
@@ -38,7 +38,7 @@
 				<fx:include source="/fxml/preferences_updates.fxml"/>
 			</content>
 		</Tab>
-		<Tab fx:id="contributeTab" id="CONTRIBUTE" text="%preferences.contribution">
+		<Tab fx:id="contributeTab" id="CONTRIBUTE" text="%preferences.contribute">
 			<graphic>
 				<FontAwesome5IconView glyph="HEART"/>
 			</graphic>

--- a/main/ui/src/main/resources/fxml/preferences.fxml
+++ b/main/ui/src/main/resources/fxml/preferences.fxml
@@ -38,12 +38,12 @@
 				<fx:include source="/fxml/preferences_updates.fxml"/>
 			</content>
 		</Tab>
-		<Tab fx:id="donationKeyTab" id="DONATION_KEY" text="%preferences.donationKey">
+		<Tab fx:id="contributeTab" id="CONTRIBUTE" text="%preferences.contribution">
 			<graphic>
 				<FontAwesome5IconView glyph="HEART"/>
 			</graphic>
 			<content>
-				<fx:include source="/fxml/preferences_donationkey.fxml"/>
+				<fx:include source="/fxml/preferences_contribute.fxml"/>
 			</content>
 		</Tab>
 		<Tab fx:id="aboutTab" id="ABOUT" text="%preferences.about">

--- a/main/ui/src/main/resources/fxml/preferences_contribute.fxml
+++ b/main/ui/src/main/resources/fxml/preferences_contribute.fxml
@@ -24,7 +24,7 @@
 					<Circle styleClass="glyph-icon-primary" radius="24"/>
 					<FontAwesome5IconView styleClass="glyph-icon-white" glyph="CROWN" glyphSize="24"/>
 				</StackPane>
-				<FormattedLabel format="%preferences.contribution.registeredFor" arg1="${controller.licenseHolder.licenseSubject}" wrapText="true"/>
+				<FormattedLabel format="%preferences.contribute.registeredFor" arg1="${controller.licenseHolder.licenseSubject}" wrapText="true"/>
 			</HBox>
 
 			<HBox spacing="12" alignment="CENTER_LEFT" visible="${!controller.licenseHolder.validLicense}">
@@ -33,8 +33,8 @@
 					<FontAwesome5IconView styleClass="glyph-icon-white" glyph="HAND_HOLDING_HEART" glyphSize="24"/>
 				</StackPane>
 				<VBox HBox.hgrow="ALWAYS" spacing="6">
-					<Label text="%preferences.contribution.noCertificate" wrapText="true" VBox.vgrow="ALWAYS"/>
-					<Hyperlink text="%preferences.contribution.getCertificate" onAction="#getSupporterCertificate" contentDisplay="LEFT">
+					<Label text="%preferences.contribute.noCertificate" wrapText="true" VBox.vgrow="ALWAYS"/>
+					<Hyperlink text="%preferences.contribute.getCertificate" onAction="#getSupporterCertificate" contentDisplay="LEFT">
 						<graphic>
 							<FontAwesome5IconView glyph="LINK"/>
 						</graphic>
@@ -43,6 +43,6 @@
 			</HBox>
 		</StackPane>
 
-		<TextArea fx:id="supporterCertificateField" wrapText="true" VBox.vgrow="ALWAYS" prefRowCount="6"/>
+		<TextArea fx:id="supporterCertificateField" promptText="%preferences.contribute.promptText" wrapText="true" VBox.vgrow="ALWAYS" prefRowCount="6"/>
 	</children>
 </VBox>

--- a/main/ui/src/main/resources/fxml/preferences_contribute.fxml
+++ b/main/ui/src/main/resources/fxml/preferences_contribute.fxml
@@ -24,7 +24,7 @@
 					<Circle styleClass="glyph-icon-primary" radius="24"/>
 					<FontAwesome5IconView styleClass="glyph-icon-white" glyph="CROWN" glyphSize="24"/>
 				</StackPane>
-				<FormattedLabel format="%preferences.donationKey.registeredFor" arg1="${controller.licenseHolder.licenseSubject}" wrapText="true"/>
+				<FormattedLabel format="%preferences.contribution.registeredFor" arg1="${controller.licenseHolder.licenseSubject}" wrapText="true"/>
 			</HBox>
 
 			<HBox spacing="12" alignment="CENTER_LEFT" visible="${!controller.licenseHolder.validLicense}">
@@ -33,8 +33,8 @@
 					<FontAwesome5IconView styleClass="glyph-icon-white" glyph="HAND_HOLDING_HEART" glyphSize="24"/>
 				</StackPane>
 				<VBox HBox.hgrow="ALWAYS" spacing="6">
-					<Label text="%preferences.donationKey.noDonationKey" wrapText="true" VBox.vgrow="ALWAYS"/>
-					<Hyperlink text="%preferences.donationKey.getDonationKey" onAction="#getDonationKey" contentDisplay="LEFT">
+					<Label text="%preferences.contribution.noCertificate" wrapText="true" VBox.vgrow="ALWAYS"/>
+					<Hyperlink text="%preferences.contribution.getCertificate" onAction="#getDonationKey" contentDisplay="LEFT">
 						<graphic>
 							<FontAwesome5IconView glyph="LINK"/>
 						</graphic>

--- a/main/ui/src/main/resources/fxml/preferences_contribute.fxml
+++ b/main/ui/src/main/resources/fxml/preferences_contribute.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.shape.Circle?>
 <VBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
-	  fx:controller="org.cryptomator.ui.preferences.DonationKeyPreferencesController"
+	  fx:controller="org.cryptomator.ui.preferences.SupporterCertificateController"
 	  spacing="18">
 	<padding>
 		<Insets topRightBottomLeft="12"/>
@@ -34,7 +34,7 @@
 				</StackPane>
 				<VBox HBox.hgrow="ALWAYS" spacing="6">
 					<Label text="%preferences.contribution.noCertificate" wrapText="true" VBox.vgrow="ALWAYS"/>
-					<Hyperlink text="%preferences.contribution.getCertificate" onAction="#getDonationKey" contentDisplay="LEFT">
+					<Hyperlink text="%preferences.contribution.getCertificate" onAction="#getSupporterCertificate" contentDisplay="LEFT">
 						<graphic>
 							<FontAwesome5IconView glyph="LINK"/>
 						</graphic>
@@ -43,6 +43,6 @@
 			</HBox>
 		</StackPane>
 
-		<TextArea fx:id="donationKeyField" wrapText="true" VBox.vgrow="ALWAYS" prefRowCount="6"/>
+		<TextArea fx:id="supporterCertificateField" wrapText="true" VBox.vgrow="ALWAYS" prefRowCount="6"/>
 	</children>
 </VBox>

--- a/main/ui/src/main/resources/fxml/preferences_general.fxml
+++ b/main/ui/src/main/resources/fxml/preferences_general.fxml
@@ -23,7 +23,7 @@
 		<HBox spacing="6" alignment="CENTER_LEFT">
 			<Label text="%preferences.general.theme"/>
 			<ChoiceBox fx:id="themeChoiceBox" disable="${!controller.licenseHolder.validLicense}"/>
-			<Hyperlink styleClass="hyperlink-underline,hyperlink-muted" text="%preferences.general.unlockThemes" onAction="#showDonationTab" visible="${!controller.licenseHolder.validLicense}" managed="${!controller.licenseHolder.validLicense}"/>
+			<Hyperlink styleClass="hyperlink-underline,hyperlink-muted" text="%preferences.general.unlockThemes" onAction="#showContributeTab" visible="${!controller.licenseHolder.validLicense}" managed="${!controller.licenseHolder.validLicense}"/>
 		</HBox>
 
 		<HBox spacing="6" alignment="CENTER_LEFT">

--- a/main/ui/src/main/resources/i18n/strings.properties
+++ b/main/ui/src/main/resources/i18n/strings.properties
@@ -176,10 +176,11 @@ preferences.updates.autoUpdateCheck=Check for updates automatically
 preferences.updates.checkNowBtn=Check Now
 preferences.updates.updateAvailable=Update to version %s available.
 ## Contribution
-preferences.contribution=Support Us
-preferences.contribution.registeredFor=Registered for %s
-preferences.contribution.noCertificate=No valid supporter certificate found. It's like a license key but for awesome people using free software. ;-)
-preferences.contribution.getCertificate=Don't have one already? Learn how you can obtain it.
+preferences.contribute=Support Us
+preferences.contribute.registeredFor=Supporter certificate registered for %s
+preferences.contribute.noCertificate=Support Cryptomator and recieve a supporter certificate. It's like a license key but for awesome people using free software. ;-)
+preferences.contribute.getCertificate=Don't have one already? Learn how you can obtain it.
+preferences.contribute.promptText=Paste supporter certificate code here
 #<-- Add entries for donations and code/translation/documentation contribution -->
 
 ## About

--- a/main/ui/src/main/resources/i18n/strings.properties
+++ b/main/ui/src/main/resources/i18n/strings.properties
@@ -176,10 +176,10 @@ preferences.updates.autoUpdateCheck=Check for updates automatically
 preferences.updates.checkNowBtn=Check Now
 preferences.updates.updateAvailable=Update to version %s available.
 ## Contribution
-preferences.contribution=Contribution
+preferences.contribution=Contribute
 preferences.contribution.registeredFor=Registered for %s
 preferences.contribution.noCertificate=No valid supporter certificate found. It's like a license key but for awesome people using free software. ;-)
-preferences.contribution.getCertificate=Get a supporter certificate
+preferences.contribution.getCertificate=Don't have already one? Learn how you can obtain it.
 #<-- Add entries for donations and code/translation/documentation contribution -->
 
 ## About

--- a/main/ui/src/main/resources/i18n/strings.properties
+++ b/main/ui/src/main/resources/i18n/strings.properties
@@ -179,7 +179,7 @@ preferences.updates.updateAvailable=Update to version %s available.
 preferences.contribution=Support Us
 preferences.contribution.registeredFor=Registered for %s
 preferences.contribution.noCertificate=No valid supporter certificate found. It's like a license key but for awesome people using free software. ;-)
-preferences.contribution.getCertificate=Don't have already one? Learn how you can obtain it.
+preferences.contribution.getCertificate=Don't have one already? Learn how you can obtain it.
 #<-- Add entries for donations and code/translation/documentation contribution -->
 
 ## About

--- a/main/ui/src/main/resources/i18n/strings.properties
+++ b/main/ui/src/main/resources/i18n/strings.properties
@@ -176,7 +176,7 @@ preferences.updates.autoUpdateCheck=Check for updates automatically
 preferences.updates.checkNowBtn=Check Now
 preferences.updates.updateAvailable=Update to version %s available.
 ## Contribution
-preferences.contribution=Contribute
+preferences.contribution=Support us
 preferences.contribution.registeredFor=Registered for %s
 preferences.contribution.noCertificate=No valid supporter certificate found. It's like a license key but for awesome people using free software. ;-)
 preferences.contribution.getCertificate=Don't have already one? Learn how you can obtain it.

--- a/main/ui/src/main/resources/i18n/strings.properties
+++ b/main/ui/src/main/resources/i18n/strings.properties
@@ -175,11 +175,13 @@ preferences.updates.currentVersion=Current Version: %s
 preferences.updates.autoUpdateCheck=Check for updates automatically
 preferences.updates.checkNowBtn=Check Now
 preferences.updates.updateAvailable=Update to version %s available.
-## Donation Key
-preferences.donationKey=Donation
-preferences.donationKey.registeredFor=Registered for %s
-preferences.donationKey.noDonationKey=No valid donation key found. It's like a license key but for awesome people using free software. ;-)
-preferences.donationKey.getDonationKey=Get a donation key
+## Contribution
+preferences.contribution=Contribution
+preferences.contribution.registeredFor=Registered for %s
+preferences.contribution.noCertificate=No valid supporter certificate found. It's like a license key but for awesome people using free software. ;-)
+preferences.contribution.getCertificate=Get a supporter certificate
+#<-- Add entries for donations and code/translation/documentation contribution -->
+
 ## About
 preferences.about=About
 

--- a/main/ui/src/main/resources/i18n/strings.properties
+++ b/main/ui/src/main/resources/i18n/strings.properties
@@ -178,7 +178,7 @@ preferences.updates.updateAvailable=Update to version %s available.
 ## Contribution
 preferences.contribute=Support Us
 preferences.contribute.registeredFor=Supporter certificate registered for %s
-preferences.contribute.noCertificate=Support Cryptomator and recieve a supporter certificate. It's like a license key but for awesome people using free software. ;-)
+preferences.contribute.noCertificate=Support Cryptomator and receive a supporter certificate. It's like a license key but for awesome people using free software. ;-)
 preferences.contribute.getCertificate=Don't have one already? Learn how you can obtain it.
 preferences.contribute.promptText=Paste supporter certificate code here
 #<-- Add entries for donations and code/translation/documentation contribution -->

--- a/main/ui/src/main/resources/i18n/strings.properties
+++ b/main/ui/src/main/resources/i18n/strings.properties
@@ -176,7 +176,7 @@ preferences.updates.autoUpdateCheck=Check for updates automatically
 preferences.updates.checkNowBtn=Check Now
 preferences.updates.updateAvailable=Update to version %s available.
 ## Contribution
-preferences.contribution=Support us
+preferences.contribution=Support Us
 preferences.contribution.registeredFor=Registered for %s
 preferences.contribution.noCertificate=No valid supporter certificate found. It's like a license key but for awesome people using free software. ;-)
 preferences.contribution.getCertificate=Don't have already one? Learn how you can obtain it.


### PR DESCRIPTION
This PR contains the migration from the term "donation key" to "supporter certificate".

![grafik](https://user-images.githubusercontent.com/9036915/114520764-0de7c600-9c42-11eb-915b-14a2f29d164b.png)
