### PR TITLE
Building and launching on the CLI fails with ClassNotFoundException

### DIFF
--- a/src/package/launcher-linux.sh
+++ b/src/package/launcher-linux.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 cd $(dirname $0)
 java \
-	-cp "libs/*" \
+	-cp "cryptomator-${project.version}.jar:libs/*" \
 	-Dcryptomator.settingsPath="~/.config/Cryptomator/settings.json" \
 	-Dcryptomator.ipcPortPath="~/.config/Cryptomator/ipcPort.bin" \
 	-Dcryptomator.logDir="~/.local/share/Cryptomator/logs" \

--- a/src/package/launcher-mac.sh
+++ b/src/package/launcher-mac.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 cd $(dirname $0)
 java \
-	-cp "libs/*" \
+	-cp "cryptomator-${project.version}.jar:libs/*" \
 	-Dcryptomator.settingsPath="~/Library/Application Support/Cryptomator/settings.json" \
 	-Dcryptomator.ipcPortPath="~/Library/Application Support/Cryptomator/ipcPort.bin" \
 	-Dcryptomator.logDir="~/Library/Logs/Cryptomator" \

--- a/src/package/launcher-win.bat
+++ b/src/package/launcher-win.bat
@@ -1,6 +1,6 @@
 @echo off
 java ^
-	-cp "libs/*" ^
+	-cp "cryptomator-${project.version}.jar:libs/*" ^
 	-Dcryptomator.settingsPath="~/AppData/Roaming/Cryptomator/settings.json" ^
 	-Dcryptomator.ipcPortPath="~/AppData/Roaming/Cryptomator/ipcPort.bin" ^
 	-Dcryptomator.logDir="~/AppData/Roaming/Cryptomator" ^


### PR DESCRIPTION
After reworking ['Single maven module'](https://github.com/cryptomator/cryptomator/commit/7fac6da4485366f9b649b12d73b1d55e84c34204) building and launching on the CLI fails with `ClassNotFoundException: org.cryptomator.launcher.Cryptomator`.

This is due to the cryptomator-VERSION-.jar missing in the cp of the launcher-scripts.