### PR TITLE
Remove IPC socket path before creation

### DIFF
--- a/src/main/java/org/cryptomator/ipc/IpcCommunicator.java
+++ b/src/main/java/org/cryptomator/ipc/IpcCommunicator.java
@@ -44,8 +44,8 @@ public interface IpcCommunicator extends Closeable {
 		}
 		// Didn't get any connection yet? I.e. we're the first app instance, so let's launch a server:
 		try {
-			final var socketPath = socketPaths.iterator().next(); // ensure path does not exist before creating it
-			Files.deleteIfExists(socketPath);
+			final var socketPath = socketPaths.iterator().next();
+			Files.deleteIfExists(socketPath); // ensure path does not exist before creating it
 			return Server.create(socketPath);
 		} catch (IOException e) {
 			LOG.warn("Failed to create IPC server", e);


### PR DESCRIPTION
When Cryptomator crashes (in case of an unsuccessful mount), the socket path will not be destroyed since the after close handlers won't be called. When starting up Cryptomator again the ipc path still exists and the application is not able to create an ipc listener since it will receive a `BindException`. This fix ensures that the path is always deleted if it is present so it is possible for Cryptomator to create the ipc path. An alternative would be to catch the `BindException` and then delete the file and call the create method again. 

Additionally: this removes the need to do the cleanup in the after close handler of the application, though leaving files hanging while the application is not running is generally not so nice, so I decided to keep that functionality.