### PR TITLE
Simplify password creation

### DIFF
--- a/main/ui/src/main/java/org/cryptomator/ui/addvaultwizard/AddVaultModule.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/addvaultwizard/AddVaultModule.java
@@ -6,10 +6,10 @@ import dagger.Provides;
 import dagger.multibindings.IntoMap;
 import org.cryptomator.common.vaults.Vault;
 import org.cryptomator.ui.common.DefaultSceneFactory;
-import org.cryptomator.ui.common.FxmlLoaderFactory;
 import org.cryptomator.ui.common.FxController;
 import org.cryptomator.ui.common.FxControllerKey;
 import org.cryptomator.ui.common.FxmlFile;
+import org.cryptomator.ui.common.FxmlLoaderFactory;
 import org.cryptomator.ui.common.FxmlScene;
 import org.cryptomator.ui.common.NewPasswordController;
 import org.cryptomator.ui.common.PasswordStrengthUtil;
@@ -32,13 +32,6 @@ import java.util.ResourceBundle;
 
 @Module
 public abstract class AddVaultModule {
-
-	@Provides
-	@AddVaultWizardScoped
-	@Named("newPassword")
-	static ObjectProperty<CharSequence> provideNewPasswordProperty() {
-		return new SimpleObjectProperty<>("");
-	}
 
 	@Provides
 	@AddVaultWizardWindow
@@ -167,8 +160,8 @@ public abstract class AddVaultModule {
 	@Provides
 	@IntoMap
 	@FxControllerKey(NewPasswordController.class)
-	static FxController provideNewPasswordController(ResourceBundle resourceBundle, PasswordStrengthUtil strengthRater, @Named("newPassword") ObjectProperty<CharSequence> password) {
-		return new NewPasswordController(resourceBundle, strengthRater, password);
+	static FxController provideNewPasswordController(ResourceBundle resourceBundle, PasswordStrengthUtil strengthRater) {
+		return new NewPasswordController(resourceBundle, strengthRater);
 	}
 
 	@Binds

--- a/main/ui/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultPasswordController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultPasswordController.java
@@ -14,6 +14,7 @@ import org.cryptomator.ui.common.ErrorComponent;
 import org.cryptomator.ui.common.FxController;
 import org.cryptomator.ui.common.FxmlFile;
 import org.cryptomator.ui.common.FxmlScene;
+import org.cryptomator.ui.common.NewPasswordController;
 import org.cryptomator.ui.common.Tasks;
 import org.cryptomator.ui.keyloading.masterkeyfile.MasterkeyFileLoadingStrategy;
 import org.cryptomator.ui.recoverykey.RecoveryKeyFactory;
@@ -23,7 +24,6 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javafx.beans.binding.Bindings;
-import javafx.beans.binding.BooleanBinding;
 import javafx.beans.binding.ObjectBinding;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
@@ -41,7 +41,6 @@ import java.net.URI;
 import java.nio.channels.WritableByteChannel;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.security.SecureRandom;
@@ -70,7 +69,6 @@ public class CreateNewVaultPasswordController implements FxController {
 	private final StringProperty recoveryKeyProperty;
 	private final VaultListManager vaultListManager;
 	private final ResourceBundle resourceBundle;
-	private final ObjectProperty<CharSequence> password;
 	private final ReadmeGenerator readmeGenerator;
 	private final SecureRandom csprng;
 	private final MasterkeyFileAccess masterkeyFileAccess;
@@ -81,9 +79,10 @@ public class CreateNewVaultPasswordController implements FxController {
 	public ToggleGroup recoveryKeyChoice;
 	public Toggle showRecoveryKey;
 	public Toggle skipRecoveryKey;
+	public NewPasswordController newPasswordSceneController;
 
 	@Inject
-	CreateNewVaultPasswordController(@AddVaultWizardWindow Stage window, @FxmlScene(FxmlFile.ADDVAULT_NEW_LOCATION) Lazy<Scene> chooseLocationScene, @FxmlScene(FxmlFile.ADDVAULT_NEW_RECOVERYKEY) Lazy<Scene> recoveryKeyScene, @FxmlScene(FxmlFile.ADDVAULT_SUCCESS) Lazy<Scene> successScene, ErrorComponent.Builder errorComponent, ExecutorService executor, RecoveryKeyFactory recoveryKeyFactory, @Named("vaultName") StringProperty vaultName, ObjectProperty<Path> vaultPath, @AddVaultWizardWindow ObjectProperty<Vault> vault, @Named("recoveryKey") StringProperty recoveryKey, VaultListManager vaultListManager, ResourceBundle resourceBundle, @Named("newPassword") ObjectProperty<CharSequence> password, ReadmeGenerator readmeGenerator, SecureRandom csprng, MasterkeyFileAccess masterkeyFileAccess) {
+	CreateNewVaultPasswordController(@AddVaultWizardWindow Stage window, @FxmlScene(FxmlFile.ADDVAULT_NEW_LOCATION) Lazy<Scene> chooseLocationScene, @FxmlScene(FxmlFile.ADDVAULT_NEW_RECOVERYKEY) Lazy<Scene> recoveryKeyScene, @FxmlScene(FxmlFile.ADDVAULT_SUCCESS) Lazy<Scene> successScene, ErrorComponent.Builder errorComponent, ExecutorService executor, RecoveryKeyFactory recoveryKeyFactory, @Named("vaultName") StringProperty vaultName, ObjectProperty<Path> vaultPath, @AddVaultWizardWindow ObjectProperty<Vault> vault, @Named("recoveryKey") StringProperty recoveryKey, VaultListManager vaultListManager, ResourceBundle resourceBundle, ReadmeGenerator readmeGenerator, SecureRandom csprng, MasterkeyFileAccess masterkeyFileAccess) {
 		this.window = window;
 		this.chooseLocationScene = chooseLocationScene;
 		this.recoveryKeyScene = recoveryKeyScene;
@@ -97,7 +96,6 @@ public class CreateNewVaultPasswordController implements FxController {
 		this.recoveryKeyProperty = recoveryKey;
 		this.vaultListManager = vaultListManager;
 		this.resourceBundle = resourceBundle;
-		this.password = password;
 		this.readmeGenerator = readmeGenerator;
 		this.csprng = csprng;
 		this.masterkeyFileAccess = masterkeyFileAccess;
@@ -108,8 +106,7 @@ public class CreateNewVaultPasswordController implements FxController {
 
 	@FXML
 	public void initialize() {
-		BooleanBinding isValidNewPassword = Bindings.createBooleanBinding(() -> password.get() != null && password.get().length() > 0, password);
-		readyToCreateVault.bind(isValidNewPassword.and(recoveryKeyChoice.selectedToggleProperty().isNotNull()).and(processing.not()));
+		readyToCreateVault.bind(newPasswordSceneController.passwordsMatchAndSufficientProperty().and(recoveryKeyChoice.selectedToggleProperty().isNotNull()).and(processing.not()));
 	}
 
 	@FXML
@@ -142,8 +139,8 @@ public class CreateNewVaultPasswordController implements FxController {
 		Path pathToVault = vaultPathProperty.get();
 		processing.set(true);
 		Tasks.create(() -> {
-			initializeVault(pathToVault, password.get());
-			return recoveryKeyFactory.createRecoveryKey(pathToVault, password.get());
+			initializeVault(pathToVault);
+			return recoveryKeyFactory.createRecoveryKey(pathToVault, newPasswordSceneController.passwordField.getCharacters());
 		}).onSuccess(recoveryKey -> {
 			initializationSucceeded(pathToVault);
 			recoveryKeyProperty.set(recoveryKey);
@@ -160,7 +157,7 @@ public class CreateNewVaultPasswordController implements FxController {
 		Path pathToVault = vaultPathProperty.get();
 		processing.set(true);
 		Tasks.create(() -> {
-			initializeVault(pathToVault, password.get());
+			initializeVault(pathToVault);
 		}).onSuccess(() -> {
 			initializationSucceeded(pathToVault);
 			window.setScene(successScene.get());
@@ -172,11 +169,11 @@ public class CreateNewVaultPasswordController implements FxController {
 		}).runOnce(executor);
 	}
 
-	private void initializeVault(Path path, CharSequence passphrase) throws IOException {
+	private void initializeVault(Path path) throws IOException {
 		// 1. write masterkey:
 		Path masterkeyFilePath = path.resolve(MASTERKEY_FILENAME);
 		try (Masterkey masterkey = Masterkey.generate(csprng)) {
-			masterkeyFileAccess.persist(masterkey, masterkeyFilePath, passphrase);
+			masterkeyFileAccess.persist(masterkey, masterkeyFilePath, newPasswordSceneController.passwordField.getCharacters());
 
 			// 2. initialize vault:
 			try {

--- a/main/ui/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultPasswordController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultPasswordController.java
@@ -107,6 +107,10 @@ public class CreateNewVaultPasswordController implements FxController {
 	@FXML
 	public void initialize() {
 		readyToCreateVault.bind(newPasswordSceneController.passwordsMatchAndSufficientProperty().and(recoveryKeyChoice.selectedToggleProperty().isNotNull()).and(processing.not()));
+		window.setOnHiding(event -> {
+			newPasswordSceneController.passwordField.wipe();
+			newPasswordSceneController.reenterField.wipe();
+		});
 	}
 
 	@FXML

--- a/main/ui/src/main/java/org/cryptomator/ui/changepassword/ChangePasswordModule.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/changepassword/ChangePasswordModule.java
@@ -5,10 +5,10 @@ import dagger.Module;
 import dagger.Provides;
 import dagger.multibindings.IntoMap;
 import org.cryptomator.ui.common.DefaultSceneFactory;
-import org.cryptomator.ui.common.FxmlLoaderFactory;
 import org.cryptomator.ui.common.FxController;
 import org.cryptomator.ui.common.FxControllerKey;
 import org.cryptomator.ui.common.FxmlFile;
+import org.cryptomator.ui.common.FxmlLoaderFactory;
 import org.cryptomator.ui.common.FxmlScene;
 import org.cryptomator.ui.common.NewPasswordController;
 import org.cryptomator.ui.common.PasswordStrengthUtil;
@@ -16,8 +16,6 @@ import org.cryptomator.ui.common.StageFactory;
 
 import javax.inject.Named;
 import javax.inject.Provider;
-import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.Scene;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
@@ -26,13 +24,6 @@ import java.util.ResourceBundle;
 
 @Module
 abstract class ChangePasswordModule {
-
-	@Provides
-	@ChangePasswordScoped
-	@Named("newPassword")
-	static ObjectProperty<CharSequence> provideNewPasswordProperty() {
-		return new SimpleObjectProperty<>("");
-	}
 
 	@Provides
 	@ChangePasswordWindow
@@ -71,8 +62,8 @@ abstract class ChangePasswordModule {
 	@Provides
 	@IntoMap
 	@FxControllerKey(NewPasswordController.class)
-	static FxController provideNewPasswordController(ResourceBundle resourceBundle, PasswordStrengthUtil strengthRater, @Named("newPassword") ObjectProperty<CharSequence> password) {
-		return new NewPasswordController(resourceBundle, strengthRater, password);
+	static FxController provideNewPasswordController(ResourceBundle resourceBundle, PasswordStrengthUtil strengthRater) {
+		return new NewPasswordController(resourceBundle, strengthRater);
 	}
 
 }

--- a/main/ui/src/main/java/org/cryptomator/ui/controls/SecurePasswordField.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/controls/SecurePasswordField.java
@@ -123,7 +123,7 @@ public class SecurePasswordField extends TextField {
 	}
 
 	private void updateCapsLocked() {
-		// AWT code needed until https://bugs.openjdk.java.net/browse/JDK-8090882 is closed:
+		//TODO: fixed in JavaFX 17. AWT code needed until update (see https://bugs.openjdk.java.net/browse/JDK-8259680)
 		capsLocked.set(isFocused() && Toolkit.getDefaultToolkit().getLockingKeyState(java.awt.event.KeyEvent.VK_CAPS_LOCK));
 	}
 

--- a/main/ui/src/main/java/org/cryptomator/ui/recoverykey/RecoveryKeyModule.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/recoverykey/RecoveryKeyModule.java
@@ -6,10 +6,10 @@ import dagger.Provides;
 import dagger.multibindings.IntoMap;
 import org.cryptomator.common.vaults.Vault;
 import org.cryptomator.ui.common.DefaultSceneFactory;
-import org.cryptomator.ui.common.FxmlLoaderFactory;
 import org.cryptomator.ui.common.FxController;
 import org.cryptomator.ui.common.FxControllerKey;
 import org.cryptomator.ui.common.FxmlFile;
+import org.cryptomator.ui.common.FxmlLoaderFactory;
 import org.cryptomator.ui.common.FxmlScene;
 import org.cryptomator.ui.common.NewPasswordController;
 import org.cryptomator.ui.common.PasswordStrengthUtil;
@@ -17,8 +17,6 @@ import org.cryptomator.ui.common.StageFactory;
 
 import javax.inject.Named;
 import javax.inject.Provider;
-import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.scene.Scene;
@@ -55,14 +53,6 @@ abstract class RecoveryKeyModule {
 	static StringProperty provideRecoveryKeyProperty() {
 		return new SimpleStringProperty();
 	}
-
-	@Provides
-	@RecoveryKeyScoped
-	@Named("newPassword")
-	static ObjectProperty<CharSequence> provideNewPasswordProperty() {
-		return new SimpleObjectProperty<>("");
-	}
-
 
 	// ------------------
 
@@ -126,8 +116,8 @@ abstract class RecoveryKeyModule {
 	@Provides
 	@IntoMap
 	@FxControllerKey(NewPasswordController.class)
-	static FxController provideNewPasswordController(ResourceBundle resourceBundle, PasswordStrengthUtil strengthRater, @Named("newPassword") ObjectProperty<CharSequence> password) {
-		return new NewPasswordController(resourceBundle, strengthRater, password);
+	static FxController provideNewPasswordController(ResourceBundle resourceBundle, PasswordStrengthUtil strengthRater) {
+		return new NewPasswordController(resourceBundle, strengthRater);
 	}
 
 }

--- a/main/ui/src/main/java/org/cryptomator/ui/recoverykey/RecoveryKeyResetPasswordController.java
+++ b/main/ui/src/main/java/org/cryptomator/ui/recoverykey/RecoveryKeyResetPasswordController.java
@@ -6,14 +6,12 @@ import org.cryptomator.ui.common.ErrorComponent;
 import org.cryptomator.ui.common.FxController;
 import org.cryptomator.ui.common.FxmlFile;
 import org.cryptomator.ui.common.FxmlScene;
+import org.cryptomator.ui.common.NewPasswordController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import javax.inject.Named;
-import javafx.beans.binding.Bindings;
-import javafx.beans.binding.BooleanBinding;
-import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.StringProperty;
 import javafx.concurrent.Task;
 import javafx.fxml.FXML;
@@ -32,21 +30,19 @@ public class RecoveryKeyResetPasswordController implements FxController {
 	private final RecoveryKeyFactory recoveryKeyFactory;
 	private final ExecutorService executor;
 	private final StringProperty recoveryKey;
-	private final ObjectProperty<CharSequence> newPassword;
 	private final Lazy<Scene> recoverScene;
-	private final BooleanBinding invalidNewPassword;
 	private final ErrorComponent.Builder errorComponent;
 
+	public NewPasswordController newPasswordController;
+
 	@Inject
-	public RecoveryKeyResetPasswordController(@RecoveryKeyWindow Stage window, @RecoveryKeyWindow Vault vault, RecoveryKeyFactory recoveryKeyFactory, ExecutorService executor, @RecoveryKeyWindow StringProperty recoveryKey, @Named("newPassword") ObjectProperty<CharSequence> newPassword, @FxmlScene(FxmlFile.RECOVERYKEY_RECOVER) Lazy<Scene> recoverScene, ErrorComponent.Builder errorComponent) {
+	public RecoveryKeyResetPasswordController(@RecoveryKeyWindow Stage window, @RecoveryKeyWindow Vault vault, RecoveryKeyFactory recoveryKeyFactory, ExecutorService executor, @RecoveryKeyWindow StringProperty recoveryKey, @FxmlScene(FxmlFile.RECOVERYKEY_RECOVER) Lazy<Scene> recoverScene, ErrorComponent.Builder errorComponent) {
 		this.window = window;
 		this.vault = vault;
 		this.recoveryKeyFactory = recoveryKeyFactory;
 		this.executor = executor;
 		this.recoveryKey = recoveryKey;
-		this.newPassword = newPassword;
 		this.recoverScene = recoverScene;
-		this.invalidNewPassword = Bindings.createBooleanBinding(this::isInvalidNewPassword, newPassword);
 		this.errorComponent = errorComponent;
 	}
 
@@ -81,7 +77,7 @@ public class RecoveryKeyResetPasswordController implements FxController {
 
 		@Override
 		protected Void call() throws IOException, IllegalArgumentException {
-			recoveryKeyFactory.resetPasswordWithRecoveryKey(vault.getPath(), recoveryKey.get(), newPassword.get());
+			recoveryKeyFactory.resetPasswordWithRecoveryKey(vault.getPath(), recoveryKey.get(), newPasswordController.passwordField.getCharacters());
 			return null;
 		}
 
@@ -89,11 +85,12 @@ public class RecoveryKeyResetPasswordController implements FxController {
 
 	/* Getter/Setter */
 
-	public BooleanBinding invalidNewPasswordProperty() {
-		return invalidNewPassword;
+	public ReadOnlyBooleanProperty validPasswordProperty() {
+		return newPasswordController.passwordsMatchAndSufficientProperty();
 	}
 
-	public boolean isInvalidNewPassword() {
-		return newPassword.get() == null || newPassword.get().length() == 0;
+	public boolean isValidPassword() {
+		return newPasswordController.passwordsMatchAndSufficientProperty().get();
 	}
+
 }

--- a/main/ui/src/main/resources/fxml/addvault_new_password.fxml
+++ b/main/ui/src/main/resources/fxml/addvault_new_password.fxml
@@ -23,7 +23,7 @@
 		<Insets topRightBottomLeft="24"/>
 	</padding>
 	<children>
-		<fx:include source="/fxml/new_password.fxml"/>
+		<fx:include fx:id="newPasswordScene" source="/fxml/new_password.fxml"/>
 
 		<Region VBox.vgrow="ALWAYS"/>
 

--- a/main/ui/src/main/resources/fxml/changepassword.fxml
+++ b/main/ui/src/main/resources/fxml/changepassword.fxml
@@ -25,7 +25,7 @@
 
 		<Region prefHeight="12" VBox.vgrow="NEVER"/>
 
-		<fx:include source="/fxml/new_password.fxml"/>
+		<fx:include fx:id="newPassword" source="/fxml/new_password.fxml"/>
 
 		<CheckBox fx:id="finalConfirmationCheckbox" text="%changepassword.finalConfirmation" wrapText="true"/>
 

--- a/main/ui/src/main/resources/fxml/recoverykey_reset_password.fxml
+++ b/main/ui/src/main/resources/fxml/recoverykey_reset_password.fxml
@@ -25,7 +25,7 @@
 			<ButtonBar buttonMinWidth="120" buttonOrder="B+I">
 				<buttons>
 					<Button text="%generic.button.back" ButtonBar.buttonData="BACK_PREVIOUS" cancelButton="true" onAction="#back"/>
-					<Button text="%generic.button.done" ButtonBar.buttonData="FINISH" defaultButton="true" onAction="#done" disable="${controller.invalidNewPassword}"/>
+					<Button text="%generic.button.done" ButtonBar.buttonData="FINISH" defaultButton="true" onAction="#done" disable="${!controller.validPassword}"/>
 				</buttons>
 			</ButtonBar>
 		</VBox>

--- a/main/ui/src/main/resources/fxml/recoverykey_reset_password.fxml
+++ b/main/ui/src/main/resources/fxml/recoverykey_reset_password.fxml
@@ -17,7 +17,7 @@
 		<Insets topRightBottomLeft="12"/>
 	</padding>
 	<children>
-		<fx:include source="/fxml/new_password.fxml"/>
+		<fx:include fx:id="newPassword" source="/fxml/new_password.fxml"/>
 
 		<Region VBox.vgrow="ALWAYS"/>
 


### PR DESCRIPTION
This PR removes string properties to pass a user password between different controllers and directly access password fields from included fxml files.

While this increase the coupling between two JavaFX controllers, in this context this is quite natural, since in every case of the applied changes one controller contains the "new password" controller. Hence there is no need to create an artificial property just to pass the passphrase between those two, the password can directly be read by using the builtin field injection of JavaFX.
