### PR TITLE
PPA build for Ubuntu Bionic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,7 +207,7 @@ jobs:
   ppa:
     name: Upload source package to PPA
     needs: [buildkit, metadata]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: install build tools

--- a/dist/linux/debian/changelog
+++ b/dist/linux/debian/changelog
@@ -1,4 +1,4 @@
-cryptomator (${PPA_VERSION}) focal; urgency=low
+cryptomator (${PPA_VERSION}) bionic; urgency=low
 
   * Full changelog can be found on https://github.com/cryptomator/cryptomator/releases
 


### PR DESCRIPTION
OpenJDK 17 is available on Ubuntu Bionic, so we should be able to build the PPA version of Cryptomator 1.6.x for Bionic as well.

If this experiment succeeds, this fixes #1905. It should be tested using [the `cryptomator-beta` PPA](https://launchpad.net/~sebastian-stenzel/+archive/ubuntu/cryptomator-beta/+packages)

We can then copy binaries from Bionic to Focal (and newer releases), assuming there are no breaking changes in dependencies.