### PR TITLE
Update actions/setup-java and use Temurin in release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,15 +39,11 @@ jobs:
           profile: mac
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
-      - uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          cache: 'maven'
       - name: Ensure to use tagged version
         run: mvn versions:set -DnewVersion=${GITHUB_REF##*/} # use shell parameter expansion to strip of 'refs/tags'
         if: startsWith(github.ref, 'refs/tags/')
@@ -156,8 +152,9 @@ jobs:
             --resource-dir dist/mac/resources
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
       - name: Download ${{ matrix.profile }}-buildkit
         uses: actions/download-artifact@v2
@@ -502,8 +499,9 @@ jobs:
           name: win-appdir
       - name: Untar appdir.tar
         run: tar -xvf appdir.tar
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
       - name: Patch Application Directory
         run: |


### PR DESCRIPTION
This solves an issue with the `jlinked` runtime based on `OpenJDK Runtime Environment Zulu17.30+51-CA (build 17.0.1+12-LTS)`, which results during launch on macOS:

```
Error occurred during initialization of boot layer
java.lang.module.FindException: Hash of javafx.base (3af64106ce76d7e0b3d38ae5a5d89f7ddf5d0109e0b0088b6e392847a462cc13) differs to expected hash (d75b7ed00f1b64bc63be63af589e2469f152516d447877894ff1bfd147bdba3b) recorded in java.base
```

Furthermore, we no longer need a `cache` step, as this is now supported with the newer `setup-java` action.