### PR TITLE
Feature/#1508 observable mounts

### DIFF
--- a/main/commons/src/main/java/org/cryptomator/common/vaults/DokanyVolume.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/DokanyVolume.java
@@ -13,6 +13,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
 
 public class DokanyVolume extends AbstractVolume {
@@ -39,7 +41,7 @@ public class DokanyVolume extends AbstractVolume {
 	}
 
 	@Override
-	public void mount(CryptoFileSystem fs, String mountFlags) throws InvalidMountPointException, VolumeException {
+	public CompletionStage<Void> mount(CryptoFileSystem fs, String mountFlags) throws InvalidMountPointException, VolumeException {
 		this.mountPoint = determineMountPoint();
 		try {
 			this.mount = mountFactory.mount(fs.getPath("/"), mountPoint, vaultSettings.mountName().get(), FS_TYPE_NAME, mountFlags.strip());
@@ -49,6 +51,7 @@ public class DokanyVolume extends AbstractVolume {
 			}
 			throw new VolumeException("Unable to mount Filesystem", e);
 		}
+		return CompletableFuture.failedFuture(new IllegalStateException("THOU SHOULD NOT PASS")); //FIXME
 	}
 
 	@Override

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/DokanyVolume.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/DokanyVolume.java
@@ -13,9 +13,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
 public class DokanyVolume extends AbstractVolume {

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/FuseVolume.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/FuseVolume.java
@@ -20,6 +20,8 @@ import javax.inject.Named;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.regex.Pattern;
 
 public class FuseVolume extends AbstractVolume {
@@ -35,10 +37,11 @@ public class FuseVolume extends AbstractVolume {
 	}
 
 	@Override
-	public void mount(CryptoFileSystem fs, String mountFlags) throws InvalidMountPointException, VolumeException {
+	public CompletionStage<Void> mount(CryptoFileSystem fs, String mountFlags) throws InvalidMountPointException, VolumeException {
 		this.mountPoint = determineMountPoint();
 
 		mount(fs.getPath("/"), mountFlags);
+		return CompletableFuture.failedFuture(new IllegalStateException("THOU SHOULD NOT PASS")); //FIXME
 	}
 
 	private void mount(Path root, String mountFlags) throws VolumeException {

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/LockNotCompletedException.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/LockNotCompletedException.java
@@ -1,0 +1,12 @@
+package org.cryptomator.common.vaults;
+
+public class LockNotCompletedException extends Exception {
+
+	public LockNotCompletedException(String reason) {
+		super(reason);
+	}
+
+	public LockNotCompletedException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/Vault.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/Vault.java
@@ -42,7 +42,6 @@ import java.util.EnumSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.cryptomator.common.Constants.MASTERKEY_FILENAME;
@@ -140,13 +139,12 @@ public class Vault {
 			cryptoFileSystem.set(fs);
 			try {
 				volume = volumeProvider.get();
-				volume.mount(fs, getEffectiveMountFlags()).handle((voit, throwable) -> {
+				volume.mount(fs, getEffectiveMountFlags(), throwable -> {
 					destroyCryptoFileSystem();
 					setState(VaultState.LOCKED); //TODO: possible race conditions of the vault state. Use Platform.runLater()?
 					if (throwable != null) {
 						LOG.warn("Unexpected unmount and lock of vault" + getDisplayName(), throwable);
 					}
-					return CompletableFuture.completedFuture(null);
 				});
 			} catch (Exception e) {
 				destroyCryptoFileSystem();

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/Vault.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/Vault.java
@@ -44,9 +44,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
 import static org.cryptomator.common.Constants.MASTERKEY_FILENAME;
 
@@ -74,8 +71,6 @@ public class Vault {
 	private final StringBinding accessPoint;
 	private final BooleanBinding accessPointPresent;
 	private final BooleanProperty showingStats;
-	private final Lock lock = new ReentrantLock(); //FIXME: naming
-	private final Condition isLocked = lock.newCondition(); //FIXME: improve naming
 
 	private volatile Volume volume;
 
@@ -152,13 +147,6 @@ public class Vault {
 					if (throwable != null) {
 						LOG.warn("Unexpected unmount and lock of vault " + getDisplayName(), throwable);
 					}
-					lock.lock();
-					try {
-						isLocked.signal();
-					} finally {
-						lock.unlock();
-					}
-
 				});
 			} catch (Exception e) {
 				destroyCryptoFileSystem();
@@ -176,20 +164,15 @@ public class Vault {
 			volume.unmount();
 		}
 		destroyCryptoFileSystem();
-		lock.lock();
 		try {
-			while (state.get() != VaultState.Value.LOCKED) {
-				if (!isLocked.await(3000, TimeUnit.MILLISECONDS)) {
-					throw new VolumeException("Locking failed"); //FIXME: other exception
-				}
+			boolean locked = state.awaitState(VaultState.Value.LOCKED, 3000, TimeUnit.MILLISECONDS);
+			if (!locked) {
+				throw new VolumeException("Locking failed"); //FIXME: other exception
 			}
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
 			throw new VolumeException("Lock failed."); //FIXME: other/new exception
-		} finally {
-			lock.unlock();
 		}
-
 	}
 
 	public void reveal(Volume.Revealer vaultRevealer) throws VolumeException {

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/VaultComponent.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/VaultComponent.java
@@ -26,7 +26,7 @@ public interface VaultComponent {
 		Builder vaultSettings(VaultSettings vaultSettings);
 
 		@BindsInstance
-		Builder initialVaultState(VaultState vaultState);
+		Builder initialVaultState(VaultState.Value vaultState);
 
 		@BindsInstance
 		Builder initialErrorCause(@Nullable @Named("lastKnownException") Exception initialErrorCause);

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/VaultListManager.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/VaultListManager.java
@@ -93,45 +93,43 @@ public class VaultListManager {
 	private Vault create(VaultSettings vaultSettings) {
 		VaultComponent.Builder compBuilder = vaultComponentBuilder.vaultSettings(vaultSettings);
 		try {
-			VaultState vaultState = determineVaultState(vaultSettings.path().get());
+			VaultState.Value vaultState = determineVaultState(vaultSettings.path().get());
 			compBuilder.initialVaultState(vaultState);
 		} catch (IOException e) {
 			LOG.warn("Failed to determine vault state for " + vaultSettings.path().get(), e);
-			compBuilder.initialVaultState(VaultState.ERROR);
+			compBuilder.initialVaultState(VaultState.Value.ERROR);
 			compBuilder.initialErrorCause(e);
 		}
 		return compBuilder.build().vault();
 	}
 
-	public static VaultState redetermineVaultState(Vault vault) {
-		VaultState previousState = vault.getState();
+	public static VaultState.Value redetermineVaultState(Vault vault) {
+		VaultState state = vault.stateProperty();
+		VaultState.Value previousState = state.getValue();
 		return switch (previousState) {
 			case LOCKED, NEEDS_MIGRATION, MISSING -> {
-				long stamp = vault.lockVaultState();
 				try {
-					VaultState determinedState = determineVaultState(vault.getPath());
-					vault.setState(determinedState, stamp);
+					VaultState.Value determinedState = determineVaultState(vault.getPath());
+					state.set(determinedState);
 					yield determinedState;
 				} catch (IOException e) {
 					LOG.warn("Failed to determine vault state for " + vault.getPath(), e);
-					vault.setState(VaultState.ERROR, stamp);
+					state.set(VaultState.Value.ERROR);
 					vault.setLastKnownException(e);
-					yield VaultState.ERROR;
-				} finally {
-					vault.unlockVaultState(stamp);
+					yield VaultState.Value.ERROR;
 				}
 			}
 			case ERROR, UNLOCKED, PROCESSING -> previousState;
 		};
 	}
 
-	private static VaultState determineVaultState(Path pathToVault) throws IOException {
+	private static VaultState.Value determineVaultState(Path pathToVault) throws IOException {
 		if (!CryptoFileSystemProvider.containsVault(pathToVault, MASTERKEY_FILENAME)) {
-			return VaultState.MISSING;
+			return VaultState.Value.MISSING;
 		} else if (Migrators.get().needsMigration(pathToVault, MASTERKEY_FILENAME)) {
-			return VaultState.NEEDS_MIGRATION;
+			return VaultState.Value.NEEDS_MIGRATION;
 		} else {
-			return VaultState.LOCKED;
+			return VaultState.Value.LOCKED;
 		}
 	}
 

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/VaultModule.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/VaultModule.java
@@ -41,12 +41,6 @@ public class VaultModule {
 	}
 
 	@Provides
-	@PerVault
-	public ObjectProperty<VaultState> provideVaultState(VaultState initialState) {
-		return new SimpleObjectProperty<>(initialState);
-	}
-
-	@Provides
 	@Named("lastKnownException")
 	@PerVault
 	public ObjectProperty<Exception> provideLastKnownException(@Named("lastKnownException") @Nullable Exception initialErrorCause) {

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/VaultState.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/VaultState.java
@@ -1,34 +1,92 @@
 package org.cryptomator.common.vaults;
 
-public enum VaultState {
-	/**
-	 * No vault found at the provided path
-	 */
-	MISSING,
+import com.google.common.base.Preconditions;
+
+import javax.inject.Inject;
+import javafx.application.Platform;
+import javafx.beans.value.ObservableObjectValue;
+import javafx.beans.value.ObservableValueBase;
+import java.util.concurrent.atomic.AtomicReference;
+
+@PerVault
+public class VaultState extends ObservableValueBase<VaultState.Value> implements ObservableObjectValue<VaultState.Value> {
+
+	public enum Value {
+		/**
+		 * No vault found at the provided path
+		 */
+		MISSING,
+
+		/**
+		 * Vault requires migration to a newer vault format
+		 */
+		NEEDS_MIGRATION,
+
+		/**
+		 * Vault ready to be unlocked
+		 */
+		LOCKED,
+
+		/**
+		 * Vault in transition between two other states
+		 */
+		PROCESSING,
+
+		/**
+		 * Vault is unlocked
+		 */
+		UNLOCKED,
+
+		/**
+		 * Unknown state due to preceeding unrecoverable exceptions.
+		 */
+		ERROR;
+	}
+
+	private final AtomicReference<Value> value;
+
+	@Inject
+	public VaultState(VaultState.Value initialValue){
+		this.value = new AtomicReference<>(initialValue);
+	}
+
+	@Override
+	public Value get() {
+		return getValue();
+	}
+
+	@Override
+	public Value getValue() {
+		return value.get();
+	}
 
 	/**
-	 * Vault requires migration to a newer vault format
+	 * Transitions from <code>fromState</code> to <code>toState</code>.
+	 * @param fromState Previous state
+	 * @param toState New state
+	 * @return <code>true</code> if successful
 	 */
-	NEEDS_MIGRATION,
+	public boolean transition(Value fromState, Value toState) {
+		Preconditions.checkArgument(fromState != toState, "fromState must be different than toState");
+		boolean success = value.compareAndSet(fromState, toState);
+		if (success) {
+			fireValueChangedEvent();
+		}
+		return success;
+	}
 
-	/**
-	 * Vault ready to be unlocked
-	 */
-	LOCKED,
+	public void set(Value newState) {
+		var oldState = value.getAndSet(newState);
+		if (oldState != newState) {
+			fireValueChangedEvent();
+		}
+	}
 
-	/**
-	 * Vault in transition between two other states
-	 */
-	PROCESSING,
-
-	/**
-	 * Vault is unlocked
-	 */
-	UNLOCKED,
-
-	/**
-	 * Unknown state due to preceeding unrecoverable exceptions.
-	 */
-	ERROR;
-
+	protected void fireValueChangedEvent() {
+		if (Platform.isFxApplicationThread()) {
+			super.fireValueChangedEvent();
+		} else {
+			Platform.runLater(super::fireValueChangedEvent);
+		}
+	}
 }

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/VaultState.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/VaultState.java
@@ -107,7 +107,7 @@ public class VaultState extends ObservableValueBase<VaultState.Value> implements
 	public boolean awaitState(Value desiredState, long time, TimeUnit unit) throws InterruptedException {
 		lock.lock();
 		try {
-			long remaining = unit.convert(time, TimeUnit.NANOSECONDS);
+			long remaining = TimeUnit.NANOSECONDS.convert(time, unit);
 			while (value.get() != desiredState) {
 				if (remaining <= 0L) {
 					return false;

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/VaultState.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/VaultState.java
@@ -1,6 +1,8 @@
 package org.cryptomator.common.vaults;
 
 import com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javafx.application.Platform;
@@ -10,6 +12,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 @PerVault
 public class VaultState extends ObservableValueBase<VaultState.Value> implements ObservableObjectValue<VaultState.Value> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(VaultState.class);
 
 	public enum Value {
 		/**
@@ -46,7 +50,7 @@ public class VaultState extends ObservableValueBase<VaultState.Value> implements
 	private final AtomicReference<Value> value;
 
 	@Inject
-	public VaultState(VaultState.Value initialValue){
+	public VaultState(VaultState.Value initialValue) {
 		this.value = new AtomicReference<>(initialValue);
 	}
 
@@ -62,6 +66,7 @@ public class VaultState extends ObservableValueBase<VaultState.Value> implements
 
 	/**
 	 * Transitions from <code>fromState</code> to <code>toState</code>.
+	 *
 	 * @param fromState Previous state
 	 * @param toState New state
 	 * @return <code>true</code> if successful
@@ -71,6 +76,8 @@ public class VaultState extends ObservableValueBase<VaultState.Value> implements
 		boolean success = value.compareAndSet(fromState, toState);
 		if (success) {
 			fireValueChangedEvent();
+		} else {
+			LOG.debug("Failed transiting into state {}: Expected state was {}, but actual state is {}.", fromState, toState, value.get());
 		}
 		return success;
 	}

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/VaultStats.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/VaultStats.java
@@ -52,13 +52,13 @@ public class VaultStats {
 	}
 
 	private void vaultStateChanged(@SuppressWarnings("unused") Observable observable) {
-		if (VaultState.UNLOCKED.equals(state.get())) {
+		if (VaultState.UNLOCKED == state.get()) {
 			assert fs.get() != null;
 			LOG.debug("start recording stats");
-			updateService.restart();
+			Platform.runLater(() -> updateService.restart());
 		} else {
 			LOG.debug("stop recording stats");
-			updateService.cancel();
+			Platform.runLater(() -> updateService.cancel());
 		}
 	}
 

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/VaultStats.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/VaultStats.java
@@ -26,7 +26,7 @@ public class VaultStats {
 	private static final Logger LOG = LoggerFactory.getLogger(VaultStats.class);
 
 	private final AtomicReference<CryptoFileSystem> fs;
-	private final ObjectProperty<VaultState> state;
+	private final VaultState state;
 	private final ScheduledService<Optional<CryptoFileSystemStats>> updateService;
 	private final LongProperty bytesPerSecondRead = new SimpleLongProperty();
 	private final LongProperty bytesPerSecondWritten = new SimpleLongProperty();
@@ -41,7 +41,7 @@ public class VaultStats {
 	private final LongProperty filesWritten = new SimpleLongProperty();
 
 	@Inject
-	VaultStats(AtomicReference<CryptoFileSystem> fs, ObjectProperty<VaultState> state, ExecutorService executor) {
+	VaultStats(AtomicReference<CryptoFileSystem> fs, VaultState state, ExecutorService executor) {
 		this.fs = fs;
 		this.state = state;
 		this.updateService = new UpdateStatsService();
@@ -52,7 +52,7 @@ public class VaultStats {
 	}
 
 	private void vaultStateChanged(@SuppressWarnings("unused") Observable observable) {
-		if (VaultState.UNLOCKED == state.get()) {
+		if (VaultState.Value.UNLOCKED == state.get()) {
 			assert fs.get() != null;
 			LOG.debug("start recording stats");
 			Platform.runLater(() -> updateService.restart());

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/Volume.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/Volume.java
@@ -7,6 +7,7 @@ import org.cryptomator.cryptofs.CryptoFileSystem;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
 
 /**
@@ -32,7 +33,7 @@ public interface Volume {
 	 * @param fs
 	 * @throws IOException
 	 */
-	void mount(CryptoFileSystem fs, String mountFlags) throws IOException, VolumeException, InvalidMountPointException;
+	CompletionStage<Void> mount(CryptoFileSystem fs, String mountFlags) throws IOException, VolumeException, InvalidMountPointException;
 
 	/**
 	 * Reveals the mounted volume.

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/Volume.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/Volume.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 /**
@@ -33,7 +34,7 @@ public interface Volume {
 	 * @param fs
 	 * @throws IOException
 	 */
-	CompletionStage<Void> mount(CryptoFileSystem fs, String mountFlags) throws IOException, VolumeException, InvalidMountPointException;
+	void mount(CryptoFileSystem fs, String mountFlags, Consumer<Throwable> onExitAction) throws IOException, VolumeException, InvalidMountPointException;
 
 	/**
 	 * Reveals the mounted volume.

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/WebDavVolume.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/WebDavVolume.java
@@ -19,6 +19,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 public class WebDavVolume implements Volume {
@@ -43,10 +44,9 @@ public class WebDavVolume implements Volume {
 	}
 
 	@Override
-	public CompletionStage<Void> mount(CryptoFileSystem fs, String mountFlags) throws VolumeException {
+	public void mount(CryptoFileSystem fs, String mountFlags, Consumer<Throwable> onExitAction) throws VolumeException {
 		startServlet(fs);
 		mountServlet();
-		return CompletableFuture.failedFuture(new IllegalStateException("THOU SHOULD NOT PASS")); //FIXME
 	}
 
 	private void startServlet(CryptoFileSystem fs){

--- a/main/commons/src/main/java/org/cryptomator/common/vaults/WebDavVolume.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/WebDavVolume.java
@@ -17,6 +17,8 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
 public class WebDavVolume implements Volume {
@@ -41,9 +43,10 @@ public class WebDavVolume implements Volume {
 	}
 
 	@Override
-	public void mount(CryptoFileSystem fs, String mountFlags) throws VolumeException {
+	public CompletionStage<Void> mount(CryptoFileSystem fs, String mountFlags) throws VolumeException {
 		startServlet(fs);
 		mountServlet();
+		return CompletableFuture.failedFuture(new IllegalStateException("THOU SHOULD NOT PASS")); //FIXME
 	}
 
 	private void startServlet(CryptoFileSystem fs){

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -30,8 +30,8 @@
 		<cryptomator.integrations.win.version>1.0.0-beta2</cryptomator.integrations.win.version>
 		<cryptomator.integrations.mac.version>1.0.0-beta2</cryptomator.integrations.mac.version>
 		<cryptomator.integrations.linux.version>1.0.0-beta1</cryptomator.integrations.linux.version>
-		<cryptomator.fuse.version>1.4.0-SNAPSHOT</cryptomator.fuse.version>
-		<cryptomator.dokany.version>1.3.0-SNAPSHOT</cryptomator.dokany.version>
+		<cryptomator.fuse.version>1.3.1</cryptomator.fuse.version>
+		<cryptomator.dokany.version>1.3.0</cryptomator.dokany.version>
 		<cryptomator.webdav.version>1.2.0</cryptomator.webdav.version>
 
 		<!-- 3rd party dependencies -->

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -30,8 +30,8 @@
 		<cryptomator.integrations.win.version>1.0.0-beta2</cryptomator.integrations.win.version>
 		<cryptomator.integrations.mac.version>1.0.0-beta2</cryptomator.integrations.mac.version>
 		<cryptomator.integrations.linux.version>1.0.0-beta1</cryptomator.integrations.linux.version>
-		<cryptomator.fuse.version>1.3.0</cryptomator.fuse.version>
-		<cryptomator.dokany.version>1.2.4</cryptomator.dokany.version>
+		<cryptomator.fuse.version>1.4.0-SNAPSHOT</cryptomator.fuse.version>
+		<cryptomator.dokany.version>1.3.0-SNAPSHOT</cryptomator.dokany.version>
 		<cryptomator.webdav.version>1.2.0</cryptomator.webdav.version>
 
 		<!-- 3rd party dependencies -->

--- a/main/ui/src/main/java/org/cryptomator/ui/common/VaultService.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/common/VaultService.java
@@ -163,8 +163,6 @@ public class VaultService {
 		private final Vault vault;
 		private final boolean forced;
 
-		private volatile long stamp;
-
 		/**
 		 * @param vault The vault to lock
 		 * @param forced Whether to attempt a forced lock
@@ -178,32 +176,28 @@ public class VaultService {
 
 		@Override
 		protected Vault call() throws Volume.VolumeException {
-			this.stamp = vault.lockVaultState();
 			vault.lock(forced);
 			return vault;
 		}
 
 		@Override
 		protected void scheduled() {
-			vault.setState(VaultState.PROCESSING, stamp);
+			vault.stateProperty().transition(VaultState.Value.UNLOCKED, VaultState.Value.PROCESSING);
 		}
 
 		@Override
 		protected void succeeded() {
-			vault.setState(VaultState.LOCKED, stamp);
-			vault.unlockVaultState(stamp);
+			vault.stateProperty().transition(VaultState.Value.PROCESSING, VaultState.Value.LOCKED);
 		}
 
 		@Override
 		protected void failed() {
-			vault.setState(VaultState.UNLOCKED, stamp);
-			vault.unlockVaultState(stamp);
+			vault.stateProperty().transition(VaultState.Value.PROCESSING, VaultState.Value.UNLOCKED);
 		}
 
 		@Override
 		protected void cancelled() {
-			vault.setState(VaultState.UNLOCKED, stamp);
-			vault.unlockVaultState(stamp);
+			vault.stateProperty().transition(VaultState.Value.PROCESSING, VaultState.Value.UNLOCKED);
 		}
 
 	}

--- a/main/ui/src/main/java/org/cryptomator/ui/common/VaultService.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/common/VaultService.java
@@ -1,5 +1,6 @@
 package org.cryptomator.ui.common;
 
+import org.cryptomator.common.vaults.LockNotCompletedException;
 import org.cryptomator.common.vaults.Vault;
 import org.cryptomator.common.vaults.VaultState;
 import org.cryptomator.common.vaults.Volume;
@@ -175,7 +176,7 @@ public class VaultService {
 		}
 
 		@Override
-		protected Vault call() throws Volume.VolumeException {
+		protected Vault call() throws Volume.VolumeException, LockNotCompletedException {
 			vault.lock(forced);
 			return vault;
 		}

--- a/main/ui/src/main/java/org/cryptomator/ui/fxapp/FxApplication.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/fxapp/FxApplication.java
@@ -44,8 +44,8 @@ public class FxApplication extends Application {
 	private final Lazy<MainWindowComponent> mainWindow;
 	private final Lazy<PreferencesComponent> preferencesWindow;
 	private final Lazy<QuitComponent> quitWindow;
-	private final Provider<UnlockComponent.Builder> unlockWindowBuilderProvider;
-	private final Provider<LockComponent.Builder> lockWindowBuilderProvider;
+	private final Provider<UnlockComponent.Builder> unlockWorkflowBuilderProvider;
+	private final Provider<LockComponent.Builder> lockWorkflowBuilderProvider;
 	private final Optional<TrayIntegrationProvider> trayIntegration;
 	private final Optional<UiAppearanceProvider> appearanceProvider;
 	private final VaultService vaultService;
@@ -55,12 +55,12 @@ public class FxApplication extends Application {
 	private final UiAppearanceListener systemInterfaceThemeListener = this::systemInterfaceThemeChanged;
 
 	@Inject
-	FxApplication(Settings settings, Lazy<MainWindowComponent> mainWindow, Lazy<PreferencesComponent> preferencesWindow, Provider<UnlockComponent.Builder> unlockWindowBuilderProvider, Provider<LockComponent.Builder> lockWindowBuilderProvider, Lazy<QuitComponent> quitWindow, Optional<TrayIntegrationProvider> trayIntegration, Optional<UiAppearanceProvider> appearanceProvider, VaultService vaultService, LicenseHolder licenseHolder) {
+	FxApplication(Settings settings, Lazy<MainWindowComponent> mainWindow, Lazy<PreferencesComponent> preferencesWindow, Provider<UnlockComponent.Builder> unlockWorkflowBuilderProvider, Provider<LockComponent.Builder> lockWorkflowBuilderProvider, Lazy<QuitComponent> quitWindow, Optional<TrayIntegrationProvider> trayIntegration, Optional<UiAppearanceProvider> appearanceProvider, VaultService vaultService, LicenseHolder licenseHolder) {
 		this.settings = settings;
 		this.mainWindow = mainWindow;
 		this.preferencesWindow = preferencesWindow;
-		this.unlockWindowBuilderProvider = unlockWindowBuilderProvider;
-		this.lockWindowBuilderProvider = lockWindowBuilderProvider;
+		this.unlockWorkflowBuilderProvider = unlockWorkflowBuilderProvider;
+		this.lockWorkflowBuilderProvider = lockWorkflowBuilderProvider;
 		this.quitWindow = quitWindow;
 		this.trayIntegration = trayIntegration;
 		this.appearanceProvider = appearanceProvider;
@@ -113,14 +113,14 @@ public class FxApplication extends Application {
 
 	public void startUnlockWorkflow(Vault vault, Optional<Stage> owner) {
 		Platform.runLater(() -> {
-			unlockWindowBuilderProvider.get().vault(vault).owner(owner).build().startUnlockWorkflow();
+			unlockWorkflowBuilderProvider.get().vault(vault).owner(owner).build().startUnlockWorkflow();
 			LOG.debug("Showing UnlockWindow for {}", vault.getDisplayName());
 		});
 	}
 
 	public void startLockWorkflow(Vault vault, Optional<Stage> owner) {
 		Platform.runLater(() -> {
-			lockWindowBuilderProvider.get().vault(vault).owner(owner).build().startLockWorkflow();
+			lockWorkflowBuilderProvider.get().vault(vault).owner(owner).build().startLockWorkflow();
 			LOG.debug("Start lock workflow for {}", vault.getDisplayName());
 		});
 	}

--- a/main/ui/src/main/java/org/cryptomator/ui/fxapp/FxApplication.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/fxapp/FxApplication.java
@@ -5,11 +5,13 @@ import org.cryptomator.common.LicenseHolder;
 import org.cryptomator.common.settings.Settings;
 import org.cryptomator.common.settings.UiTheme;
 import org.cryptomator.common.vaults.Vault;
+import org.cryptomator.common.vaults.VaultState;
 import org.cryptomator.integrations.tray.TrayIntegrationProvider;
 import org.cryptomator.integrations.uiappearance.Theme;
 import org.cryptomator.integrations.uiappearance.UiAppearanceException;
 import org.cryptomator.integrations.uiappearance.UiAppearanceListener;
 import org.cryptomator.integrations.uiappearance.UiAppearanceProvider;
+import org.cryptomator.ui.common.ErrorComponent;
 import org.cryptomator.ui.common.VaultService;
 import org.cryptomator.ui.lock.LockComponent;
 import org.cryptomator.ui.mainwindow.MainWindowComponent;
@@ -46,6 +48,7 @@ public class FxApplication extends Application {
 	private final Lazy<QuitComponent> quitWindow;
 	private final Provider<UnlockComponent.Builder> unlockWorkflowBuilderProvider;
 	private final Provider<LockComponent.Builder> lockWorkflowBuilderProvider;
+	private final ErrorComponent.Builder errorWindowBuilder;
 	private final Optional<TrayIntegrationProvider> trayIntegration;
 	private final Optional<UiAppearanceProvider> appearanceProvider;
 	private final VaultService vaultService;
@@ -55,13 +58,14 @@ public class FxApplication extends Application {
 	private final UiAppearanceListener systemInterfaceThemeListener = this::systemInterfaceThemeChanged;
 
 	@Inject
-	FxApplication(Settings settings, Lazy<MainWindowComponent> mainWindow, Lazy<PreferencesComponent> preferencesWindow, Provider<UnlockComponent.Builder> unlockWorkflowBuilderProvider, Provider<LockComponent.Builder> lockWorkflowBuilderProvider, Lazy<QuitComponent> quitWindow, Optional<TrayIntegrationProvider> trayIntegration, Optional<UiAppearanceProvider> appearanceProvider, VaultService vaultService, LicenseHolder licenseHolder) {
+	FxApplication(Settings settings, Lazy<MainWindowComponent> mainWindow, Lazy<PreferencesComponent> preferencesWindow, Provider<UnlockComponent.Builder> unlockWorkflowBuilderProvider, Provider<LockComponent.Builder> lockWorkflowBuilderProvider, Lazy<QuitComponent> quitWindow, ErrorComponent.Builder errorWindowBuilder, Optional<TrayIntegrationProvider> trayIntegration, Optional<UiAppearanceProvider> appearanceProvider, VaultService vaultService, LicenseHolder licenseHolder) {
 		this.settings = settings;
 		this.mainWindow = mainWindow;
 		this.preferencesWindow = preferencesWindow;
 		this.unlockWorkflowBuilderProvider = unlockWorkflowBuilderProvider;
 		this.lockWorkflowBuilderProvider = lockWorkflowBuilderProvider;
 		this.quitWindow = quitWindow;
+		this.errorWindowBuilder = errorWindowBuilder;
 		this.trayIntegration = trayIntegration;
 		this.appearanceProvider = appearanceProvider;
 		this.vaultService = vaultService;
@@ -113,15 +117,23 @@ public class FxApplication extends Application {
 
 	public void startUnlockWorkflow(Vault vault, Optional<Stage> owner) {
 		Platform.runLater(() -> {
-			unlockWorkflowBuilderProvider.get().vault(vault).owner(owner).build().startUnlockWorkflow();
-			LOG.debug("Showing UnlockWindow for {}", vault.getDisplayName());
+			if (vault.stateProperty().transition(VaultState.Value.LOCKED, VaultState.Value.PROCESSING)) {
+				unlockWorkflowBuilderProvider.get().vault(vault).owner(owner).build().startUnlockWorkflow();
+				LOG.debug("Start unlock workflow for {}", vault.getDisplayName());
+			} else {
+				showMainWindow().thenAccept(mainWindow -> errorWindowBuilder.window(mainWindow).cause(new IllegalStateException("Unable to unlock vault in non-locked state.")));
+			}
 		});
 	}
 
 	public void startLockWorkflow(Vault vault, Optional<Stage> owner) {
 		Platform.runLater(() -> {
-			lockWorkflowBuilderProvider.get().vault(vault).owner(owner).build().startLockWorkflow();
-			LOG.debug("Start lock workflow for {}", vault.getDisplayName());
+			if (vault.stateProperty().transition(VaultState.Value.UNLOCKED, VaultState.Value.PROCESSING)) {
+				lockWorkflowBuilderProvider.get().vault(vault).owner(owner).build().startLockWorkflow();
+				LOG.debug("Start lock workflow for {}", vault.getDisplayName());
+			} else {
+				showMainWindow().thenAccept(mainWindow -> errorWindowBuilder.window(mainWindow).cause(new IllegalStateException("Unable to lock vault in non-unlocked state.")));
+			}
 		});
 	}
 

--- a/main/ui/src/main/java/org/cryptomator/ui/launcher/AppLifecycleListener.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/launcher/AppLifecycleListener.java
@@ -24,11 +24,13 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.cryptomator.common.vaults.VaultState.Value.*;
+
 @Singleton
 public class AppLifecycleListener {
 
 	private static final Logger LOG = LoggerFactory.getLogger(AppLifecycleListener.class);
-	public static final Set<VaultState> STATES_ALLOWING_TERMINATION = EnumSet.of(VaultState.LOCKED, VaultState.NEEDS_MIGRATION, VaultState.MISSING, VaultState.ERROR);
+	public static final Set<VaultState.Value> STATES_ALLOWING_TERMINATION = EnumSet.of(LOCKED, NEEDS_MIGRATION, MISSING, ERROR);
 
 	private final FxApplicationStarter fxApplicationStarter;
 	private final CountDownLatch shutdownLatch;

--- a/main/ui/src/main/java/org/cryptomator/ui/launcher/AppLifecycleListener.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/launcher/AppLifecycleListener.java
@@ -1,6 +1,7 @@
 package org.cryptomator.ui.launcher;
 
 import org.cryptomator.common.ShutdownHook;
+import org.cryptomator.common.vaults.LockNotCompletedException;
 import org.cryptomator.common.vaults.Vault;
 import org.cryptomator.common.vaults.VaultState;
 import org.cryptomator.common.vaults.Volume;
@@ -129,6 +130,8 @@ public class AppLifecycleListener {
 					vault.lock(true);
 				} catch (Volume.VolumeException e) {
 					LOG.error("Failed to unmount vault " + vault.getPath(), e);
+				} catch (LockNotCompletedException e) {
+					LOG.error("Failed to lock vault " + vault.getPath(), e);
 				}
 			}
 		}

--- a/main/ui/src/main/java/org/cryptomator/ui/lock/LockWorkflow.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/lock/LockWorkflow.java
@@ -1,6 +1,7 @@
 package org.cryptomator.ui.lock;
 
 import dagger.Lazy;
+import org.cryptomator.common.vaults.LockNotCompletedException;
 import org.cryptomator.common.vaults.Vault;
 import org.cryptomator.common.vaults.VaultState;
 import org.cryptomator.common.vaults.Volume;
@@ -49,10 +50,10 @@ public class LockWorkflow extends Task<Void> {
 	}
 
 	@Override
-	protected Void call() throws Volume.VolumeException, InterruptedException {
+	protected Void call() throws Volume.VolumeException, InterruptedException, LockNotCompletedException {
 		try {
 			vault.lock(false);
-		} catch (Volume.VolumeException e) {
+		} catch (Volume.VolumeException | LockNotCompletedException e) {
 			LOG.debug("Regular lock of {} failed.", vault.getDisplayName(), e);
 			var decision = askUserForAction();
 			switch (decision) {

--- a/main/ui/src/main/java/org/cryptomator/ui/lock/LockWorkflow.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/lock/LockWorkflow.java
@@ -83,7 +83,7 @@ public class LockWorkflow extends Task<Void> {
 	@Override
 	protected void succeeded() {
 		LOG.info("Lock of {} succeeded.", vault.getDisplayName());
-		//DO NOT SET VAULT STATE HERE, this is done by the vault internally
+		vault.stateProperty().transition(VaultState.Value.PROCESSING, VaultState.Value.LOCKED);
 	}
 
 	@Override

--- a/main/ui/src/main/java/org/cryptomator/ui/mainwindow/VaultDetailController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/mainwindow/VaultDetailController.java
@@ -32,7 +32,8 @@ public class VaultDetailController implements FxController {
 		this.anyVaultSelected = vault.isNotNull();
 	}
 
-	private FontAwesome5Icon getGlyphForVaultState(VaultState state) {
+	// TODO deduplicate w/ VaultListCellController
+	private FontAwesome5Icon getGlyphForVaultState(VaultState.Value state) {
 		if (state != null) {
 			return switch (state) {
 				case LOCKED -> FontAwesome5Icon.LOCK;

--- a/main/ui/src/main/java/org/cryptomator/ui/mainwindow/VaultListCellController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/mainwindow/VaultListCellController.java
@@ -24,7 +24,8 @@ public class VaultListCellController implements FxController {
 				.map(this::getGlyphForVaultState);
 	}
 
-	private FontAwesome5Icon getGlyphForVaultState(VaultState state) {
+	// TODO deduplicate w/ VaultDetailController
+	private FontAwesome5Icon getGlyphForVaultState(VaultState.Value state) {
 		if (state != null) {
 			return switch (state) {
 				case LOCKED -> FontAwesome5Icon.LOCK;

--- a/main/ui/src/main/java/org/cryptomator/ui/mainwindow/VaultListContextMenuController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/mainwindow/VaultListContextMenuController.java
@@ -14,19 +14,13 @@ import org.cryptomator.ui.vaultoptions.VaultOptionsComponent;
 
 import javax.inject.Inject;
 import javafx.beans.binding.Binding;
-import javafx.beans.binding.Bindings;
 import javafx.beans.property.ObjectProperty;
 import javafx.fxml.FXML;
 import javafx.stage.Stage;
-import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Optional;
 
-import static org.cryptomator.common.vaults.VaultState.ERROR;
-import static org.cryptomator.common.vaults.VaultState.LOCKED;
-import static org.cryptomator.common.vaults.VaultState.MISSING;
-import static org.cryptomator.common.vaults.VaultState.NEEDS_MIGRATION;
-import static org.cryptomator.common.vaults.VaultState.UNLOCKED;
+import static org.cryptomator.common.vaults.VaultState.Value.*;
 
 @MainWindowScoped
 public class VaultListContextMenuController implements FxController {
@@ -37,7 +31,7 @@ public class VaultListContextMenuController implements FxController {
 	private final KeychainManager keychain;
 	private final RemoveVaultComponent.Builder removeVault;
 	private final VaultOptionsComponent.Builder vaultOptionsWindow;
-	private final OptionalBinding<VaultState> selectedVaultState;
+	private final OptionalBinding<VaultState.Value> selectedVaultState;
 	private final Binding<Boolean> selectedVaultPassphraseStored;
 	private final Binding<Boolean> selectedVaultRemovable;
 	private final Binding<Boolean> selectedVaultUnlockable;
@@ -57,7 +51,6 @@ public class VaultListContextMenuController implements FxController {
 		this.selectedVaultRemovable = selectedVaultState.map(EnumSet.of(LOCKED, MISSING, ERROR, NEEDS_MIGRATION)::contains).orElse(false);
 		this.selectedVaultUnlockable = selectedVaultState.map(LOCKED::equals).orElse(false);
 		this.selectedVaultLockable = selectedVaultState.map(UNLOCKED::equals).orElse(false);
-
 	}
 
 	private boolean isPasswordStored(Vault vault) {

--- a/main/ui/src/main/java/org/cryptomator/ui/stats/VaultStatisticsModule.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/stats/VaultStatisticsModule.java
@@ -43,8 +43,8 @@ abstract class VaultStatisticsModule {
 		var weakStage = new WeakReference<>(stage);
 		vault.stateProperty().addListener(new ChangeListener<>() {
 			@Override
-			public void changed(ObservableValue<? extends VaultState> observable, VaultState oldValue, VaultState newValue) {
-				if (newValue != VaultState.UNLOCKED) {
+			public void changed(ObservableValue<? extends VaultState.Value> observable, VaultState.Value oldValue, VaultState.Value newValue) {
+				if (newValue != VaultState.Value.UNLOCKED) {
 					Stage stage = weakStage.get();
 					if (stage != null) {
 						stage.hide();

--- a/main/ui/src/main/java/org/cryptomator/ui/unlock/UnlockWorkflow.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/unlock/UnlockWorkflow.java
@@ -59,6 +59,8 @@ public class UnlockWorkflow extends Task<Boolean> {
 	private final Lazy<Scene> invalidMountPointScene;
 	private final ErrorComponent.Builder errorComponent;
 
+	private volatile long stamp;
+
 	@Inject
 	UnlockWorkflow(@UnlockWindow Stage window, @UnlockWindow Vault vault, VaultService vaultService, AtomicReference<char[]> password, @Named("savePassword") AtomicBoolean savePassword, @Named("savedPassword") Optional<char[]> savedPassword, UserInteractionLock<PasswordEntry> passwordEntryLock, KeychainManager keychain, @FxmlScene(FxmlFile.UNLOCK) Lazy<Scene> unlockScene, @FxmlScene(FxmlFile.UNLOCK_SUCCESS) Lazy<Scene> successScene, @FxmlScene(FxmlFile.UNLOCK_INVALID_MOUNT_POINT) Lazy<Scene> invalidMountPointScene, ErrorComponent.Builder errorComponent) {
 		this.window = window;
@@ -87,6 +89,7 @@ public class UnlockWorkflow extends Task<Boolean> {
 	@Override
 	protected Boolean call() throws InterruptedException, IOException, VolumeException, InvalidMountPointException {
 		try {
+			this.stamp = vault.lockVaultState();
 			if (attemptUnlock()) {
 				handleSuccess();
 				return true;
@@ -207,22 +210,25 @@ public class UnlockWorkflow extends Task<Boolean> {
 
 	@Override
 	protected void scheduled() {
-		vault.setState(VaultState.PROCESSING);
+		vault.setState(VaultState.PROCESSING, stamp);
 	}
 
 	@Override
 	protected void succeeded() {
-		vault.setState(VaultState.UNLOCKED);
+		vault.setState(VaultState.UNLOCKED, stamp);
+		vault.unlockVaultState(stamp);
 	}
 
 	@Override
 	protected void failed() {
-		vault.setState(VaultState.LOCKED);
+		vault.setState(VaultState.LOCKED, stamp);
+		vault.unlockVaultState(stamp);
 	}
 
 	@Override
 	protected void cancelled() {
-		vault.setState(VaultState.LOCKED);
+		vault.setState(VaultState.LOCKED, stamp);
+		vault.unlockVaultState(stamp);
 	}
 
 }

--- a/main/ui/src/main/java/org/cryptomator/ui/unlock/UnlockWorkflow.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/unlock/UnlockWorkflow.java
@@ -73,22 +73,15 @@ public class UnlockWorkflow extends Task<Boolean> {
 		this.successScene = successScene;
 		this.invalidMountPointScene = invalidMountPointScene;
 		this.errorComponent = errorComponent;
-
-		setOnFailed(event -> {
-			Throwable throwable = event.getSource().getException();
-			if (throwable instanceof InvalidMountPointException e) {
-				handleInvalidMountPoint(e);
-			} else {
-				handleGenericError(throwable);
-			}
-		});
 	}
 
 	@Override
 	protected Boolean call() throws InterruptedException, IOException, VolumeException, InvalidMountPointException {
 		try {
 			if (attemptUnlock()) {
-				handleSuccess();
+				if (savePassword.get()) {
+					savePasswordToSystemkeychain(); //savePassword will be wiped on method return, so it must be set here
+				}
 				return true;
 			} else {
 				cancel(false); // set Tasks state to cancelled
@@ -129,24 +122,6 @@ public class UnlockWorkflow extends Task<Boolean> {
 			}
 		});
 		return passwordEntryLock.awaitInteraction();
-	}
-
-	private void handleSuccess() {
-		LOG.info("Unlock of '{}' succeeded.", vault.getDisplayName());
-		if (savePassword.get()) {
-			savePasswordToSystemkeychain();
-		}
-		switch (vault.getVaultSettings().actionAfterUnlock().get()) {
-			case ASK -> Platform.runLater(() -> {
-				window.setScene(successScene.get());
-				window.show();
-			});
-			case REVEAL -> {
-				Platform.runLater(window::close);
-				vaultService.reveal(vault);
-			}
-			case IGNORE -> Platform.runLater(window::close);
-		}
 	}
 
 	private void savePasswordToSystemkeychain() {
@@ -193,7 +168,7 @@ public class UnlockWorkflow extends Task<Boolean> {
 
 	private void handleGenericError(Throwable e) {
 		LOG.error("Unlock failed for technical reasons.", e);
-		errorComponent.cause(e).window(window).returnToScene(window.getScene()).build().showErrorScene();
+		errorComponent.cause(e).window(window).build().showErrorScene();
 	}
 
 	private void wipePassword(char[] pw) {
@@ -203,22 +178,39 @@ public class UnlockWorkflow extends Task<Boolean> {
 	}
 
 	@Override
-	protected void scheduled() {
-		vault.stateProperty().transition(VaultState.Value.LOCKED, VaultState.Value.PROCESSING);
-	}
-
-	@Override
 	protected void succeeded() {
+		LOG.info("Unlock of '{}' succeeded.", vault.getDisplayName());
+
+		switch (vault.getVaultSettings().actionAfterUnlock().get()) {
+			case ASK -> Platform.runLater(() -> {
+				window.setScene(successScene.get());
+				window.show();
+			});
+			case REVEAL -> {
+				Platform.runLater(window::close);
+				vaultService.reveal(vault);
+			}
+			case IGNORE -> Platform.runLater(window::close);
+		}
+
 		vault.stateProperty().transition(VaultState.Value.PROCESSING, VaultState.Value.UNLOCKED);
 	}
 
 	@Override
 	protected void failed() {
+		LOG.info("Unlock of '{}' failed.", vault.getDisplayName());
+		Throwable throwable = super.getException();
+		if (throwable instanceof InvalidMountPointException e) {
+			handleInvalidMountPoint(e);
+		} else {
+			handleGenericError(throwable);
+		}
 		vault.stateProperty().transition(VaultState.Value.PROCESSING, VaultState.Value.LOCKED);
 	}
 
 	@Override
 	protected void cancelled() {
+		LOG.debug("Unlock of '{}' canceled.", vault.getDisplayName());
 		vault.stateProperty().transition(VaultState.Value.PROCESSING, VaultState.Value.LOCKED);
 	}
 


### PR DESCRIPTION
Closes #1508 

## Description
This PR adds to Cryptomator the capability, that the GUI automatically adapt to external unmount events of an opened & unlocked vault. This feature is only implemented for native volume adapters (Dokany/FUSE).

## Implementation Details

On an unlock and mount of a vault (see `Vault::unlock`), an `onExitAction` is handed down to the nio-library and is executed as soon as the native, blocking main method representing the mount returns.

Due to the asynchronous nature of the `onExitAction`, additional synchronisation for the vault state had to be impemented. The vault state was migrated to its own class with an not synchronized `setState()` function and an synchronized version `transition(from, to)` which takes the currently expected vault state into account, failing if the actual state differs from it. 

Additionally, the lock method was refactored to not explicitly setting the vault state but waiting for the `onExitAction` to complete.

