### PR TITLE
Update Cryptomator screenshots for flathub, taken of 1.6.5

### DIFF
--- a/dist/linux/common/org.cryptomator.Cryptomator.metainfo.xml
+++ b/dist/linux/common/org.cryptomator.Cryptomator.metainfo.xml
@@ -44,11 +44,11 @@
 	<screenshots>
 		<screenshot>
 			<caption>Light theme</caption>
-			<image>https://cryptomator.org/presskit/linux-screenshot-1.png</image>
+			<image>https://user-images.githubusercontent.com/11858409/156986109-6e58f59c-8b8c-4501-b33b-bb1e33007cea.png</image>
 		</screenshot>
 		<screenshot>
 			<caption>Dark theme</caption>
-			<image>https://cryptomator.org/presskit/linux-screenshot-2.png</image>
+			<image>https://user-images.githubusercontent.com/11858409/156986113-6c5d7801-86e0-4643-bc2f-aff9d95d3ce0.png</image>
 		</screenshot>
 	</screenshots>
 


### PR DESCRIPTION
The shots do appstream-util validate.

To use the new screenshots for flathub, we need to merge this PR and update this hash afterwards:
https://github.com/flathub/org.cryptomator.Cryptomator/blob/f11f3f9ffdf507194758b73b7771f12c4afc0c10/org.cryptomator.Cryptomator.yaml#L95