### PR TITLE
Instruction for building on the CLI have a slight error

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ For more information on the security details visit [cryptomator.org](https://doc
 ### Run Maven
 
 ```
-cd main
 mvn clean install
 # or mvn clean install -Pwindows
 # or mvn clean install -Pmac


### PR DESCRIPTION
On reworking ['Single maven module'](https://github.com/cryptomator/cryptomator/commit/7fac6da4485366f9b649b12d73b1d55e84c34204) you missed one little bit in the README.md.