### PR TITLE
Including pluginDir to linux/appimage/build.sh

### DIFF
--- a/dist/linux/appimage/build.sh
+++ b/dist/linux/appimage/build.sh
@@ -41,6 +41,7 @@ ${JAVA_HOME}/bin/jpackage \
     --app-version "${VERSION}.${REVISION_NO}" \
     --java-options "-Dfile.encoding=\"utf-8\"" \
     --java-options "-Dcryptomator.logDir=\"~/.local/share/Cryptomator/logs\"" \
+    --java-options "-Dcryptomator.pluginDir=\"~/.local/share/Cryptomator/plugins\"" \
     --java-options "-Dcryptomator.settingsPath=\"~/.config/Cryptomator/settings.json:~/.Cryptomator/settings.json\"" \
     --java-options "-Dcryptomator.ipcSocketPath=\"~/.config/Cryptomator/ipc.socket\"" \
     --java-options "-Dcryptomator.mountPointsDir=\"~/.local/share/Cryptomator/mnt\"" \

--- a/dist/linux/appimage/build.sh
+++ b/dist/linux/appimage/build.sh
@@ -68,10 +68,9 @@ rm -r jni/x86_64-Linux
 # load AppImageTool
 curl -L https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage -o /tmp/appimagetool.AppImage
 chmod +x /tmp/appimagetool.AppImage
-/tmp/appimagetool.AppImage --appimage-extract
 
 # create AppImage
-./squashfs-root/AppRun \
+/tmp/appimagetool.AppImage \
     Cryptomator.AppDir \
     cryptomator-SNAPSHOT-x86_64.AppImage \
     -u 'gh-releases-zsync|cryptomator|cryptomator|latest|cryptomator-*-x86_64.AppImage.zsync'

--- a/dist/linux/appimage/build.sh
+++ b/dist/linux/appimage/build.sh
@@ -68,9 +68,10 @@ rm -r jni/x86_64-Linux
 # load AppImageTool
 curl -L https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage -o /tmp/appimagetool.AppImage
 chmod +x /tmp/appimagetool.AppImage
+/tmp/appimagetool.AppImage --appimage-extract
 
 # create AppImage
-/tmp/appimagetool.AppImage \
+./squashfs-root/AppRun \
     Cryptomator.AppDir \
     cryptomator-SNAPSHOT-x86_64.AppImage \
     -u 'gh-releases-zsync|cryptomator|cryptomator|latest|cryptomator-*-x86_64.AppImage.zsync'


### PR DESCRIPTION
The `dist/linux/appimage/build.sh` file fails to build an app image the way it is.

I found the changes in this Pull Request from `.github/workflows/release.yml`.
