### PR TITLE
Lambda can be replaced with method reference

### DIFF
--- a/src/main/java/org/cryptomator/common/vaults/VaultStats.java
+++ b/src/main/java/org/cryptomator/common/vaults/VaultStats.java
@@ -64,7 +64,7 @@ public class VaultStats {
 			});
 		} else {
 			LOG.debug("stop recording stats");
-			Platform.runLater(() -> updateService.cancel());
+			Platform.runLater(updateService::cancel);
 		}
 	}
 

--- a/src/main/java/org/cryptomator/ui/traymenu/TrayMenuController.java
+++ b/src/main/java/org/cryptomator/ui/traymenu/TrayMenuController.java
@@ -128,7 +128,7 @@ class TrayMenuController {
 	}
 
 	void showMainWindow(@SuppressWarnings("unused") ActionEvent actionEvent) {
-		showMainAppAndThen(app -> app.showMainWindow());
+		showMainAppAndThen(FxApplication::showMainWindow);
 	}
 
 	private void showPreferencesWindow(@SuppressWarnings("unused") EventObject actionEvent) {


### PR DESCRIPTION
It provides more clean and readeable code and follows the Item 43: Prefer method references to lambdas from Effective Java 
