### PR TITLE
Show vault locked/unlocked state in the vault title in the tray menu

### DIFF
--- a/src/main/java/org/cryptomator/ui/traymenu/TrayMenuController.java
+++ b/src/main/java/org/cryptomator/ui/traymenu/TrayMenuController.java
@@ -91,7 +91,7 @@ class TrayMenuController {
 			unlockItem.addActionListener(createActionListenerForVault(vault, this::unlockVault));
 			submenu.add(unlockItem);
 		} else if (vault.isUnlocked()) {
-			submenu.setLabel("*".concat(submenu.getLabel()));
+			submenu.setLabel("* ".concat(submenu.getLabel()));
 
 			MenuItem lockItem = new MenuItem(resourceBundle.getString("traymenu.vault.lock"));
 			lockItem.addActionListener(createActionListenerForVault(vault, this::lockVault));

--- a/src/main/java/org/cryptomator/ui/traymenu/TrayMenuController.java
+++ b/src/main/java/org/cryptomator/ui/traymenu/TrayMenuController.java
@@ -91,6 +91,8 @@ class TrayMenuController {
 			unlockItem.addActionListener(createActionListenerForVault(vault, this::unlockVault));
 			submenu.add(unlockItem);
 		} else if (vault.isUnlocked()) {
+			submenu.setLabel("*".concat(submenu.getLabel()));
+
 			MenuItem lockItem = new MenuItem(resourceBundle.getString("traymenu.vault.lock"));
 			lockItem.addActionListener(createActionListenerForVault(vault, this::lockVault));
 			submenu.add(lockItem);


### PR DESCRIPTION
Closes #1583.

## Description

This PR adds the unlock status to the name of the vault in the tray. It adds `*` as a prefix to each unlocked vault. I tried it as a suffix like it was described in the issue but the marker is less obvious since the name of each vault is not consistent.

With this new feature, it's easier than ever to find exactly which vaults are unlocked with a visual marker in the list.

## Example
Here's an example with `testvault` as an unlocked vault and `testvault2` as a locked fault.

![2022-03-14 02_47_58-](https://user-images.githubusercontent.com/25964106/158119377-f27e5c8d-c2bc-4643-b681-66181dcd9fcb.png)

