### PR TITLE
Update copyright years from 2021 to 2022 to reflect the new year

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,7 @@ jobs:
           --dest appdir
           --name Cryptomator
           --vendor "Skymatic GmbH"
-          --copyright "(C) 2016 - 2021 Skymatic GmbH"
+          --copyright "(C) 2016 - 2022 Skymatic GmbH"
           --java-options "-Xss5m"
           --java-options "-Xmx256m"
           --java-options "-Dcryptomator.appVersion=\"${{ needs.metadata.outputs.semVerStr }}\""
@@ -529,7 +529,7 @@ jobs:
           --dest installer
           --name Cryptomator
           --vendor "Skymatic GmbH"
-          --copyright "(C) 2016 - 2021 Skymatic GmbH"
+          --copyright "(C) 2016 - 2022 Skymatic GmbH"
           --app-version "${{ needs.metadata.outputs.semVerNum }}"
           --win-menu
           --win-dir-chooser

--- a/dist/linux/appimage/build.sh
+++ b/dist/linux/appimage/build.sh
@@ -35,7 +35,7 @@ ${JAVA_HOME}/bin/jpackage \
     --dest . \
     --name Cryptomator \
     --vendor "Skymatic GmbH" \
-    --copyright "(C) 2016 - 2021 Skymatic GmbH" \
+    --copyright "(C) 2016 - 2022 Skymatic GmbH" \
     --java-options "-Xss5m" \
     --java-options "-Xmx256m" \
     --app-version "${VERSION}.${REVISION_NO}" \

--- a/dist/linux/debian/copyright
+++ b/dist/linux/debian/copyright
@@ -4,11 +4,11 @@ Upstream-Contact: Cryptomator <info@cryptomator.org>
 Source: https://cryptomator.org
 
 Files: *
-Copyright: 2016-2021 Skymatic GmbH
+Copyright: 2016-2022 Skymatic GmbH
 License: GPL-3+
 
 Files: debian/org.cryptomator.Cryptomator.appdata.xml
-Copyright: 2016-2021 Skymatic GmbH
+Copyright: 2016-2022 Skymatic GmbH
 License: FSFAP
 
 License: GPL-3+

--- a/dist/linux/debian/rules
+++ b/dist/linux/debian/rules
@@ -29,7 +29,7 @@ override_dh_auto_build:
 		--dest . \
 		--name cryptomator \
 		--vendor "Skymatic GmbH" \
-		--copyright "(C) 2016 - 2021 Skymatic GmbH" \
+		--copyright "(C) 2016 - 2022 Skymatic GmbH" \
 		--java-options "-Xss5m" \
 		--java-options "-Xmx256m" \
 		--java-options "-Dfile.encoding=\"utf-8\"" \

--- a/dist/mac/dmg/build.sh
+++ b/dist/mac/dmg/build.sh
@@ -54,7 +54,7 @@ ${JAVA_HOME}/bin/jpackage \
     --dest . \
     --name Cryptomator \
     --vendor "Skymatic GmbH" \
-    --copyright "(C) 2016 - 2021 Skymatic GmbH" \
+    --copyright "(C) 2016 - 2022 Skymatic GmbH" \
     --java-options "-Xss5m" \
     --java-options "-Xmx256m" \
     --java-options "-Dcryptomator.appVersion=\"${VERSION_NO}\"" \

--- a/dist/mac/dmg/resources/license.rtf
+++ b/dist/mac/dmg/resources/license.rtf
@@ -10,7 +10,7 @@
 \f1\b0 \
 \
 
-\f0\b \'a9 2016 \'96 2021 Skymatic GmbH
+\f0\b \'a9 2016 \'96 2022 Skymatic GmbH
 \f1\b0 \
 \
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.\

--- a/dist/win/build.ps1
+++ b/dist/win/build.ps1
@@ -47,7 +47,7 @@ Copy-Item "$buildDir\..\..\target\cryptomator-*.jar" -Destination "$buildDir\..\
 	--dest . `
 	--name Cryptomator `
 	--vendor "Skymatic GmbH" `
-	--copyright "(C) 2016 - 2021 Skymatic GmbH" `
+	--copyright "(C) 2016 - 2022 Skymatic GmbH" `
 	--java-options "-Xss5m" `
 	--java-options "-Xmx256m" `
 	--java-options "-Dcryptomator.appVersion=`"$semVerNo`"" `
@@ -78,7 +78,7 @@ $Env:JP_WIXWIZARD_RESOURCES = "$buildDir\resources"
 	--dest installer `
 	--name Cryptomator `
 	--vendor "Skymatic GmbH" `
-	--copyright "(C) 2016 - 2021 Skymatic GmbH" `
+	--copyright "(C) 2016 - 2022 Skymatic GmbH" `
 	--app-version "$semVerNo" `
 	--win-menu `
 	--win-dir-chooser `

--- a/dist/win/resources/license.rtf
+++ b/dist/win/resources/license.rtf
@@ -3,7 +3,7 @@
 {\*\generator Riched20 10.0.17134}\viewkind4\uc1 
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\b\fs16\lang7 Cryptomator is distributed under the GPLv3 License, found below. Please see the bottom of this document for any other license applicable to code used within Cryptomator.\b0\par
 \par
-\b\'a9 2016 \endash  2021 Skymatic GmbH\b0\par
+\b\'a9 2016 \endash  2022 Skymatic GmbH\b0\par
 \par
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.\par
 \par
@@ -82,4 +82,3 @@ You should have received a copy of the GNU General Public License along with thi
 \tab SIL OFL 1.1 License:\par
 \tab\tab - Font Awesome 5.12.0 ({{\field{\*\fldinst{HYPERLINK https://fontawesome.com/ }}{\fldrslt{https://fontawesome.com/\ul0\cf0}}}}\f0\fs16 )\b\par
 }
- 

--- a/src/main/resources/fxml/preferences_about.fxml
+++ b/src/main/resources/fxml/preferences_about.fxml
@@ -22,7 +22,7 @@
 			</ImageView>
 			<VBox spacing="3" HBox.hgrow="ALWAYS" alignment="CENTER_LEFT">
 				<FormattedLabel styleClass="label-large" format="Cryptomator %s" arg1="${controller.applicationVersion}"/>
-				<Label text="© 2016 – 2021 Skymatic GmbH"/>
+				<Label text="© 2016 – 2022 Skymatic GmbH"/>
 			</VBox>
 		</HBox>
 


### PR DESCRIPTION
I went through the various license files and UI files and updated the outdated "(C) 2016 - 2021 Skymatic GmbH" to "(C) 2016 - 2022 Skymatic GmbH".