### PR TITLE
Feature/#1593 hotkeys

### DIFF
--- a/main/ui/src/main/java/org/cryptomator/ui/mainwindow/VaultDetailLockedController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/mainwindow/VaultDetailLockedController.java
@@ -14,7 +14,10 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.fxml.FXML;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.stage.Stage;
+import java.awt.Button;
 import java.util.Optional;
 
 @MainWindowScoped
@@ -39,6 +42,15 @@ public class VaultDetailLockedController implements FxController {
 		} else {
 			this.passwordSaved = new SimpleBooleanProperty(false);
 		}
+	}
+
+	public void initialize() {
+		mainWindow.addEventFilter(KeyEvent.KEY_PRESSED, keyEvent -> {
+			if( keyEvent.getCode() == KeyCode.ENTER && vault.get() != null && vault.get().isLocked()) {
+				this.unlock();
+				keyEvent.consume();
+			}
+		});
 	}
 
 	@FXML

--- a/main/ui/src/main/java/org/cryptomator/ui/mainwindow/VaultDetailUnlockedController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/mainwindow/VaultDetailUnlockedController.java
@@ -49,6 +49,12 @@ public class VaultDetailUnlockedController implements FxController {
 				keyEvent.consume();
 			}
 		});
+		mainWindow.addEventFilter(KeyEvent.KEY_PRESSED, keyEvent -> {
+			if (keyEvent.isShortcutDown() && keyEvent.getCode() == KeyCode.L && vault.get() != null && vault.get().isUnlocked()) {
+				this.lock();
+				keyEvent.consume();
+			}
+		});
 	}
 
 	@FXML

--- a/main/ui/src/main/java/org/cryptomator/ui/mainwindow/VaultDetailUnlockedController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/mainwindow/VaultDetailUnlockedController.java
@@ -13,6 +13,8 @@ import javax.inject.Inject;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.fxml.FXML;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.stage.Stage;
 import java.util.Optional;
 
@@ -38,6 +40,15 @@ public class VaultDetailUnlockedController implements FxController {
 
 	private VaultStatisticsComponent buildVaultStats(Vault vault) {
 		return vaultStatsBuilder.vault(vault).build();
+	}
+
+	public void initialize() {
+		mainWindow.addEventFilter(KeyEvent.KEY_PRESSED, keyEvent -> {
+			if (keyEvent.getCode() == KeyCode.ENTER && vault.get() != null && vault.get().isUnlocked()) {
+				this.revealAccessLocation();
+				keyEvent.consume();
+			}
+		});
 	}
 
 	@FXML

--- a/main/ui/src/main/java/org/cryptomator/ui/mainwindow/VaultListContextMenuController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/mainwindow/VaultListContextMenuController.java
@@ -3,6 +3,7 @@ package org.cryptomator.ui.mainwindow;
 import com.tobiasdiez.easybind.EasyBind;
 import com.tobiasdiez.easybind.optional.ObservableOptionalValue;
 import com.tobiasdiez.easybind.optional.OptionalBinding;
+import org.apache.commons.lang3.SystemUtils;
 import org.cryptomator.common.keychain.KeychainManager;
 import org.cryptomator.common.vaults.Vault;
 import org.cryptomator.common.vaults.VaultState;
@@ -16,6 +17,8 @@ import javax.inject.Inject;
 import javafx.beans.binding.Binding;
 import javafx.beans.property.ObjectProperty;
 import javafx.fxml.FXML;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.stage.Stage;
 import java.util.EnumSet;
 import java.util.Optional;
@@ -51,6 +54,27 @@ public class VaultListContextMenuController implements FxController {
 		this.selectedVaultRemovable = selectedVaultState.map(EnumSet.of(LOCKED, MISSING, ERROR, NEEDS_MIGRATION)::contains).orElse(false);
 		this.selectedVaultUnlockable = selectedVaultState.map(LOCKED::equals).orElse(false);
 		this.selectedVaultLockable = selectedVaultState.map(UNLOCKED::equals).orElse(false);
+	}
+
+	public void initialize() {
+		mainWindow.addEventFilter(KeyEvent.KEY_RELEASED, keyEvent -> {
+			if (keyEvent.getCode() == KeyCode.DELETE && isSelectedVaultRemovable()) {
+				selectedVault.ifValuePresent(v -> {
+					removeVault.vault(v).build().showRemoveVault();
+				});
+				keyEvent.consume();
+			}
+		});
+		if (SystemUtils.IS_OS_MAC) {
+			mainWindow.addEventFilter(KeyEvent.KEY_RELEASED, keyEvent -> {
+				if (keyEvent.getCode() == KeyCode.BACK_SPACE && isSelectedVaultRemovable()) {
+					selectedVault.ifValuePresent(v -> {
+						removeVault.vault(v).build().showRemoveVault();
+					});
+					keyEvent.consume();
+				}
+			});
+		}
 	}
 
 	private boolean isPasswordStored(Vault vault) {

--- a/main/ui/src/main/java/org/cryptomator/ui/mainwindow/VaultListController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/mainwindow/VaultListController.java
@@ -15,12 +15,15 @@ import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.ListView;
 import javafx.scene.input.ContextMenuEvent;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseEvent;
+import javafx.stage.Stage;
 
 @MainWindowScoped
 public class VaultListController implements FxController {
 
 
+	private final Stage mainWindow;
 	private final ObservableList<Vault> vaults;
 	private final ObjectProperty<Vault> selectedVault;
 	private final VaultListCellFactory cellFactory;
@@ -30,7 +33,8 @@ public class VaultListController implements FxController {
 	public ListView<Vault> vaultList;
 
 	@Inject
-	VaultListController(ObservableList<Vault> vaults, ObjectProperty<Vault> selectedVault, VaultListCellFactory cellFactory, AddVaultWizardComponent.Builder addVaultWizard) {
+	VaultListController(@MainWindow Stage mainWindow, ObservableList<Vault> vaults, ObjectProperty<Vault> selectedVault, VaultListCellFactory cellFactory, AddVaultWizardComponent.Builder addVaultWizard) {
+		this.mainWindow = mainWindow;
 		this.vaults = vaults;
 		this.selectedVault = selectedVault;
 		this.cellFactory = cellFactory;
@@ -57,6 +61,11 @@ public class VaultListController implements FxController {
 		vaultList.addEventFilter(ContextMenuEvent.CONTEXT_MENU_REQUESTED, request -> {
 			if (selectedVault.get() == null) {
 				request.consume();
+			}
+		});
+		mainWindow.addEventFilter(KeyEvent.KEY_RELEASED, keyevent -> {
+			if (keyevent.isShortcutDown() && keyevent.getCode().isDigitKey()) {
+				vaultList.getSelectionModel().select(Integer.parseInt(keyevent.getText()) - 1);
 			}
 		});
 	}


### PR DESCRIPTION
References #1593 .

This PR adds the following hotkeys to Cryptomator:
* `CMD`/`STRG` + 1/2/.../9: Select first, second,...., nineth vault from the vault list
* `Entf`: Start RemoveVault dialogue if one is selected
* `Backspace`: Start RemoveVault dialogue if one is selected (MacOS only)
* `Enter`: If a vault is selected, perform primary action (i.e. unlock or reveal)
* `CMD`+`L`: If selected vault is unlocked, lock it