### PR TITLE
Moved interface preferences to its own tab

### DIFF
--- a/src/main/java/org/cryptomator/common/settings/UiTheme.java
+++ b/src/main/java/org/cryptomator/common/settings/UiTheme.java
@@ -3,9 +3,9 @@ package org.cryptomator.common.settings;
 import org.apache.commons.lang3.SystemUtils;
 
 public enum UiTheme {
-	LIGHT("preferences.general.theme.light"), //
-	DARK("preferences.general.theme.dark"), //
-	AUTOMATIC("preferences.general.theme.automatic");
+	LIGHT("preferences.interface.theme.light"), //
+	DARK("preferences.interface.theme.dark"), //
+	AUTOMATIC("preferences.interface.theme.automatic");
 
 	public static UiTheme[] applicableValues() {
 		if (SystemUtils.IS_OS_MAC || SystemUtils.IS_OS_WINDOWS) {

--- a/src/main/java/org/cryptomator/ui/preferences/GeneralPreferencesController.java
+++ b/src/main/java/org/cryptomator/ui/preferences/GeneralPreferencesController.java
@@ -1,37 +1,25 @@
 package org.cryptomator.ui.preferences;
 
-import com.google.common.base.Strings;
 import org.cryptomator.common.Environment;
-import org.cryptomator.common.LicenseHolder;
 import org.cryptomator.common.settings.Settings;
-import org.cryptomator.common.settings.UiTheme;
 import org.cryptomator.integrations.autostart.AutoStartProvider;
 import org.cryptomator.integrations.autostart.ToggleAutoStartFailedException;
 import org.cryptomator.integrations.keychain.KeychainAccessProvider;
-import org.cryptomator.launcher.SupportedLanguages;
 import org.cryptomator.ui.common.FxController;
 import org.cryptomator.ui.fxapp.FxApplicationWindows;
-import org.cryptomator.ui.traymenu.TrayMenuComponent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javafx.application.Application;
 import javafx.beans.binding.Bindings;
-import javafx.beans.property.ObjectProperty;
-import javafx.beans.value.ObservableValue;
 import javafx.fxml.FXML;
-import javafx.geometry.NodeOrientation;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ChoiceBox;
-import javafx.scene.control.RadioButton;
-import javafx.scene.control.Toggle;
 import javafx.scene.control.ToggleGroup;
 import javafx.stage.Stage;
 import javafx.util.StringConverter;
-import java.util.Locale;
 import java.util.Optional;
-import java.util.ResourceBundle;
 import java.util.Set;
 
 @PreferencesScoped
@@ -41,39 +29,23 @@ public class GeneralPreferencesController implements FxController {
 
 	private final Stage window;
 	private final Settings settings;
-	private final boolean trayMenuInitialized;
-	private final boolean trayMenuSupported;
 	private final Optional<AutoStartProvider> autoStartProvider;
-	private final ObjectProperty<SelectedPreferencesTab> selectedTabProperty;
-	private final LicenseHolder licenseHolder;
-	private final ResourceBundle resourceBundle;
 	private final Application application;
 	private final Environment environment;
 	private final Set<KeychainAccessProvider> keychainAccessProviders;
 	private final FxApplicationWindows appWindows;
-	public ChoiceBox<UiTheme> themeChoiceBox;
 	public ChoiceBox<KeychainAccessProvider> keychainBackendChoiceBox;
-	public CheckBox showMinimizeButtonCheckbox;
-	public CheckBox showTrayIconCheckbox;
 	public CheckBox startHiddenCheckbox;
-	public ChoiceBox<String> preferredLanguageChoiceBox;
 	public CheckBox debugModeCheckbox;
 	public CheckBox autoStartCheckbox;
 	public ToggleGroup nodeOrientation;
-	public RadioButton nodeOrientationLtr;
-	public RadioButton nodeOrientationRtl;
 
 	@Inject
-	GeneralPreferencesController(@PreferencesWindow Stage window, Settings settings, TrayMenuComponent trayMenu, Optional<AutoStartProvider> autoStartProvider, Set<KeychainAccessProvider> keychainAccessProviders, ObjectProperty<SelectedPreferencesTab> selectedTabProperty, LicenseHolder licenseHolder, ResourceBundle resourceBundle, Application application, Environment environment, FxApplicationWindows appWindows) {
+	GeneralPreferencesController(@PreferencesWindow Stage window, Settings settings, Optional<AutoStartProvider> autoStartProvider, Set<KeychainAccessProvider> keychainAccessProviders, Application application, Environment environment, FxApplicationWindows appWindows) {
 		this.window = window;
 		this.settings = settings;
-		this.trayMenuInitialized = trayMenu.isInitialized();
-		this.trayMenuSupported = trayMenu.isSupported();
 		this.autoStartProvider = autoStartProvider;
 		this.keychainAccessProviders = keychainAccessProviders;
-		this.selectedTabProperty = selectedTabProperty;
-		this.licenseHolder = licenseHolder;
-		this.resourceBundle = resourceBundle;
 		this.application = application;
 		this.environment = environment;
 		this.appWindows = appWindows;
@@ -81,31 +53,11 @@ public class GeneralPreferencesController implements FxController {
 
 	@FXML
 	public void initialize() {
-		themeChoiceBox.getItems().addAll(UiTheme.applicableValues());
-		if (!themeChoiceBox.getItems().contains(settings.theme().get())) {
-			settings.theme().set(UiTheme.LIGHT);
-		}
-		themeChoiceBox.valueProperty().bindBidirectional(settings.theme());
-		themeChoiceBox.setConverter(new UiThemeConverter(resourceBundle));
-
-		showMinimizeButtonCheckbox.selectedProperty().bindBidirectional(settings.showMinimizeButton());
-
-		showTrayIconCheckbox.selectedProperty().bindBidirectional(settings.showTrayIcon());
-
 		startHiddenCheckbox.selectedProperty().bindBidirectional(settings.startHidden());
-
-		preferredLanguageChoiceBox.getItems().add(null);
-		preferredLanguageChoiceBox.getItems().addAll(SupportedLanguages.LANGUAGAE_TAGS);
-		preferredLanguageChoiceBox.valueProperty().bindBidirectional(settings.languageProperty());
-		preferredLanguageChoiceBox.setConverter(new LanguageTagConverter(resourceBundle));
 
 		debugModeCheckbox.selectedProperty().bindBidirectional(settings.debugMode());
 
 		autoStartProvider.ifPresent(autoStart -> autoStartCheckbox.setSelected(autoStart.isEnabled()));
-
-		nodeOrientationLtr.setSelected(settings.userInterfaceOrientation().get() == NodeOrientation.LEFT_TO_RIGHT);
-		nodeOrientationRtl.setSelected(settings.userInterfaceOrientation().get() == NodeOrientation.RIGHT_TO_LEFT);
-		nodeOrientation.selectedToggleProperty().addListener(this::toggleNodeOrientation);
 
 		var keychainSettingsConverter = new KeychainProviderClassNameConverter(keychainAccessProviders);
 		keychainBackendChoiceBox.getItems().addAll(keychainAccessProviders);
@@ -114,27 +66,8 @@ public class GeneralPreferencesController implements FxController {
 		Bindings.bindBidirectional(settings.keychainProvider(), keychainBackendChoiceBox.valueProperty(), keychainSettingsConverter);
 	}
 
-
-	public boolean isTrayMenuInitialized() {
-		return trayMenuInitialized;
-	}
-
-	public boolean isTrayMenuSupported() {
-		return trayMenuSupported;
-	}
-
 	public boolean isAutoStartSupported() {
 		return autoStartProvider.isPresent();
-	}
-
-	private void toggleNodeOrientation(@SuppressWarnings("unused") ObservableValue<? extends Toggle> observable, @SuppressWarnings("unused") Toggle oldValue, Toggle newValue) {
-		if (nodeOrientationLtr.equals(newValue)) {
-			settings.userInterfaceOrientation().set(NodeOrientation.LEFT_TO_RIGHT);
-		} else if (nodeOrientationRtl.equals(newValue)) {
-			settings.userInterfaceOrientation().set(NodeOrientation.RIGHT_TO_LEFT);
-		} else {
-			LOG.warn("Unexpected toggle option {}", newValue);
-		}
 	}
 
 	@FXML
@@ -155,16 +88,6 @@ public class GeneralPreferencesController implements FxController {
 		});
 	}
 
-	public LicenseHolder getLicenseHolder() {
-		return licenseHolder;
-	}
-
-
-	@FXML
-	public void showContributeTab() {
-		selectedTabProperty.set(SelectedPreferencesTab.CONTRIBUTE);
-	}
-
 	@FXML
 	public void showLogfileDirectory() {
 		environment.getLogDir().ifPresent(logDirPath -> application.getHostServices().showDocument(logDirPath.toUri().toString()));
@@ -172,53 +95,7 @@ public class GeneralPreferencesController implements FxController {
 
 	/* Helper classes */
 
-	private static class UiThemeConverter extends StringConverter<UiTheme> {
-
-		private final ResourceBundle resourceBundle;
-
-		UiThemeConverter(ResourceBundle resourceBundle) {
-			this.resourceBundle = resourceBundle;
-		}
-
-		@Override
-		public String toString(UiTheme impl) {
-			return resourceBundle.getString(impl.getDisplayName());
-		}
-
-		@Override
-		public UiTheme fromString(String string) {
-			throw new UnsupportedOperationException();
-		}
-
-	}
-
-	private static class LanguageTagConverter extends StringConverter<String> {
-
-		private final ResourceBundle resourceBundle;
-
-		LanguageTagConverter(ResourceBundle resourceBundle) {
-			this.resourceBundle = resourceBundle;
-		}
-
-		@Override
-		public String toString(String tag) {
-			if (tag == null) {
-				return resourceBundle.getString("preferences.general.language.auto");
-			} else {
-				var locale = Locale.forLanguageTag(tag);
-				var lang = locale.getDisplayLanguage(locale);
-				var region = locale.getDisplayCountry(locale);
-				return lang + (Strings.isNullOrEmpty(region) ? "" : " (" + region + ")");
-			}
-		}
-
-		@Override
-		public String fromString(String displayLanguage) {
-			throw new UnsupportedOperationException();
-		}
-	}
-
-	private class KeychainProviderDisplayNameConverter extends StringConverter<KeychainAccessProvider> {
+	private static class KeychainProviderDisplayNameConverter extends StringConverter<KeychainAccessProvider> {
 
 		@Override
 		public String toString(KeychainAccessProvider provider) {

--- a/src/main/java/org/cryptomator/ui/preferences/InterfacePreferencesController.java
+++ b/src/main/java/org/cryptomator/ui/preferences/InterfacePreferencesController.java
@@ -1,0 +1,156 @@
+package org.cryptomator.ui.preferences;
+
+import com.google.common.base.Strings;
+import org.cryptomator.common.LicenseHolder;
+import org.cryptomator.common.settings.Settings;
+import org.cryptomator.common.settings.UiTheme;
+import org.cryptomator.launcher.SupportedLanguages;
+import org.cryptomator.ui.common.FxController;
+import org.cryptomator.ui.traymenu.TrayMenuComponent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.value.ObservableValue;
+import javafx.fxml.FXML;
+import javafx.geometry.NodeOrientation;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.ChoiceBox;
+import javafx.scene.control.RadioButton;
+import javafx.scene.control.Toggle;
+import javafx.scene.control.ToggleGroup;
+import javafx.util.StringConverter;
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+@PreferencesScoped
+public class InterfacePreferencesController implements FxController {
+
+	private static final Logger LOG = LoggerFactory.getLogger(InterfacePreferencesController.class);
+
+	private final Settings settings;
+	private final boolean trayMenuInitialized;
+	private final boolean trayMenuSupported;
+	private final ObjectProperty<SelectedPreferencesTab> selectedTabProperty;
+	private final LicenseHolder licenseHolder;
+	private final ResourceBundle resourceBundle;
+	public ChoiceBox<UiTheme> themeChoiceBox;
+	public CheckBox showMinimizeButtonCheckbox;
+	public CheckBox showTrayIconCheckbox;
+	public ChoiceBox<String> preferredLanguageChoiceBox;
+	public ToggleGroup nodeOrientation;
+	public RadioButton nodeOrientationLtr;
+	public RadioButton nodeOrientationRtl;
+
+	@Inject
+	InterfacePreferencesController(Settings settings, TrayMenuComponent trayMenu, ObjectProperty<SelectedPreferencesTab> selectedTabProperty, LicenseHolder licenseHolder, ResourceBundle resourceBundle) {
+		this.settings = settings;
+		this.trayMenuInitialized = trayMenu.isInitialized();
+		this.trayMenuSupported = trayMenu.isSupported();
+		this.selectedTabProperty = selectedTabProperty;
+		this.licenseHolder = licenseHolder;
+		this.resourceBundle = resourceBundle;
+	}
+
+	@FXML
+	public void initialize() {
+		themeChoiceBox.getItems().addAll(UiTheme.applicableValues());
+		if (!themeChoiceBox.getItems().contains(settings.theme().get())) {
+			settings.theme().set(UiTheme.LIGHT);
+		}
+		themeChoiceBox.valueProperty().bindBidirectional(settings.theme());
+		themeChoiceBox.setConverter(new UiThemeConverter(resourceBundle));
+
+		showMinimizeButtonCheckbox.selectedProperty().bindBidirectional(settings.showMinimizeButton());
+
+		showTrayIconCheckbox.selectedProperty().bindBidirectional(settings.showTrayIcon());
+
+		preferredLanguageChoiceBox.getItems().add(null);
+		preferredLanguageChoiceBox.getItems().addAll(SupportedLanguages.LANGUAGAE_TAGS);
+		preferredLanguageChoiceBox.valueProperty().bindBidirectional(settings.languageProperty());
+		preferredLanguageChoiceBox.setConverter(new LanguageTagConverter(resourceBundle));
+
+		nodeOrientationLtr.setSelected(settings.userInterfaceOrientation().get() == NodeOrientation.LEFT_TO_RIGHT);
+		nodeOrientationRtl.setSelected(settings.userInterfaceOrientation().get() == NodeOrientation.RIGHT_TO_LEFT);
+		nodeOrientation.selectedToggleProperty().addListener(this::toggleNodeOrientation);
+	}
+
+
+	public boolean isTrayMenuInitialized() {
+		return trayMenuInitialized;
+	}
+
+	public boolean isTrayMenuSupported() {
+		return trayMenuSupported;
+	}
+
+	private void toggleNodeOrientation(@SuppressWarnings("unused") ObservableValue<? extends Toggle> observable, @SuppressWarnings("unused") Toggle oldValue, Toggle newValue) {
+		if (nodeOrientationLtr.equals(newValue)) {
+			settings.userInterfaceOrientation().set(NodeOrientation.LEFT_TO_RIGHT);
+		} else if (nodeOrientationRtl.equals(newValue)) {
+			settings.userInterfaceOrientation().set(NodeOrientation.RIGHT_TO_LEFT);
+		} else {
+			LOG.warn("Unexpected toggle option {}", newValue);
+		}
+	}
+
+	public LicenseHolder getLicenseHolder() {
+		return licenseHolder;
+	}
+
+
+	@FXML
+	public void showContributeTab() {
+		selectedTabProperty.set(SelectedPreferencesTab.CONTRIBUTE);
+	}
+
+	/* Helper classes */
+
+	private static class UiThemeConverter extends StringConverter<UiTheme> {
+
+		private final ResourceBundle resourceBundle;
+
+		UiThemeConverter(ResourceBundle resourceBundle) {
+			this.resourceBundle = resourceBundle;
+		}
+
+		@Override
+		public String toString(UiTheme impl) {
+			return resourceBundle.getString(impl.getDisplayName());
+		}
+
+		@Override
+		public UiTheme fromString(String string) {
+			throw new UnsupportedOperationException();
+		}
+
+	}
+
+	private static class LanguageTagConverter extends StringConverter<String> {
+
+		private final ResourceBundle resourceBundle;
+
+		LanguageTagConverter(ResourceBundle resourceBundle) {
+			this.resourceBundle = resourceBundle;
+		}
+
+		@Override
+		public String toString(String tag) {
+			if (tag == null) {
+				return resourceBundle.getString("preferences.general.language.auto");
+			} else {
+				var locale = Locale.forLanguageTag(tag);
+				var lang = locale.getDisplayLanguage(locale);
+				var region = locale.getDisplayCountry(locale);
+				return lang + (Strings.isNullOrEmpty(region) ? "" : " (" + region + ")");
+			}
+		}
+
+		@Override
+		public String fromString(String displayLanguage) {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+}

--- a/src/main/java/org/cryptomator/ui/preferences/InterfacePreferencesController.java
+++ b/src/main/java/org/cryptomator/ui/preferences/InterfacePreferencesController.java
@@ -138,7 +138,7 @@ public class InterfacePreferencesController implements FxController {
 		@Override
 		public String toString(String tag) {
 			if (tag == null) {
-				return resourceBundle.getString("preferences.general.language.auto");
+				return resourceBundle.getString("preferences.interface.language.auto");
 			} else {
 				var locale = Locale.forLanguageTag(tag);
 				var lang = locale.getDisplayLanguage(locale);

--- a/src/main/java/org/cryptomator/ui/preferences/PreferencesController.java
+++ b/src/main/java/org/cryptomator/ui/preferences/PreferencesController.java
@@ -24,6 +24,7 @@ public class PreferencesController implements FxController {
 	private final BooleanBinding updateAvailable;
 	public TabPane tabPane;
 	public Tab generalTab;
+	public Tab interfaceTab;
 	public Tab volumeTab;
 	public Tab updatesTab;
 	public Tab contributeTab;
@@ -50,10 +51,11 @@ public class PreferencesController implements FxController {
 
 	private Tab getTabToSelect(SelectedPreferencesTab selectedTab) {
 		return switch (selectedTab) {
-			case UPDATES -> updatesTab;
-			case VOLUME -> volumeTab;
-			case CONTRIBUTE -> contributeTab;
 			case GENERAL -> generalTab;
+			case INTERFACE -> interfaceTab;
+			case VOLUME -> volumeTab;
+			case UPDATES -> updatesTab;
+			case CONTRIBUTE -> contributeTab;
 			case ABOUT -> aboutTab;
 			case ANY -> updateAvailable.get() ? updatesTab : generalTab;
 		};

--- a/src/main/java/org/cryptomator/ui/preferences/PreferencesModule.java
+++ b/src/main/java/org/cryptomator/ui/preferences/PreferencesModule.java
@@ -66,6 +66,11 @@ abstract class PreferencesModule {
 
 	@Binds
 	@IntoMap
+	@FxControllerKey(InterfacePreferencesController.class)
+	abstract FxController bindInterfacePreferencesController(InterfacePreferencesController controller);
+
+	@Binds
+	@IntoMap
 	@FxControllerKey(UpdatesPreferencesController.class)
 	abstract FxController bindUpdatesPreferencesController(UpdatesPreferencesController controller);
 

--- a/src/main/java/org/cryptomator/ui/preferences/SelectedPreferencesTab.java
+++ b/src/main/java/org/cryptomator/ui/preferences/SelectedPreferencesTab.java
@@ -12,6 +12,11 @@ public enum SelectedPreferencesTab {
 	GENERAL,
 
 	/**
+	 * Show interface tab
+	 */
+	INTERFACE,
+
+	/**
 	 * Show volume tab
 	 */
 	VOLUME,

--- a/src/main/resources/fxml/preferences.fxml
+++ b/src/main/resources/fxml/preferences.fxml
@@ -22,6 +22,14 @@
 				<fx:include source="preferences_general.fxml"/>
 			</content>
 		</Tab>
+		<Tab fx:id="interfaceTab" id="INTERFACE" text="%preferences.interface">
+			<graphic>
+				<FontAwesome5IconView glyph="EYE"/>
+			</graphic>
+			<content>
+				<fx:include source="preferences_interface.fxml"/>
+			</content>
+		</Tab>
 		<Tab fx:id="volumeTab" id="VOLUME" text="%preferences.volume">
 			<graphic>
 				<FontAwesome5IconView glyph="HDD"/>

--- a/src/main/resources/fxml/preferences.fxml
+++ b/src/main/resources/fxml/preferences.fxml
@@ -9,7 +9,7 @@
 		 fx:controller="org.cryptomator.ui.preferences.PreferencesController"
 		 minWidth="-Infinity"
 		 maxWidth="-Infinity"
-		 prefWidth="500"
+		 prefWidth="650"
 		 tabMinWidth="60"
 		 tabClosingPolicy="UNAVAILABLE"
 		 tabDragPolicy="FIXED">

--- a/src/main/resources/fxml/preferences_about.fxml
+++ b/src/main/resources/fxml/preferences_about.fxml
@@ -13,7 +13,7 @@
 	  fx:controller="org.cryptomator.ui.preferences.AboutController"
 	  spacing="18">
 	<padding>
-		<Insets topRightBottomLeft="12"/>
+		<Insets top="12" right="24" bottom="12" left="24"/>
 	</padding>
 	<children>
 		<HBox spacing="12" VBox.vgrow="NEVER">

--- a/src/main/resources/fxml/preferences_about.fxml
+++ b/src/main/resources/fxml/preferences_about.fxml
@@ -11,9 +11,9 @@
 <VBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
 	  fx:controller="org.cryptomator.ui.preferences.AboutController"
-	  spacing="18">
+	  spacing="24">
 	<padding>
-		<Insets top="12" right="24" bottom="12" left="24"/>
+		<Insets topRightBottomLeft="24"/>
 	</padding>
 	<children>
 		<HBox spacing="12" VBox.vgrow="NEVER">

--- a/src/main/resources/fxml/preferences_contribute.fxml
+++ b/src/main/resources/fxml/preferences_contribute.fxml
@@ -15,7 +15,7 @@
 	  fx:controller="org.cryptomator.ui.preferences.SupporterCertificateController"
 	  spacing="18">
 	<padding>
-		<Insets topRightBottomLeft="12"/>
+		<Insets top="12" right="24" bottom="12" left="24"/>
 	</padding>
 	<children>
 		<StackPane VBox.vgrow="NEVER" prefHeight="60">

--- a/src/main/resources/fxml/preferences_contribute.fxml
+++ b/src/main/resources/fxml/preferences_contribute.fxml
@@ -13,9 +13,9 @@
 <VBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
 	  fx:controller="org.cryptomator.ui.preferences.SupporterCertificateController"
-	  spacing="18">
+	  spacing="24">
 	<padding>
-		<Insets top="12" right="24" bottom="12" left="24"/>
+		<Insets topRightBottomLeft="24"/>
 	</padding>
 	<children>
 		<StackPane VBox.vgrow="NEVER" prefHeight="60">

--- a/src/main/resources/fxml/preferences_general.fxml
+++ b/src/main/resources/fxml/preferences_general.fxml
@@ -20,28 +20,7 @@
 		<Insets topRightBottomLeft="12"/>
 	</padding>
 	<children>
-		<HBox spacing="6" alignment="CENTER_LEFT">
-			<Label text="%preferences.general.theme"/>
-			<ChoiceBox fx:id="themeChoiceBox" disable="${!controller.licenseHolder.validLicense}"/>
-			<Hyperlink styleClass="hyperlink-underline,hyperlink-muted" text="%preferences.general.unlockThemes" onAction="#showContributeTab" visible="${!controller.licenseHolder.validLicense}" managed="${!controller.licenseHolder.validLicense}"/>
-		</HBox>
-
-		<HBox spacing="6" alignment="CENTER_LEFT">
-			<Label text="%preferences.general.interfaceOrientation" HBox.hgrow="NEVER"/>
-			<RadioButton fx:id="nodeOrientationLtr" text="%preferences.general.interfaceOrientation.ltr" alignment="CENTER_LEFT" toggleGroup="${nodeOrientation}"/>
-			<RadioButton fx:id="nodeOrientationRtl" text="%preferences.general.interfaceOrientation.rtl" alignment="CENTER_RIGHT" toggleGroup="${nodeOrientation}"/>
-		</HBox>
-
-		<CheckBox fx:id="showMinimizeButtonCheckbox" text="%preferences.general.showMinimizeButton" visible="${controller.trayMenuInitialized}" managed="${controller.trayMenuInitialized}"/>
-
-		<CheckBox fx:id="showTrayIconCheckbox" text="%preferences.general.showTrayIcon" visible="${controller.trayMenuSupported}" managed="${controller.trayMenuSupported}"/>
-
 		<CheckBox fx:id="startHiddenCheckbox" text="%preferences.general.startHidden" />
-
-		<HBox spacing="6" alignment="CENTER_LEFT">
-			<Label text="%preferences.general.language"/>
-			<ChoiceBox fx:id="preferredLanguageChoiceBox"/>
-		</HBox>
 
 		<HBox spacing="6" alignment="CENTER_LEFT">
 			<CheckBox fx:id="debugModeCheckbox" text="%preferences.general.debugLogging"/>

--- a/src/main/resources/fxml/preferences_general.fxml
+++ b/src/main/resources/fxml/preferences_general.fxml
@@ -5,19 +5,18 @@
 <?import javafx.scene.control.ChoiceBox?>
 <?import javafx.scene.control.Hyperlink?>
 <?import javafx.scene.control.Label?>
-<?import javafx.scene.control.RadioButton?>
 <?import javafx.scene.control.ToggleGroup?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 <VBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
 	  fx:controller="org.cryptomator.ui.preferences.GeneralPreferencesController"
-	  spacing="6">
+	  spacing="9">
 	<fx:define>
 		<ToggleGroup fx:id="nodeOrientation"/>
 	</fx:define>
 	<padding>
-		<Insets topRightBottomLeft="12"/>
+		<Insets top="12" right="24" bottom="12" left="24"/>
 	</padding>
 	<children>
 		<CheckBox fx:id="startHiddenCheckbox" text="%preferences.general.startHidden" />

--- a/src/main/resources/fxml/preferences_general.fxml
+++ b/src/main/resources/fxml/preferences_general.fxml
@@ -8,6 +8,7 @@
 <?import javafx.scene.control.ToggleGroup?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
+<?import javafx.scene.layout.Region?>
 <VBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
 	  fx:controller="org.cryptomator.ui.preferences.GeneralPreferencesController"
@@ -19,18 +20,20 @@
 		<Insets top="12" right="24" bottom="12" left="24"/>
 	</padding>
 	<children>
-		<CheckBox fx:id="startHiddenCheckbox" text="%preferences.general.startHidden" />
+		<CheckBox fx:id="autoStartCheckbox" text="%preferences.general.autoStart" visible="${controller.autoStartSupported}" managed="${controller.autoStartSupported}" onAction="#toggleAutoStart"/>
 
-		<HBox spacing="6" alignment="CENTER_LEFT">
-			<CheckBox fx:id="debugModeCheckbox" text="%preferences.general.debugLogging"/>
-			<Hyperlink styleClass="hyperlink-underline" text="%preferences.general.debugDirectory" onAction="#showLogfileDirectory"/>
-		</HBox>
+		<CheckBox fx:id="startHiddenCheckbox" text="%preferences.general.startHidden" />
 
 		<HBox spacing="6" alignment="CENTER_LEFT">
 			<Label text="%preferences.general.keychainBackend"/>
 			<ChoiceBox fx:id="keychainBackendChoiceBox"/>
 		</HBox>
 
-		<CheckBox fx:id="autoStartCheckbox" text="%preferences.general.autoStart" visible="${controller.autoStartSupported}" managed="${controller.autoStartSupported}" onAction="#toggleAutoStart"/>
+		<Region VBox.vgrow="ALWAYS"/>
+
+		<HBox spacing="6" alignment="CENTER_LEFT">
+			<CheckBox fx:id="debugModeCheckbox" text="%preferences.general.debugLogging"/>
+			<Hyperlink styleClass="hyperlink-underline" text="%preferences.general.debugDirectory" onAction="#showLogfileDirectory"/>
+		</HBox>
 	</children>
 </VBox>

--- a/src/main/resources/fxml/preferences_general.fxml
+++ b/src/main/resources/fxml/preferences_general.fxml
@@ -12,26 +12,26 @@
 <VBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
 	  fx:controller="org.cryptomator.ui.preferences.GeneralPreferencesController"
-	  spacing="9">
+	  spacing="12">
 	<fx:define>
 		<ToggleGroup fx:id="nodeOrientation"/>
 	</fx:define>
 	<padding>
-		<Insets top="12" right="24" bottom="12" left="24"/>
+		<Insets topRightBottomLeft="24"/>
 	</padding>
 	<children>
 		<CheckBox fx:id="autoStartCheckbox" text="%preferences.general.autoStart" visible="${controller.autoStartSupported}" managed="${controller.autoStartSupported}" onAction="#toggleAutoStart"/>
 
 		<CheckBox fx:id="startHiddenCheckbox" text="%preferences.general.startHidden" />
 
-		<HBox spacing="6" alignment="CENTER_LEFT">
+		<HBox spacing="12" alignment="CENTER_LEFT">
 			<Label text="%preferences.general.keychainBackend"/>
 			<ChoiceBox fx:id="keychainBackendChoiceBox"/>
 		</HBox>
 
 		<Region VBox.vgrow="ALWAYS"/>
 
-		<HBox spacing="6" alignment="CENTER_LEFT">
+		<HBox spacing="12" alignment="CENTER_LEFT">
 			<CheckBox fx:id="debugModeCheckbox" text="%preferences.general.debugLogging"/>
 			<Hyperlink styleClass="hyperlink-underline" text="%preferences.general.debugDirectory" onAction="#showLogfileDirectory"/>
 		</HBox>

--- a/src/main/resources/fxml/preferences_interface.fxml
+++ b/src/main/resources/fxml/preferences_interface.fxml
@@ -12,12 +12,12 @@
 <VBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
 	  fx:controller="org.cryptomator.ui.preferences.InterfacePreferencesController"
-	  spacing="6">
+	  spacing="9">
 	<fx:define>
 		<ToggleGroup fx:id="nodeOrientation"/>
 	</fx:define>
 	<padding>
-		<Insets topRightBottomLeft="12"/>
+		<Insets top="12" right="24" bottom="12" left="24"/>
 	</padding>
 	<children>
 		<HBox spacing="6" alignment="CENTER_LEFT">

--- a/src/main/resources/fxml/preferences_interface.fxml
+++ b/src/main/resources/fxml/preferences_interface.fxml
@@ -21,25 +21,25 @@
 	</padding>
 	<children>
 		<HBox spacing="6" alignment="CENTER_LEFT">
-			<Label text="%preferences.general.theme"/>
+			<Label text="%preferences.interface.theme"/>
 			<ChoiceBox fx:id="themeChoiceBox" disable="${!controller.licenseHolder.validLicense}"/>
-			<Hyperlink styleClass="hyperlink-underline,hyperlink-muted" text="%preferences.general.unlockThemes" onAction="#showContributeTab" visible="${!controller.licenseHolder.validLicense}" managed="${!controller.licenseHolder.validLicense}"/>
+			<Hyperlink styleClass="hyperlink-underline,hyperlink-muted" text="%preferences.interface.unlockThemes" onAction="#showContributeTab" visible="${!controller.licenseHolder.validLicense}" managed="${!controller.licenseHolder.validLicense}"/>
 		</HBox>
 
 		<HBox spacing="6" alignment="CENTER_LEFT">
-			<Label text="%preferences.general.language"/>
+			<Label text="%preferences.interface.language"/>
 			<ChoiceBox fx:id="preferredLanguageChoiceBox"/>
 		</HBox>
 
 		<HBox spacing="6" alignment="CENTER_LEFT">
-			<Label text="%preferences.general.interfaceOrientation" HBox.hgrow="NEVER"/>
-			<RadioButton fx:id="nodeOrientationLtr" text="%preferences.general.interfaceOrientation.ltr" alignment="CENTER_LEFT" toggleGroup="${nodeOrientation}"/>
-			<RadioButton fx:id="nodeOrientationRtl" text="%preferences.general.interfaceOrientation.rtl" alignment="CENTER_RIGHT" toggleGroup="${nodeOrientation}"/>
+			<Label text="%preferences.interface.interfaceOrientation" HBox.hgrow="NEVER"/>
+			<RadioButton fx:id="nodeOrientationLtr" text="%preferences.interface.interfaceOrientation.ltr" alignment="CENTER_LEFT" toggleGroup="${nodeOrientation}"/>
+			<RadioButton fx:id="nodeOrientationRtl" text="%preferences.interface.interfaceOrientation.rtl" alignment="CENTER_RIGHT" toggleGroup="${nodeOrientation}"/>
 		</HBox>
 
 
-		<CheckBox fx:id="showMinimizeButtonCheckbox" text="%preferences.general.showMinimizeButton" visible="${controller.trayMenuInitialized}" managed="${controller.trayMenuInitialized}"/>
+		<CheckBox fx:id="showMinimizeButtonCheckbox" text="%preferences.interface.showMinimizeButton" visible="${controller.trayMenuInitialized}" managed="${controller.trayMenuInitialized}"/>
 
-		<CheckBox fx:id="showTrayIconCheckbox" text="%preferences.general.showTrayIcon" visible="${controller.trayMenuSupported}" managed="${controller.trayMenuSupported}"/>
+		<CheckBox fx:id="showTrayIconCheckbox" text="%preferences.interface.showTrayIcon" visible="${controller.trayMenuSupported}" managed="${controller.trayMenuSupported}"/>
 	</children>
 </VBox>

--- a/src/main/resources/fxml/preferences_interface.fxml
+++ b/src/main/resources/fxml/preferences_interface.fxml
@@ -12,26 +12,26 @@
 <VBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
 	  fx:controller="org.cryptomator.ui.preferences.InterfacePreferencesController"
-	  spacing="9">
+	  spacing="12">
 	<fx:define>
 		<ToggleGroup fx:id="nodeOrientation"/>
 	</fx:define>
 	<padding>
-		<Insets top="12" right="24" bottom="12" left="24"/>
+		<Insets topRightBottomLeft="24"/>
 	</padding>
 	<children>
-		<HBox spacing="6" alignment="CENTER_LEFT">
+		<HBox spacing="12" alignment="CENTER_LEFT">
 			<Label text="%preferences.interface.theme"/>
 			<ChoiceBox fx:id="themeChoiceBox" disable="${!controller.licenseHolder.validLicense}"/>
 			<Hyperlink styleClass="hyperlink-underline,hyperlink-muted" text="%preferences.interface.unlockThemes" onAction="#showContributeTab" visible="${!controller.licenseHolder.validLicense}" managed="${!controller.licenseHolder.validLicense}"/>
 		</HBox>
 
-		<HBox spacing="6" alignment="CENTER_LEFT">
+		<HBox spacing="12" alignment="CENTER_LEFT">
 			<Label text="%preferences.interface.language"/>
 			<ChoiceBox fx:id="preferredLanguageChoiceBox"/>
 		</HBox>
 
-		<HBox spacing="6" alignment="CENTER_LEFT">
+		<HBox spacing="12" alignment="CENTER_LEFT">
 			<Label text="%preferences.interface.interfaceOrientation" HBox.hgrow="NEVER"/>
 			<RadioButton fx:id="nodeOrientationLtr" text="%preferences.interface.interfaceOrientation.ltr" alignment="CENTER_LEFT" toggleGroup="${nodeOrientation}"/>
 			<RadioButton fx:id="nodeOrientationRtl" text="%preferences.interface.interfaceOrientation.rtl" alignment="CENTER_RIGHT" toggleGroup="${nodeOrientation}"/>

--- a/src/main/resources/fxml/preferences_interface.fxml
+++ b/src/main/resources/fxml/preferences_interface.fxml
@@ -27,18 +27,19 @@
 		</HBox>
 
 		<HBox spacing="6" alignment="CENTER_LEFT">
+			<Label text="%preferences.general.language"/>
+			<ChoiceBox fx:id="preferredLanguageChoiceBox"/>
+		</HBox>
+
+		<HBox spacing="6" alignment="CENTER_LEFT">
 			<Label text="%preferences.general.interfaceOrientation" HBox.hgrow="NEVER"/>
 			<RadioButton fx:id="nodeOrientationLtr" text="%preferences.general.interfaceOrientation.ltr" alignment="CENTER_LEFT" toggleGroup="${nodeOrientation}"/>
 			<RadioButton fx:id="nodeOrientationRtl" text="%preferences.general.interfaceOrientation.rtl" alignment="CENTER_RIGHT" toggleGroup="${nodeOrientation}"/>
 		</HBox>
 
+
 		<CheckBox fx:id="showMinimizeButtonCheckbox" text="%preferences.general.showMinimizeButton" visible="${controller.trayMenuInitialized}" managed="${controller.trayMenuInitialized}"/>
 
 		<CheckBox fx:id="showTrayIconCheckbox" text="%preferences.general.showTrayIcon" visible="${controller.trayMenuSupported}" managed="${controller.trayMenuSupported}"/>
-
-		<HBox spacing="6" alignment="CENTER_LEFT">
-			<Label text="%preferences.general.language"/>
-			<ChoiceBox fx:id="preferredLanguageChoiceBox"/>
-		</HBox>
 	</children>
 </VBox>

--- a/src/main/resources/fxml/preferences_interface.fxml
+++ b/src/main/resources/fxml/preferences_interface.fxml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.CheckBox?>
+<?import javafx.scene.control.ChoiceBox?>
+<?import javafx.scene.control.Hyperlink?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.RadioButton?>
+<?import javafx.scene.control.ToggleGroup?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
+<VBox xmlns:fx="http://javafx.com/fxml"
+	  xmlns="http://javafx.com/javafx"
+	  fx:controller="org.cryptomator.ui.preferences.InterfacePreferencesController"
+	  spacing="6">
+	<fx:define>
+		<ToggleGroup fx:id="nodeOrientation"/>
+	</fx:define>
+	<padding>
+		<Insets topRightBottomLeft="12"/>
+	</padding>
+	<children>
+		<HBox spacing="6" alignment="CENTER_LEFT">
+			<Label text="%preferences.general.theme"/>
+			<ChoiceBox fx:id="themeChoiceBox" disable="${!controller.licenseHolder.validLicense}"/>
+			<Hyperlink styleClass="hyperlink-underline,hyperlink-muted" text="%preferences.general.unlockThemes" onAction="#showContributeTab" visible="${!controller.licenseHolder.validLicense}" managed="${!controller.licenseHolder.validLicense}"/>
+		</HBox>
+
+		<HBox spacing="6" alignment="CENTER_LEFT">
+			<Label text="%preferences.general.interfaceOrientation" HBox.hgrow="NEVER"/>
+			<RadioButton fx:id="nodeOrientationLtr" text="%preferences.general.interfaceOrientation.ltr" alignment="CENTER_LEFT" toggleGroup="${nodeOrientation}"/>
+			<RadioButton fx:id="nodeOrientationRtl" text="%preferences.general.interfaceOrientation.rtl" alignment="CENTER_RIGHT" toggleGroup="${nodeOrientation}"/>
+		</HBox>
+
+		<CheckBox fx:id="showMinimizeButtonCheckbox" text="%preferences.general.showMinimizeButton" visible="${controller.trayMenuInitialized}" managed="${controller.trayMenuInitialized}"/>
+
+		<CheckBox fx:id="showTrayIconCheckbox" text="%preferences.general.showTrayIcon" visible="${controller.trayMenuSupported}" managed="${controller.trayMenuSupported}"/>
+
+		<HBox spacing="6" alignment="CENTER_LEFT">
+			<Label text="%preferences.general.language"/>
+			<ChoiceBox fx:id="preferredLanguageChoiceBox"/>
+		</HBox>
+	</children>
+</VBox>

--- a/src/main/resources/fxml/preferences_updates.fxml
+++ b/src/main/resources/fxml/preferences_updates.fxml
@@ -11,19 +11,19 @@
 <VBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
 	  fx:controller="org.cryptomator.ui.preferences.UpdatesPreferencesController"
-	  spacing="9">
+	  spacing="12">
 	<fx:define>
 		<FormattedString fx:id="linkLabel" format="%preferences.updates.updateAvailable" arg1="${controller.latestVersion}"/>
 	</fx:define>
 	<padding>
-		<Insets top="12" right="24" bottom="12" left="24"/>
+		<Insets topRightBottomLeft="24"/>
 	</padding>
 	<children>
 		<FormattedLabel format="%preferences.updates.currentVersion" arg1="${controller.currentVersion}" textAlignment="CENTER" wrapText="true"/>
 
 		<CheckBox fx:id="checkForUpdatesCheckbox" text="%preferences.updates.autoUpdateCheck"/>
 
-		<VBox alignment="CENTER" spacing="6">
+		<VBox alignment="CENTER" spacing="12">
 			<Button text="%preferences.updates.checkNowBtn" defaultButton="true" onAction="#checkNow" contentDisplay="${controller.checkForUpdatesButtonState}">
 				<graphic>
 					<FontAwesome5Spinner fx:id="spinner" glyphSize="12"/>

--- a/src/main/resources/fxml/preferences_updates.fxml
+++ b/src/main/resources/fxml/preferences_updates.fxml
@@ -11,12 +11,12 @@
 <VBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
 	  fx:controller="org.cryptomator.ui.preferences.UpdatesPreferencesController"
-	  spacing="6">
+	  spacing="9">
 	<fx:define>
 		<FormattedString fx:id="linkLabel" format="%preferences.updates.updateAvailable" arg1="${controller.latestVersion}"/>
 	</fx:define>
 	<padding>
-		<Insets topRightBottomLeft="12"/>
+		<Insets top="12" right="24" bottom="12" left="24"/>
 	</padding>
 	<children>
 		<FormattedLabel format="%preferences.updates.currentVersion" arg1="${controller.currentVersion}" textAlignment="CENTER" wrapText="true"/>

--- a/src/main/resources/fxml/preferences_volume.fxml
+++ b/src/main/resources/fxml/preferences_volume.fxml
@@ -10,23 +10,23 @@
 <VBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
 	  fx:controller="org.cryptomator.ui.preferences.VolumePreferencesController"
-	  spacing="9">
+	  spacing="12">
 	<padding>
-		<Insets top="12" right="24" bottom="12" left="24"/>
+		<Insets topRightBottomLeft="24"/>
 	</padding>
 	<children>
-		<HBox spacing="6" alignment="CENTER_LEFT">
+		<HBox spacing="12" alignment="CENTER_LEFT">
 			<Label text="%preferences.volume.type"/>
 			<ChoiceBox fx:id="volumeTypeChoiceBox"/>
 		</HBox>
 
-		<HBox spacing="6" alignment="CENTER_LEFT" visible="${controller.showWebDavSettings}">
+		<HBox spacing="12" alignment="CENTER_LEFT" visible="${controller.showWebDavSettings}">
 			<Label text="%preferences.volume.webdav.port"/>
 			<NumericTextField fx:id="webDavPortField"/>
 			<Button text="%generic.button.apply" fx:id="changeWebDavPortButton" onAction="#doChangeWebDavPort"/>
 		</HBox>
 
-		<HBox spacing="6" alignment="CENTER_LEFT" visible="${controller.showWebDavScheme}">
+		<HBox spacing="12" alignment="CENTER_LEFT" visible="${controller.showWebDavScheme}">
 			<Label text="%preferences.volume.webdav.scheme"/>
 			<ChoiceBox fx:id="webDavUrlSchemeChoiceBox" maxWidth="Infinity"/>
 		</HBox>

--- a/src/main/resources/fxml/preferences_volume.fxml
+++ b/src/main/resources/fxml/preferences_volume.fxml
@@ -10,9 +10,9 @@
 <VBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
 	  fx:controller="org.cryptomator.ui.preferences.VolumePreferencesController"
-	  spacing="6">
+	  spacing="9">
 	<padding>
-		<Insets topRightBottomLeft="12"/>
+		<Insets top="12" right="24" bottom="12" left="24"/>
 	</padding>
 	<children>
 		<HBox spacing="6" alignment="CENTER_LEFT">

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -208,6 +208,8 @@ preferences.general.keychainBackend=Store passwords with
 preferences.general.interfaceOrientation=Interface Orientation
 preferences.general.interfaceOrientation.ltr=Left to Right
 preferences.general.interfaceOrientation.rtl=Right to Left
+## Interface
+preferences.interface=Interface
 ## Volume
 preferences.volume=Virtual Drive
 preferences.volume.type=Volume Type

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -191,25 +191,25 @@ health.fix.failTip=Fix failed, see log for details
 preferences.title=Preferences
 ## General
 preferences.general=General
-preferences.general.theme=Look & Feel
-preferences.general.theme.automatic=Automatic
-preferences.general.theme.light=Light
-preferences.general.theme.dark=Dark
-preferences.general.unlockThemes=Unlock dark mode
-preferences.general.showMinimizeButton=Show minimize button
-preferences.general.showTrayIcon=Show tray icon (requires restart)
 preferences.general.startHidden=Hide window when starting Cryptomator
-preferences.general.language=Language (requires restart)
-preferences.general.language.auto=System Default
 preferences.general.debugLogging=Enable debug logging
 preferences.general.debugDirectory=Reveal log files
 preferences.general.autoStart=Launch Cryptomator on system start
 preferences.general.keychainBackend=Store passwords with
-preferences.general.interfaceOrientation=Interface Orientation
-preferences.general.interfaceOrientation.ltr=Left to Right
-preferences.general.interfaceOrientation.rtl=Right to Left
 ## Interface
 preferences.interface=Interface
+preferences.interface.theme=Look & Feel
+preferences.interface.theme.automatic=Automatic
+preferences.interface.theme.dark=Dark
+preferences.interface.theme.light=Light
+preferences.interface.unlockThemes=Unlock dark mode
+preferences.interface.language=Language (requires restart)
+preferences.interface.language.auto=System Default
+preferences.interface.interfaceOrientation=Interface Orientation
+preferences.interface.interfaceOrientation.ltr=Left to Right
+preferences.interface.interfaceOrientation.rtl=Right to Left
+preferences.interface.showMinimizeButton=Show minimize button
+preferences.interface.showTrayIcon=Show tray icon (requires restart)
 ## Volume
 preferences.volume=Virtual Drive
 preferences.volume.type=Volume Type


### PR DESCRIPTION
This moves L&F-related settings from "General" to its own preferences tab. This declutters not only the interface but also the code the attached controllers.

<img width="716" alt="Screenshot 2022-04-09 at 15 33 07" src="https://user-images.githubusercontent.com/1204330/162576350-ede46477-0966-4056-8592-3bed6550a19b.png">

The freed up space in "General" might be used to integrate the sparse "Virtual Drive" settings again, but this should be a separate PR. 