### PR TITLE
Handle exception when force-locking

### DIFF
--- a/src/main/java/org/cryptomator/ui/common/UserInteractionLock.java
+++ b/src/main/java/org/cryptomator/ui/common/UserInteractionLock.java
@@ -16,7 +16,11 @@ public class UserInteractionLock<E extends Enum> {
 	private volatile E state;
 
 	public UserInteractionLock(E initialValue) {
-		state = initialValue;
+		this.state = initialValue;
+	}
+
+	public synchronized void reset(E value) {
+		this.state = value;
 	}
 
 	public void interacted(E result) {

--- a/src/main/java/org/cryptomator/ui/lock/LockForcedController.java
+++ b/src/main/java/org/cryptomator/ui/lock/LockForcedController.java
@@ -35,7 +35,13 @@ public class LockForcedController implements FxController {
 	}
 
 	@FXML
-	public void confirmForcedLock() {
+	public void retry() {
+		forceLockDecisionLock.interacted(LockModule.ForceLockDecision.RETRY);
+		window.close();
+	}
+
+	@FXML
+	public void force() {
 		forceLockDecisionLock.interacted(LockModule.ForceLockDecision.FORCE);
 		window.close();
 	}
@@ -52,6 +58,10 @@ public class LockForcedController implements FxController {
 
 	public String getVaultName() {
 		return vault.getDisplayName();
+	}
+
+	public boolean isForceSupported() {
+		return vault.supportsForcedUnmount();
 	}
 
 }

--- a/src/main/java/org/cryptomator/ui/lock/LockModule.java
+++ b/src/main/java/org/cryptomator/ui/lock/LockModule.java
@@ -28,6 +28,7 @@ abstract class LockModule {
 
 	enum ForceLockDecision {
 		CANCEL,
+		RETRY,
 		FORCE;
 	}
 

--- a/src/main/java/org/cryptomator/ui/lock/LockWorkflow.java
+++ b/src/main/java/org/cryptomator/ui/lock/LockWorkflow.java
@@ -62,6 +62,7 @@ public class LockWorkflow extends Task<Void> {
 			LOG.info("Locking {} failed (forced: {}).", vault.getDisplayName(), forced, e);
 			var decision = askUserForAction();
 			switch (decision) {
+				case RETRY -> lock(false);
 				case FORCE -> lock(true);
 				case CANCEL -> cancel(false);
 			}

--- a/src/main/java/org/cryptomator/ui/lock/LockWorkflow.java
+++ b/src/main/java/org/cryptomator/ui/lock/LockWorkflow.java
@@ -51,20 +51,25 @@ public class LockWorkflow extends Task<Void> {
 
 	@Override
 	protected Void call() throws Volume.VolumeException, InterruptedException, LockNotCompletedException {
-		try {
-			vault.lock(false);
-		} catch (Volume.VolumeException | LockNotCompletedException e) {
-			LOG.debug("Regular lock of {} failed.", vault.getDisplayName(), e);
-			var decision = askUserForAction();
-			switch (decision) {
-				case FORCE -> vault.lock(true);
-				case CANCEL -> cancel(false);
-			}
-		}
+		lock(false);
 		return null;
 	}
 
+	private void lock(boolean forced) throws InterruptedException {
+		try {
+			vault.lock(forced);
+		} catch (Volume.VolumeException | LockNotCompletedException e) {
+			LOG.info("Locking {} failed (forced: {}).", vault.getDisplayName(), forced, e);
+			var decision = askUserForAction();
+			switch (decision) {
+				case FORCE -> lock(true);
+				case CANCEL -> cancel(false);
+			}
+		}
+	}
+
 	private LockModule.ForceLockDecision askUserForAction() throws InterruptedException {
+		forceLockDecisionLock.reset(null);
 		// show forcedLock dialogue ...
 		Platform.runLater(() -> {
 			lockWindow.setScene(lockForcedScene.get());

--- a/src/main/resources/fxml/lock_forced.fxml
+++ b/src/main/resources/fxml/lock_forced.fxml
@@ -33,11 +33,11 @@
 		</HBox>
 
 		<VBox alignment="BOTTOM_CENTER" VBox.vgrow="ALWAYS">
-			<ButtonBar buttonMinWidth="120" buttonOrder="+CI">
+			<ButtonBar buttonMinWidth="100" buttonOrder="+CIU">
 				<buttons>
 					<Button text="%generic.button.cancel" ButtonBar.buttonData="CANCEL_CLOSE" defaultButton="true" cancelButton="true" onAction="#cancel"/>
-					<!-- TODO: third button with retry? -->
-					<Button text="%lock.forced.confirmBtn" ButtonBar.buttonData="FINISH" onAction="#confirmForcedLock"/>
+					<Button text="%lock.forced.retryBtn" ButtonBar.buttonData="FINISH" onAction="#retry"/>
+					<Button text="%lock.forced.forceBtn" ButtonBar.buttonData="OTHER" onAction="#force" disable="${!controller.forceSupported}"/>
 				</buttons>
 			</ButtonBar>
 		</VBox>

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -118,7 +118,7 @@ unlock.error.invalidMountPoint.existing=Mount point "%s" already exists or paren
 
 # Lock
 ## Force
-lock.forced.heading=Graceful lock failed
+lock.forced.heading=Lock failed
 lock.forced.message=Locking "%s" was blocked by pending operations or open files. You can force lock this vault, however interrupting I/O may result in the loss of unsaved data.
 lock.forced.retryBtn=Retry
 lock.forced.forceBtn=Force Lock

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -120,7 +120,8 @@ unlock.error.invalidMountPoint.existing=Mount point "%s" already exists or paren
 ## Force
 lock.forced.heading=Graceful lock failed
 lock.forced.message=Locking "%s" was blocked by pending operations or open files. You can force lock this vault, however interrupting I/O may result in the loss of unsaved data.
-lock.forced.confirmBtn=Force Lock
+lock.forced.retryBtn=Retry
+lock.forced.forceBtn=Force Lock
 ## Failure
 lock.fail.heading=Locking vault failed.
 lock.fail.message=Vault "%s" could not be locked. Ensure unsaved work is saved elsewhere and important Read/Write operations are finished. In order to close the vault, kill the Cryptomator process.


### PR DESCRIPTION
This fixes #1934, essentially by adding a retry loop:

![Retry Unlock Flow](https://user-images.githubusercontent.com/1204330/142204193-608180fa-4b91-4579-adf6-535331caa6d5.png)

Furthermore this adds a (graceful) retry button:

<img width="511" alt="Screenshot 2021-11-17 at 14 02 07" src="https://user-images.githubusercontent.com/1204330/142205837-9046663d-1de3-4f7f-8c5b-8d125a0c0591.png">
