### PR TITLE
Update JavaFX to 17.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ pom.xml.versionsBackup
 .idea/uiDesigner.xml
 .idea/**/libraries/
 *.iml
+
+hs_err_pid*.log

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 		<cryptomator.webdav.version>1.2.6</cryptomator.webdav.version>
 
 		<!-- 3rd party dependencies -->
-		<javafx.version>17.0.1</javafx.version>
+		<javafx.version>17.0.2</javafx.version>
 		<commons-lang3.version>3.12.0</commons-lang3.version>
 		<jwt.version>3.18.2</jwt.version>
 		<easybind.version>2.2</easybind.version>

--- a/src/main/resources/license/THIRD-PARTY.txt
+++ b/src/main/resources/license/THIRD-PARTY.txt
@@ -62,10 +62,10 @@ Cryptomator uses 40 third-party dependencies under the following licenses:
         GPLv2:
 			- jnr-posix (com.github.jnr:jnr-posix:3.1.10 - http://nexus.sonatype.org/oss-repository-hosting.html/jnr-posix)
         GPLv2+CE:
-			- javafx-base (org.openjfx:javafx-base:17.0.1 - https://openjdk.java.net/projects/openjfx/javafx-base/)
-			- javafx-controls (org.openjfx:javafx-controls:17.0.1 - https://openjdk.java.net/projects/openjfx/javafx-controls/)
-			- javafx-fxml (org.openjfx:javafx-fxml:17.0.1 - https://openjdk.java.net/projects/openjfx/javafx-fxml/)
-			- javafx-graphics (org.openjfx:javafx-graphics:17.0.1 - https://openjdk.java.net/projects/openjfx/javafx-graphics/)
+			- javafx-base (org.openjfx:javafx-base:17.0.2 - https://openjdk.java.net/projects/openjfx/javafx-base/)
+			- javafx-controls (org.openjfx:javafx-controls:17.0.2 - https://openjdk.java.net/projects/openjfx/javafx-controls/)
+			- javafx-fxml (org.openjfx:javafx-fxml:17.0.2 - https://openjdk.java.net/projects/openjfx/javafx-fxml/)
+			- javafx-graphics (org.openjfx:javafx-graphics:17.0.2 - https://openjdk.java.net/projects/openjfx/javafx-graphics/)
         LGPL 2.1:
 			- jnr-posix (com.github.jnr:jnr-posix:3.1.10 - http://nexus.sonatype.org/oss-repository-hosting.html/jnr-posix)
         LGPL-2.1-or-later:


### PR DESCRIPTION
Updating JavaFX inside Maven to 17.0.2 to fix [JDK-8275723](https://bugs.openjdk.java.net/browse/JDK-8275723). This is only relevant for development on a Mac with an M1 processor.