### PR TITLE
method loadVaultConfig() throws exception instead of returning optional

### DIFF
--- a/main/commons/src/main/java/org/cryptomator/common/vaults/Vault.java
+++ b/main/commons/src/main/java/org/cryptomator/common/vaults/Vault.java
@@ -109,7 +109,7 @@ public class Vault {
 		} else if(vaultSettings.maxCleartextFilenameLength().get() == -1) {
 			LOG.debug("Determining cleartext filename length limitations...");
 			var checker = new FileSystemCapabilityChecker();
-			int shorteningThreshold = getUnverifiedVaultConfig().orElseThrow().allegedShorteningThreshold();
+			int shorteningThreshold = getUnverifiedVaultConfig().allegedShorteningThreshold();
 			int ciphertextLimit = checker.determineSupportedCiphertextFileNameLength(getPath());
 			if (ciphertextLimit < shorteningThreshold) {
 				int cleartextLimit = checker.determineSupportedCleartextFileNameLength(getPath());
@@ -327,14 +327,10 @@ public class Vault {
 		return stats;
 	}
 
-	public Optional<UnverifiedVaultConfig> getUnverifiedVaultConfig() {
+	public UnverifiedVaultConfig getUnverifiedVaultConfig() throws IOException {
 		Path configPath = getPath().resolve(org.cryptomator.common.Constants.VAULTCONFIG_FILENAME);
-		try {
-			String token = Files.readString(configPath, StandardCharsets.US_ASCII);
-			return Optional.of(VaultConfig.decode(token));
-		} catch (IOException e) {
-			return Optional.empty();
-		}
+		String token = Files.readString(configPath, StandardCharsets.US_ASCII);
+		return VaultConfig.decode(token);
 	}
 
 	public Observable[] observables() {


### PR DESCRIPTION
To get the unverfied config of a vault the method `Vault::loadVaultConfig` exists. It returns `Optional<UnverifiedVaultConfig>`, such that it can be used within the Dagger graph.

This PR changes the method signature to directly return the unverified config and throws an exception on failure. This has the advance, that the stacktrace of the error is preserved. Additionally, one can directly react to an error and do not has to work around the Optionals wrapping.

To address the dagger concerns, inside the key loading module the keyID is not extracted in an extra method, but directly when choosing the appropiate key provider. The drawback of this approach is, that the keyID cannot be injected directly for future uses.