### PR TITLE
Prevent key recovery for foreign vault

### DIFF
--- a/src/main/java/org/cryptomator/ui/recoverykey/RecoveryKeyModule.java
+++ b/src/main/java/org/cryptomator/ui/recoverykey/RecoveryKeyModule.java
@@ -4,7 +4,9 @@ import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
 import dagger.multibindings.IntoMap;
+import org.cryptomator.common.Nullable;
 import org.cryptomator.common.vaults.Vault;
+import org.cryptomator.cryptofs.VaultConfig;
 import org.cryptomator.ui.common.DefaultSceneFactory;
 import org.cryptomator.ui.common.FxController;
 import org.cryptomator.ui.common.FxControllerKey;
@@ -22,11 +24,24 @@ import javafx.beans.property.StringProperty;
 import javafx.scene.Scene;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
+import java.io.IOException;
 import java.util.Map;
 import java.util.ResourceBundle;
 
 @Module
 abstract class RecoveryKeyModule {
+
+	@Provides
+	@Nullable
+	@RecoveryKeyWindow
+	@RecoveryKeyScoped
+	static VaultConfig.UnverifiedVaultConfig vaultConfig(@RecoveryKeyWindow Vault vault) {
+		try {
+			return vault.getVaultConfigCache().get();
+		} catch (IOException e) {
+			return null;
+		}
+	}
 
 	@Provides
 	@RecoveryKeyWindow

--- a/src/test/java/org/cryptomator/ui/recoverykey/RecoveryKeyFactoryTest.java
+++ b/src/test/java/org/cryptomator/ui/recoverykey/RecoveryKeyFactoryTest.java
@@ -7,10 +7,13 @@ import org.cryptomator.cryptolib.common.MasterkeyFileAccess;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.function.Predicate;
 
 public class RecoveryKeyFactoryTest {
 
@@ -73,6 +76,21 @@ public class RecoveryKeyFactoryTest {
 				investor boot depth left theory snow whereby terminal weekly reject happiness circuit partial cup ad \
 				""");
 		Assertions.assertTrue(result);
+	}
+
+	@ParameterizedTest(name = "success = {0}")
+	@DisplayName("validateRecoveryKey() with extended validation")
+	@ValueSource(booleans = {true, false})
+	public void testValidateValidateRecoveryKeyWithValidKey(boolean extendedValidationResult) {
+		Predicate<byte[]> validator = Mockito.mock(Predicate.class);
+		Mockito.doReturn(extendedValidationResult).when(validator).test(Mockito.any());
+		boolean result = inTest.validateRecoveryKey("""
+				pathway lift abuse plenty export texture gentleman landscape beyond ceiling around leaf cafe charity \
+				border breakdown victory surely computer cat linger restrict infer crowd live computer true written amazed \
+				investor boot depth left theory snow whereby terminal weekly reject happiness circuit partial cup ad \
+				""", validator);
+		Mockito.verify(validator).test(Mockito.any());
+		Assertions.assertEquals(extendedValidationResult, result);
 	}
 
 }


### PR DESCRIPTION
Prevent using a recovery key if a vault config file exists and the provided key didn't sign it.

This fixes #2076 and prevents people from "false positive key recoveries" that led to [follow-up errors (empty vault)](https://github.com/cryptomator/cryptomator/discussions?discussions_q=G50O%3AP31S%3AP31S).