### PR TITLE
Sign tarball in release using GPG

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,11 +76,11 @@ jobs:
           name: buildkit-win.zip
           path: .
       - name: Create tarball
-        run: git archive --prefix="cryptomator-${{ github.ref }}/" -o ${{ github.ref }}.tar.gz ${{ github.ref }}
+        run: git archive --prefix="cryptomator-${{ github.ref }}/" -o "cryptomator-${{ github.ref }}.tar.gz" ${{ github.ref }}
       - name: Sign tarball with key 615D449FE6E6A235
         run: |
           echo "${GPG_PRIVATE_KEY}" | gpg --batch --quiet --import
-          echo "${GPG_PASSPHRASE}" | gpg --batch --quiet --passphrase-fd 0 --pinentry-mode loopback -u 615D449FE6E6A235 --detach-sign -a ${{ github.ref }}.tar.gz
+          echo "${GPG_PASSPHRASE}" | gpg --batch --quiet --passphrase-fd 0 --pinentry-mode loopback -u 615D449FE6E6A235 --detach-sign -a "cryptomator-${{ github.ref }}.tar.gz"
         env:
           GPG_PRIVATE_KEY: ${{ secrets.RELEASES_GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.RELEASES_GPG_PASSPHRASE }}
@@ -144,6 +144,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ github.ref }}.tar.gz.asc
-          asset_name: ${{ github.ref }}.tar.gz.asc
+          asset_path: "cryptomator-${{ github.ref }}.tar.gz.asc"
+          asset_name: "cryptomator-${{ github.ref }}.tar.gz.asc"
           asset_content_type: application/octet-stream

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,15 +77,13 @@ jobs:
           path: .
       - name: Create tarball
         run: git archive --prefix="cryptomator-${{ github.ref }}/" -o ${{ github.ref }}.tar.gz ${{ github.ref }}
-      - name: Prepare GPG-Agent to sign tarball with key 615D449FE6E6A235
+      - name: Sign tarball with key 615D449FE6E6A235
         run: |
           echo "${GPG_PRIVATE_KEY}" | gpg --batch --quiet --import
-          echo "${GPG_PASSPHRASE}" | gpg --batch --quiet --passphrase-fd 0 --pinentry-mode loopback -u 615D449FE6E6A235 --dry-run --sign ${{ github.ref }}.tar.gz
+          echo "${GPG_PASSPHRASE}" | gpg --batch --quiet --passphrase-fd 0 --pinentry-mode loopback -u 615D449FE6E6A235 --detach-sign -a ${{ github.ref }}.tar.gz
         env:
           GPG_PRIVATE_KEY: ${{ secrets.RELEASES_GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.RELEASES_GPG_PASSPHRASE }}
-      - name: Sign tarball
-        run: gpg --batch --quiet --pinentry-mode loopback -u 615D449FE6E6A235 --detach-sign -a ${{ github.ref }}.tar.gz
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,13 +52,14 @@ jobs:
         with:
           name: buildkit-win.zip
           path: target/buildkit-win.zip
-          
+
   release:
     name: Draft a Release on GitHub Releases
     runs-on: ubuntu-latest
     needs: build
     if: startsWith(github.ref, 'refs/tags/') && github.repository == 'cryptomator/cryptomator'
     steps:
+      - uses: actions/checkout@v2
       - name: Download buildkit-linux.zip
         uses: actions/download-artifact@v1
         with:
@@ -74,6 +75,17 @@ jobs:
         with:
           name: buildkit-win.zip
           path: .
+      - name: Create tarball
+        run: git archive --prefix="cryptomator-${{ github.ref }}/" -o ${{ github.ref }}.tar.gz ${{ github.ref }}
+      - name: Prepare GPG-Agent to sign tarball with key 615D449FE6E6A235
+        run: |
+          echo "${GPG_PRIVATE_KEY}" | gpg --batch --quiet --import
+          echo "${GPG_PASSPHRASE}" | gpg --batch --quiet --passphrase-fd 0 --pinentry-mode loopback -u 615D449FE6E6A235 --dry-run --sign ${{ github.ref }}.tar.gz
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.RELEASES_GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.RELEASES_GPG_PASSPHRASE }}
+      - name: Sign tarball
+        run: gpg --batch --quiet --pinentry-mode loopback -u 615D449FE6E6A235 --detach-sign -a ${{ github.ref }}.tar.gz
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -128,3 +140,12 @@ jobs:
           asset_path: buildkit-win.zip
           asset_name: buildkit-win.zip
           asset_content_type: application/zip
+      - name: Upload tarball signature to GitHub Releases
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.ref }}.tar.gz.asc
+          asset_name: ${{ github.ref }}.tar.gz.asc
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
As some users build this project from source using a package manager like `pacman` on arch based linux distros, we could provide a  GPG signature next to the source tarball, so that those package managers can automatically verify the signature of the downloaded sources and not check the SHA256 provided by the packager.

With this PR, a `cryptomator-${{ github.ref }}.tar.gz.asc` file e.g. `cryptomator-1.6.0.tar.gz.asc` will be added to the release assets.