### PR TITLE
Feature/set cleartext filenamelength UI

### DIFF
--- a/src/main/java/org/cryptomator/common/Constants.java
+++ b/src/main/java/org/cryptomator/common/Constants.java
@@ -6,5 +6,7 @@ public interface Constants {
 	String MASTERKEY_BACKUP_SUFFIX = ".bkup";
 	String VAULTCONFIG_FILENAME = "vault.cryptomator";
 	byte[] PEPPER = new byte[0];
+	int UNLIMITED_CLEARTEXT_FILENAME_LENGTH = Integer.MAX_VALUE;
+	int UNKNOWN_CLEARTEXT_FILENAME_LENGTH_LIMIT = -1;
 
 }

--- a/src/main/java/org/cryptomator/common/vaults/Vault.java
+++ b/src/main/java/org/cryptomator/common/vaults/Vault.java
@@ -10,6 +10,7 @@ package org.cryptomator.common.vaults;
 
 import com.google.common.base.Strings;
 import org.apache.commons.lang3.SystemUtils;
+import org.cryptomator.common.Constants;
 import org.cryptomator.common.mountpoint.InvalidMountPointException;
 import org.cryptomator.common.settings.VaultSettings;
 import org.cryptomator.common.vaults.Volume.VolumeException;
@@ -53,7 +54,6 @@ public class Vault {
 
 	private static final Logger LOG = LoggerFactory.getLogger(Vault.class);
 	private static final Path HOME_DIR = Paths.get(SystemUtils.USER_HOME);
-	private static final int UNLIMITED_FILENAME_LENGTH = Integer.MAX_VALUE;
 
 	private final VaultSettings vaultSettings;
 	private final Provider<Volume> volumeProvider;
@@ -106,7 +106,7 @@ public class Vault {
 		Set<FileSystemFlags> flags = EnumSet.noneOf(FileSystemFlags.class);
 		if (vaultSettings.usesReadOnlyMode().get()) {
 			flags.add(FileSystemFlags.READONLY);
-		} else if(vaultSettings.maxCleartextFilenameLength().get() == -1) {
+		} else if(vaultSettings.maxCleartextFilenameLength().get() == Constants.UNKNOWN_CLEARTEXT_FILENAME_LENGTH_LIMIT) {
 			LOG.debug("Determining cleartext filename length limitations...");
 			var checker = new FileSystemCapabilityChecker();
 			int shorteningThreshold = getUnverifiedVaultConfig().allegedShorteningThreshold();
@@ -115,11 +115,11 @@ public class Vault {
 				int cleartextLimit = checker.determineSupportedCleartextFileNameLength(getPath());
 				vaultSettings.maxCleartextFilenameLength().set(cleartextLimit);
 			} else {
-				vaultSettings.maxCleartextFilenameLength().setValue(UNLIMITED_FILENAME_LENGTH);
+				vaultSettings.maxCleartextFilenameLength().setValue(Constants.UNLIMITED_CLEARTEXT_FILENAME_LENGTH);
 			}
 		}
 
-		if (vaultSettings.maxCleartextFilenameLength().get() < UNLIMITED_FILENAME_LENGTH) {
+		if (vaultSettings.maxCleartextFilenameLength().get() < Constants.UNLIMITED_CLEARTEXT_FILENAME_LENGTH) {
 			LOG.warn("Limiting cleartext filename length on this device to {}.", vaultSettings.maxCleartextFilenameLength().get());
 		}
 

--- a/src/main/java/org/cryptomator/ui/controls/NumericTextField.java
+++ b/src/main/java/org/cryptomator/ui/controls/NumericTextField.java
@@ -2,6 +2,7 @@ package org.cryptomator.ui.controls;
 
 import javafx.scene.control.TextField;
 import javafx.scene.control.TextFormatter;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 public class NumericTextField extends TextField {
@@ -14,6 +15,22 @@ public class NumericTextField extends TextField {
 
 	private TextFormatter.Change filterNumericTextChange(TextFormatter.Change change) {
 		return DIGIT_PATTERN.matcher(change.getText()).matches() ? change : null;
+	}
+
+	public int getAsIntUnchecked() {
+		return Integer.valueOf(textProperty().get());
+	}
+
+	public Optional<Integer> getAsInt() {
+		try {
+			return Optional.of(Integer.valueOf(textProperty().get()));
+		} catch (NumberFormatException e) {
+			return Optional.empty();
+		}
+	}
+
+	public void setText(int n) {
+		textProperty().set(Integer.toString(n));
 	}
 
 }

--- a/src/main/java/org/cryptomator/ui/vaultoptions/GeneralVaultOptionsController.java
+++ b/src/main/java/org/cryptomator/ui/vaultoptions/GeneralVaultOptionsController.java
@@ -1,6 +1,7 @@
 package org.cryptomator.ui.vaultoptions;
 
 import org.cryptomator.common.Constants;
+import org.cryptomator.common.settings.VaultSettings;
 import org.cryptomator.common.settings.WhenUnlocked;
 import org.cryptomator.common.vaults.Vault;
 import org.cryptomator.ui.common.FxController;
@@ -25,6 +26,7 @@ public class GeneralVaultOptionsController implements FxController {
 
 	private final Stage window;
 	private final Vault vault;
+	private final VaultSettings vaultSettings;
 	private final HealthCheckComponent.Builder healthCheckWindow;
 	private final ResourceBundle resourceBundle;
 
@@ -38,23 +40,24 @@ public class GeneralVaultOptionsController implements FxController {
 	GeneralVaultOptionsController(@VaultOptionsWindow Stage window, @VaultOptionsWindow Vault vault, HealthCheckComponent.Builder healthCheckWindow, ResourceBundle resourceBundle) {
 		this.window = window;
 		this.vault = vault;
+		this.vaultSettings = vault.getVaultSettings();
 		this.healthCheckWindow = healthCheckWindow;
 		this.resourceBundle = resourceBundle;
 	}
 
 	@FXML
 	public void initialize() {
-		vaultName.textProperty().set(vault.getVaultSettings().displayName().get());
+		vaultName.textProperty().set(vaultSettings.displayName().get());
 		vaultName.focusedProperty().addListener(this::trimAndSetVaultNameOnFocusLoss);
 		vaultName.setTextFormatter(new TextFormatter<>(this::removeWhitespaces));
 
-		unlockOnStartupCheckbox.selectedProperty().bindBidirectional(vault.getVaultSettings().unlockAfterStartup());
+		unlockOnStartupCheckbox.selectedProperty().bindBidirectional(vaultSettings.unlockAfterStartup());
 
 		actionAfterUnlockChoiceBox.getItems().addAll(WhenUnlocked.values());
-		actionAfterUnlockChoiceBox.valueProperty().bindBidirectional(vault.getVaultSettings().actionAfterUnlock());
+		actionAfterUnlockChoiceBox.valueProperty().bindBidirectional(vaultSettings.actionAfterUnlock());
 		actionAfterUnlockChoiceBox.setConverter(new WhenUnlockedConverter(resourceBundle));
 
-		int maxClearTextFileNameLength = vault.getVaultSettings().maxCleartextFilenameLength().get();
+		int maxClearTextFileNameLength = vaultSettings.maxCleartextFilenameLength().get();
 		filenameLengthRestrictionCheckbox.selectedProperty().set(maxClearTextFileNameLength != Constants.UNKNOWN_CLEARTEXT_FILENAME_LENGTH_LIMIT && maxClearTextFileNameLength != Constants.UNLIMITED_CLEARTEXT_FILENAME_LENGTH);
 		filenameLengthRestrictionCheckbox.selectedProperty().addListener(this::resetFileNameLimit);
 
@@ -64,21 +67,21 @@ public class GeneralVaultOptionsController implements FxController {
 
 	private void resetFileNameLimit(Observable observable, Boolean wasTicked, Boolean isTicked) {
 		if (!isTicked) {
-			vault.getVaultSettings().maxCleartextFilenameLength().set(Constants.UNKNOWN_CLEARTEXT_FILENAME_LENGTH_LIMIT);
+			vaultSettings.maxCleartextFilenameLength().set(Constants.UNKNOWN_CLEARTEXT_FILENAME_LENGTH_LIMIT);
 			filenameLengthField.setText("");
 		}
 	}
 
 	private void setFileNameLengthLimitOnFocusLoss(Observable observable, Boolean wasFocused, Boolean isFocused) {
 		if (!isFocused) {
-			vault.getVaultSettings().maxCleartextFilenameLength().set(filenameLengthField.getAsInt().orElse(Constants.UNLIMITED_CLEARTEXT_FILENAME_LENGTH));
+			vaultSettings.maxCleartextFilenameLength().set(filenameLengthField.getAsInt().orElse(Constants.UNLIMITED_CLEARTEXT_FILENAME_LENGTH));
 		}
 	}
 
 	private void trimAndSetVaultNameOnFocusLoss(Observable observable, Boolean wasFocused, Boolean isFocused) {
 		if (!isFocused) {
 			var trimmed = vaultName.getText().trim();
-			vault.getVaultSettings().displayName().set(trimmed);
+			vaultSettings.displayName().set(trimmed);
 		}
 	}
 

--- a/src/main/resources/fxml/vault_options_general.fxml
+++ b/src/main/resources/fxml/vault_options_general.fxml
@@ -32,6 +32,7 @@
 
 		<CheckBox text="%vaultOptions.general.unlockAfterStartup" fx:id="unlockOnStartupCheckbox"/>
 
+		<!-- TODO: move to its own tab -->
 		<HBox spacing="6" alignment="CENTER_LEFT">
 			<Label text="%vaultOptions.general.actionAfterUnlock"/>
 			<ChoiceBox fx:id="actionAfterUnlockChoiceBox"/>

--- a/src/main/resources/fxml/vault_options_general.fxml
+++ b/src/main/resources/fxml/vault_options_general.fxml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import org.cryptomator.ui.controls.NumericTextField?>
 <?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
 <?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.ChoiceBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
-<?import javafx.scene.control.Button?>
 <VBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
 	  fx:controller="org.cryptomator.ui.vaultoptions.GeneralVaultOptionsController"
@@ -19,6 +20,14 @@
 		<HBox spacing="6" alignment="CENTER_LEFT">
 			<Label text="%vaultOptions.general.vaultName"/>
 			<TextField fx:id="vaultName"/>
+		</HBox>
+		<CheckBox text="Restrict length of filenames inside vault" fx:id="filenameLengthRestrictionCheckbox"/>
+		<HBox spacing="6" alignment="CENTER_LEFT" visible="${filenameLengthRestrictionCheckbox.selected}" managed="${filenameLengthRestrictionCheckbox.selected}">
+			<padding>
+				<Insets left="12"/>
+			</padding>
+			<Label text="Maximum number of Characters:"/>
+			<NumericTextField fx:id="filenameLengthField" prefWidth="100" alignment="CENTER_RIGHT"/>
 		</HBox>
 
 		<CheckBox text="%vaultOptions.general.unlockAfterStartup" fx:id="unlockOnStartupCheckbox"/>

--- a/src/main/resources/fxml/vault_options_general.fxml
+++ b/src/main/resources/fxml/vault_options_general.fxml
@@ -21,12 +21,12 @@
 			<Label text="%vaultOptions.general.vaultName"/>
 			<TextField fx:id="vaultName"/>
 		</HBox>
-		<CheckBox text="Restrict length of filenames inside vault" fx:id="filenameLengthRestrictionCheckbox"/>
+		<CheckBox text="%vaultOptions.general.manualCleartextFilenameLength" fx:id="filenameLengthRestrictionCheckbox"/>
 		<HBox spacing="6" alignment="CENTER_LEFT" visible="${filenameLengthRestrictionCheckbox.selected}" managed="${filenameLengthRestrictionCheckbox.selected}">
 			<padding>
 				<Insets left="12"/>
 			</padding>
-			<Label text="Maximum number of Characters:"/>
+			<Label text="%vaultOptions.general.cleartextFilenameLengthDescription"/>
 			<NumericTextField fx:id="filenameLengthField" prefWidth="100" alignment="CENTER_RIGHT"/>
 		</HBox>
 

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -305,6 +305,8 @@ wrongFileAlert.link=For further assistance, visit
 ## General
 vaultOptions.general=General
 vaultOptions.general.vaultName=Vault Name
+vaultOptions.general.manualCleartextFilenameLength=Restrict Length of filenames inside vault
+vaultOptions.general.cleartextFilenameLengthDescription=Maximum Number of Characters
 vaultOptions.general.unlockAfterStartup=Unlock vault when starting Cryptomator
 vaultOptions.general.actionAfterUnlock=After successful unlock
 vaultOptions.general.actionAfterUnlock.ignore=Do nothing


### PR DESCRIPTION
This PR adds the functionality, to alter the cleartext filename length limit in the ui instead of editing the JSON directly.

![grafik](https://user-images.githubusercontent.com/9036915/121187734-a8dad600-c868-11eb-9cd2-f7de4a50a10d.png)

![grafik](https://user-images.githubusercontent.com/9036915/121187809-bd1ed300-c868-11eb-82a5-d9b5074a57e6.png)

As long as the checkbox is not ticked, Cryptomator decides on its own wether this is a limit or not. Ticking the checkbox reveals the textfield to enter a positive integer. 
If no number is entered and the options windows is closed, the checkbox is unticked.
Unticking the checkbox sets the limit to -1 (e.g. unknown), meaning in the next unlock the value will be redetermined.
The option is saved as soon as the focus changes to another ui element.