### PR TITLE
Rework choose-location-screen in add vault wizard:

### DIFF
--- a/main/ui/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
@@ -42,7 +42,6 @@ public class CreateNewVaultLocationController implements FxController {
 	private final Stage window;
 	private final Lazy<Scene> chooseNameScene;
 	private final Lazy<Scene> choosePasswordScene;
-	private final ErrorComponent.Builder errorComponent;
 	private final LocationPresets locationPresets;
 	private final ObjectProperty<Path> vaultPath;
 	private final StringProperty vaultName;
@@ -65,11 +64,10 @@ public class CreateNewVaultLocationController implements FxController {
 	public FontAwesome5IconView badLocation;
 
 	@Inject
-	CreateNewVaultLocationController(@AddVaultWizardWindow Stage window, @FxmlScene(FxmlFile.ADDVAULT_NEW_NAME) Lazy<Scene> chooseNameScene, @FxmlScene(FxmlFile.ADDVAULT_NEW_PASSWORD) Lazy<Scene> choosePasswordScene, ErrorComponent.Builder errorComponent, LocationPresets locationPresets, ObjectProperty<Path> vaultPath, @Named("vaultName") StringProperty vaultName, ResourceBundle resourceBundle) {
+	CreateNewVaultLocationController(@AddVaultWizardWindow Stage window, @FxmlScene(FxmlFile.ADDVAULT_NEW_NAME) Lazy<Scene> chooseNameScene, @FxmlScene(FxmlFile.ADDVAULT_NEW_PASSWORD) Lazy<Scene> choosePasswordScene, LocationPresets locationPresets, ObjectProperty<Path> vaultPath, @Named("vaultName") StringProperty vaultName, ResourceBundle resourceBundle) {
 		this.window = window;
 		this.chooseNameScene = chooseNameScene;
 		this.choosePasswordScene = choosePasswordScene;
-		this.errorComponent = errorComponent;
 		this.locationPresets = locationPresets;
 		this.vaultPath = vaultPath;
 		this.vaultName = vaultName;

--- a/main/ui/src/main/resources/fxml/addvault_new_location.fxml
+++ b/main/ui/src/main/resources/fxml/addvault_new_location.fxml
@@ -50,7 +50,7 @@
 		<VBox spacing="6">
 			<Label text="%addvaultwizard.new.locationLabel" labelFor="$locationTextField"/>
 			<TextField promptText="%addvaultwizard.new.locationPrompt" text="${controller.vaultPath}" editable="false" disable="${!controller.anyRadioButtonSelected}" HBox.hgrow="ALWAYS"/>
-			<Label fx:id="vaultPathStatus" alignment="CENTER_RIGHT" wrapText="true" visible="${controller.anyRadioButtonSelected}" maxWidth="Infinity" graphicTextGap="6" />
+			<Label fx:id="vaultPathStatus" alignment="CENTER_RIGHT" wrapText="true" visible="${controller.anyRadioButtonSelected}" maxWidth="Infinity" graphicTextGap="6" text="${controller.statusText}" graphic="${controller.statusGraphic}" />
 		</VBox>
 
 		<Region VBox.vgrow="ALWAYS"/>

--- a/main/ui/src/main/resources/fxml/addvault_new_location.fxml
+++ b/main/ui/src/main/resources/fxml/addvault_new_location.fxml
@@ -20,6 +20,8 @@
 	  alignment="CENTER_LEFT">
 	<fx:define>
 		<ToggleGroup fx:id="predefinedLocationToggler"/>
+		<FontAwesome5IconView fx:id="badLocation" styleClass="glyph-icon-red" glyph="TIMES" />
+		<FontAwesome5IconView fx:id="goodLocation" styleClass="glyph-icon-primary" glyph="CHECK" />
 	</fx:define>
 	<padding>
 		<Insets topRightBottomLeft="24"/>
@@ -47,12 +49,8 @@
 
 		<VBox spacing="6">
 			<Label text="%addvaultwizard.new.locationLabel" labelFor="$locationTextField"/>
-			<TextField fx:id="locationTextField" promptText="%addvaultwizard.new.locationPrompt" text="${controller.vaultPath}" disable="true" HBox.hgrow="ALWAYS"/>
-			<Label text="${controller.warningText}" wrapText="true" visible="${controller.showWarning}">
-				<graphic>
-					<FontAwesome5IconView glyph="EXCLAMATION_TRIANGLE"/>
-				</graphic>
-			</Label>
+			<TextField promptText="%addvaultwizard.new.locationPrompt" text="${controller.vaultPath}" editable="false" disable="${!controller.anyRadioButtonSelected}" HBox.hgrow="ALWAYS"/>
+			<Label fx:id="vaultPathStatus" alignment="CENTER_RIGHT" wrapText="true" visible="${controller.anyRadioButtonSelected}" maxWidth="Infinity" graphicTextGap="6" />
 		</VBox>
 
 		<Region VBox.vgrow="ALWAYS"/>

--- a/main/ui/src/main/resources/i18n/strings.properties
+++ b/main/ui/src/main/resources/i18n/strings.properties
@@ -45,10 +45,10 @@ addvaultwizard.new.locationPrompt=…
 addvaultwizard.new.directoryPickerLabel=Custom Location
 addvaultwizard.new.directoryPickerButton=Choose…
 addvaultwizard.new.directoryPickerTitle=Select Directory
-addvaultwizard.new.fileAlreadyExists=A file or directory with the vault name already exists.
-addvaultwizard.new.locationDoesNotExist=A directory in the specified path does not exists or cannot be accessed.
-addvaultwizard.new.locationIsNotWritable=No write access at the specified path.
-addvaultwizard.new.locationIsOk=Suitable location for your vault.
+addvaultwizard.new.fileAlreadyExists=A file or directory with the vault name already exists
+addvaultwizard.new.locationDoesNotExist=A directory in the specified path does not exist or cannot be accessed
+addvaultwizard.new.locationIsNotWritable=No write access at the specified path
+addvaultwizard.new.locationIsOk=Suitable location for your vault
 addvaultwizard.new.invalidName=Invalid vault name. Please consider a regular directory name.
 ### Password
 addvaultwizard.new.createVaultBtn=Create Vault

--- a/main/ui/src/main/resources/i18n/strings.properties
+++ b/main/ui/src/main/resources/i18n/strings.properties
@@ -45,8 +45,10 @@ addvaultwizard.new.locationPrompt=…
 addvaultwizard.new.directoryPickerLabel=Custom Location
 addvaultwizard.new.directoryPickerButton=Choose…
 addvaultwizard.new.directoryPickerTitle=Select Directory
-addvaultwizard.new.fileAlreadyExists=Vault can not be created at this path because some object already exists.
-addvaultwizard.new.locationDoesNotExist=Vault can not be created at this path because at least one path component does not exist.
+addvaultwizard.new.fileAlreadyExists=A file or directory with the vault name already exists.
+addvaultwizard.new.locationDoesNotExist=A directory in the specified path does not exists or cannot be accessed.
+addvaultwizard.new.locationIsNotWritable=No write access at the specified path.
+addvaultwizard.new.locationIsOk=Suitable location for your vault.
 addvaultwizard.new.invalidName=Invalid vault name. Please consider a regular directory name.
 ### Password
 addvaultwizard.new.createVaultBtn=Create Vault


### PR DESCRIPTION
Unified design (compare it with the choose-password-screen), better error messages, higher focus on the storage path.

Includes:
* more checks of the chosen vault path
* every check has own error message
* perform checks when vault path changes
* if any radio button selected, enable vault path field (no-edit)

No path selected:
![grafik](https://user-images.githubusercontent.com/9036915/115001518-ff004e00-9ea3-11eb-9baa-3a4e013f4809.png)

If specified path is suitable for vault storage:
![grafik](https://user-images.githubusercontent.com/9036915/115001585-117a8780-9ea4-11eb-93b8-3ffda893ee33.png)

Example for an error:
![grafik](https://user-images.githubusercontent.com/9036915/115001618-1b03ef80-9ea4-11eb-9bea-d9bb79e2b9be.png)

