### PR TITLE
Add `cryptomator-vault` alias to etc/hosts during (re)install

### DIFF
--- a/dist/win/build.bat
+++ b/dist/win/build.bat
@@ -1,2 +1,2 @@
 @echo off
-powershell -NoExit -ExecutionPolicy Unrestricted -Command .\build.ps1
+powershell -NoLogo -NoExit -ExecutionPolicy Unrestricted -Command .\build.ps1

--- a/dist/win/build.ps1
+++ b/dist/win/build.ps1
@@ -68,7 +68,6 @@ Copy-Item "$buildDir\..\..\target\cryptomator-*.jar" -Destination "$buildDir\..\
 Copy-Item "contrib\*" -Destination "Cryptomator"
 attrib -r "Cryptomator\Cryptomator.exe"
 
-
 # create .msi bundle
 $Env:JP_WIXWIZARD_RESOURCES = "$buildDir\resources"
 & "$Env:JAVA_HOME\bin\jpackage" `

--- a/dist/win/contrib/patchHosts.bat
+++ b/dist/win/contrib/patchHosts.bat
@@ -1,0 +1,3 @@
+@echo off
+cd %~dp0
+powershell -NoLogo -NonInteractive -ExecutionPolicy Unrestricted -Command .\patchHosts.ps1

--- a/dist/win/contrib/patchHosts.ps1
+++ b/dist/win/contrib/patchHosts.ps1
@@ -1,0 +1,16 @@
+#Requires -RunAsAdministrator
+
+$sysdir = [Environment]::SystemDirectory
+$hostsFile = "$sysdir\drivers\etc\hosts"
+$aliasLine = '127.0.0.1 cryptomator-vault'
+
+foreach ($line in Get-Content $hostsFile) {
+	if ($line -eq $aliasLine){
+		Write-Output 'No changes necessary'
+        exit 0
+    }
+}
+
+Add-Content -Path $hostsFile -Encoding ascii -Value "`r`n$aliasLine"
+Write-Output 'Added alias to hosts file'
+exit 0

--- a/dist/win/resources/main.wxs
+++ b/dist/win/resources/main.wxs
@@ -123,6 +123,8 @@
     <?ifdef JpUpdateURL ?>
       <CustomAction Id="JpSetARPURLUPDATEINFO" Property="ARPURLUPDATEINFO" Value="$(var.JpUpdateURL)" />
     <?endif?>
+	
+	<CustomAction Id="PatchHostsFile" Impersonate="no" ExeCommand="[INSTALLDIR]patchHosts.bat" Directory="INSTALLDIR" Execute="deferred" Return="asyncWait" />
 
     <?ifdef JpIcon ?>
     <Property Id="ARPPRODUCTICON" Value="JpARPPRODUCTICON"/>
@@ -153,6 +155,8 @@
       <Custom Action="JpDisallowDowngrade" After="FindRelatedProducts">JP_DOWNGRADABLE_FOUND</Custom>
       <?endif?>
       <RemoveExistingProducts Before="CostInitialize"/>
+	  
+	  <Custom Action="PatchHostsFile" After="InstallFiles">NOT Installed OR REINSTALL</Custom>
     </InstallExecuteSequence>
 
     <WixVariable Id="WixUIBannerBmp" Value="$(env.JP_WIXWIZARD_RESOURCES)\banner.bmp" />

--- a/dist/win/resources/main.wxs
+++ b/dist/win/resources/main.wxs
@@ -123,8 +123,8 @@
     <?ifdef JpUpdateURL ?>
       <CustomAction Id="JpSetARPURLUPDATEINFO" Property="ARPURLUPDATEINFO" Value="$(var.JpUpdateURL)" />
     <?endif?>
-	
-	<CustomAction Id="PatchHostsFile" Impersonate="no" ExeCommand="[INSTALLDIR]patchHosts.bat" Directory="INSTALLDIR" Execute="deferred" Return="asyncWait" />
+
+    <CustomAction Id="PatchHostsFile" Impersonate="no" ExeCommand="[INSTALLDIR]patchHosts.bat" Directory="INSTALLDIR" Execute="deferred" Return="asyncWait" />
 
     <?ifdef JpIcon ?>
     <Property Id="ARPPRODUCTICON" Value="JpARPPRODUCTICON"/>
@@ -155,8 +155,8 @@
       <Custom Action="JpDisallowDowngrade" After="FindRelatedProducts">JP_DOWNGRADABLE_FOUND</Custom>
       <?endif?>
       <RemoveExistingProducts Before="CostInitialize"/>
-	  
-	  <Custom Action="PatchHostsFile" After="InstallFiles">NOT Installed OR REINSTALL</Custom>
+
+      <Custom Action="PatchHostsFile" After="InstallFiles">NOT Installed OR REINSTALL</Custom>
     </InstallExecuteSequence>
 
     <WixVariable Id="WixUIBannerBmp" Value="$(env.JP_WIXWIZARD_RESOURCES)\banner.bmp" />


### PR DESCRIPTION
This re-adds a workaround to the .msi installer, that we [introduced in version 1.3.0](https://cryptomator.org/blog/2017/07/01/release-1.3.0/#windows).

A new script is added to the installation dir, which will be invoked during installation with elevated permissions. If not already present, it'll add an entry to Windows' hosts file.