### PR TITLE
Report Download Stats

### DIFF
--- a/.github/workflows/dl-stats.yml
+++ b/.github/workflows/dl-stats.yml
@@ -1,6 +1,7 @@
 name: Report Download Stats
 
 on:
+  push: # TMP
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/dl-stats.yml
+++ b/.github/workflows/dl-stats.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const query = `query($owner:String!, $name:String!, $label:String!) {
+            const query = `query($owner:String!, $name:String!) {
               repository(owner:$owner, name:$name){
                 releases(first: 10, orderBy: {field: CREATED_AT, direction: DESC}) {
                   nodes {

--- a/.github/workflows/dl-stats.yml
+++ b/.github/workflows/dl-stats.yml
@@ -1,0 +1,38 @@
+name: Report Download Stats
+
+on:
+  workflow_dispatch:
+
+jobs:
+  get-releases:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get download count of latest releases
+        id: get-dl-stats
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const query = `query($owner:String!, $name:String!, $label:String!) {
+              repository(owner:$owner, name:$name){
+                releases(first: 10, orderBy: {field: CREATED_AT, direction: DESC}) {
+                  nodes {
+                    isPrerelease
+                    tagName
+                    releaseAssets(first: 20) {
+                      nodes {
+                        name
+                        downloadCount
+                      }
+                    }
+                  }
+                }
+              }
+            }`;
+            const variables = {
+              owner: context.repo.owner,
+              name: context.repo.repo
+            }
+            return await github.graphql(query, variables)
+      - name: Debug Log
+        run: echo "${{steps.get-dl-stats.outputs.result}}"
+

--- a/.github/workflows/dl-stats.yml
+++ b/.github/workflows/dl-stats.yml
@@ -34,6 +34,22 @@ jobs:
               name: context.repo.repo
             }
             return await github.graphql(query, variables)
-      - name: Debug Log
-        run: echo "${{steps.get-dl-stats.outputs.result}}"
+      - name: Transform Results
+        run: |
+          TIME=$(date +%s)
+          echo JSON_DATA | jq --arg TIME "$TIME" -c '.repository.releases.nodes[] | select(.isPrerelease == false) | .tagName as $tagName | .releaseAssets.nodes[] | {filename: .name, downloads: .downloadCount, release: $tagName, time: ($TIME|tonumber)}' > input.json
+
+          jq -c 'select(.filename|endswith("-x86_64.AppImage")) | {name: "github.releases.downloads", tags: ["file=AppImage", "version=\(.release)", "arch=amd64"], value: .downloads, interval: 86400, time: .time}' input.json >> output.json
+          jq -c 'select(.filename|endswith("_amd64.deb")) | {name: "github.releases.downloads", tags: ["file=deb", "version=\(.release)", "arch=amd64"], value: .downloads, interval: 86400, time: .time}' input.json >> output.json
+          jq -c 'select(.filename|endswith("-x64.msi")) | {name: "github.releases.downloads", tags: ["file=msi", "version=\(.release)", "arch=amd64"], value: .downloads, interval: 86400, time: .time}' input.json >> output.json
+          jq -c 'select(.filename|endswith("-x64.exe")) | {name: "github.releases.downloads", tags: ["file=exe", "version=\(.release)", "arch=amd64"], value: .downloads, interval: 86400, time: .time}' input.json >> output.json
+          jq -c 'select(.filename|endswith("-arm64.dmg")) | {name: "github.releases.downloads", tags: ["file=dmg", "version=\(.release)", "arch=arm64"], value: .downloads, interval: 86400, time: .time}' input.json >> output.json
+          jq -c 'select(.filename|endswith(".dmg")) | select(.filename|endswith("-arm64.dmg")|not) | {name: "github.releases.downloads", tags: ["file=dmg", "version=\(.release)", "arch=arm64"], value: .downloads, interval: 86400, time: .time}' input.json >> output.json
+          jq -c 'select(.filename|endswith("-x86_64.AppImage")) | {name: "github.releases.downloads", tags: ["file=AppImage", "version=\(.release)", "arch=amd64"], value: .downloads, interval: 86400, time: .time}' input.json >> output.json
+
+          jq -s "." output.json
+        env:
+          JSON_DATA: ${{ steps.get-dl-stats.outputs.result }}
+
+
 

--- a/.github/workflows/dl-stats.yml
+++ b/.github/workflows/dl-stats.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Upload Results
         id: upload-stats
         run: |
-          echo ${STATS} | curl -X POST -H "Authorization: Bearer ${BEARER_TOKEN} -H "Content-Type: application/json" "https://graphite-us-central1.grafana.net/metrics" --data-binary @-
+          echo ${STATS} | curl -X POST -H "Authorization: Bearer ${BEARER_TOKEN}" -H "Content-Type: application/json" "https://graphite-us-central1.grafana.net/metrics" --data-binary @-
         env:
           BEARER_TOKEN : ${{ secrets.GRAFANA_GRAPHITE_TOKEN }}
           STATS: ${{ steps.transform-stats.outputs.result }}

--- a/.github/workflows/dl-stats.yml
+++ b/.github/workflows/dl-stats.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  get-releases:
+  report-download-stats:
     runs-on: ubuntu-latest
     steps:
       - name: Get download count of latest releases
@@ -37,7 +37,7 @@ jobs:
       - name: Transform Results
         run: |
           TIME=$(date +%s)
-          echo JSON_DATA | jq --arg TIME "$TIME" -c '.repository.releases.nodes[] | select(.isPrerelease == false) | .tagName as $tagName | .releaseAssets.nodes[] | {filename: .name, downloads: .downloadCount, release: $tagName, time: ($TIME|tonumber)}' > input.json
+          echo ${JSON_DATA} | jq --arg TIME "$TIME" -c '.repository.releases.nodes[] | select(.isPrerelease == false) | .tagName as $tagName | .releaseAssets.nodes[] | {filename: .name, downloads: .downloadCount, release: $tagName, time: ($TIME|tonumber)}' > input.json
 
           jq -c 'select(.filename|endswith("-x86_64.AppImage")) | {name: "github.releases.downloads", tags: ["file=AppImage", "version=\(.release)", "arch=amd64"], value: .downloads, interval: 86400, time: .time}' input.json >> output.json
           jq -c 'select(.filename|endswith("_amd64.deb")) | {name: "github.releases.downloads", tags: ["file=deb", "version=\(.release)", "arch=amd64"], value: .downloads, interval: 86400, time: .time}' input.json >> output.json

--- a/.github/workflows/dl-stats.yml
+++ b/.github/workflows/dl-stats.yml
@@ -48,7 +48,7 @@ jobs:
           jq -c 'select(.filename|endswith("-x86_64.AppImage")) | {name: "github.releases.downloads", tags: ["file=AppImage", "version=\(.release)", "arch=amd64"], value: .downloads, interval: 86400, time: .time}' input.json >> output.json
 
           RESULT=$(jq -s "." output.json)
-          echo "::set-output name=result::${SEM_VER_STR}"
+          echo "::set-output name=result::${RESULT}"
         env:
           JSON_DATA: ${{ steps.get-stats.outputs.result }}
       - name: Upload Results

--- a/.github/workflows/dl-stats.yml
+++ b/.github/workflows/dl-stats.yml
@@ -1,7 +1,6 @@
 name: Report Download Stats
 
 on:
-  push: # TMP
   workflow_dispatch:
 
 jobs:
@@ -9,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get download count of latest releases
-        id: get-dl-stats
+        id: get-stats
         uses: actions/github-script@v6
         with:
           script: |
@@ -35,6 +34,7 @@ jobs:
             }
             return await github.graphql(query, variables)
       - name: Transform Results
+        id: transform-stats
         run: |
           TIME=$(date +%s)
           echo ${JSON_DATA} | jq --arg TIME "$TIME" -c '.repository.releases.nodes[] | select(.isPrerelease == false) | .tagName as $tagName | .releaseAssets.nodes[] | {filename: .name, downloads: .downloadCount, release: $tagName, time: ($TIME|tonumber)}' > input.json
@@ -47,9 +47,17 @@ jobs:
           jq -c 'select(.filename|endswith(".dmg")) | select(.filename|endswith("-arm64.dmg")|not) | {name: "github.releases.downloads", tags: ["file=dmg", "version=\(.release)", "arch=arm64"], value: .downloads, interval: 86400, time: .time}' input.json >> output.json
           jq -c 'select(.filename|endswith("-x86_64.AppImage")) | {name: "github.releases.downloads", tags: ["file=AppImage", "version=\(.release)", "arch=amd64"], value: .downloads, interval: 86400, time: .time}' input.json >> output.json
 
-          jq -s "." output.json
+          RESULT=$(jq -s "." output.json)
+          echo "::set-output name=result::${SEM_VER_STR}"
         env:
-          JSON_DATA: ${{ steps.get-dl-stats.outputs.result }}
+          JSON_DATA: ${{ steps.get-stats.outputs.result }}
+      - name: Upload Results
+        id: upload-stats
+        run: |
+          echo ${STATS} | curl -X POST -H "Authorization: Bearer ${BEARER_TOKEN} -H "Content-Type: application/json" "https://graphite-us-central1.grafana.net/metrics" --data-binary @-
+        env:
+          BEARER_TOKEN : ${{ secrets.GRAFANA_GRAPHITE_TOKEN }}
+          STATS: ${{ steps.transform-stats.outputs.result }}
 
 
 

--- a/.github/workflows/dl-stats.yml
+++ b/.github/workflows/dl-stats.yml
@@ -47,7 +47,7 @@ jobs:
           jq -c 'select(.filename|endswith(".dmg")) | select(.filename|endswith("-arm64.dmg")|not) | {name: "github.releases.downloads", tags: ["file=dmg", "version=\(.release)", "arch=arm64"], value: .downloads, interval: 86400, time: .time}' input.json >> output.json
           jq -c 'select(.filename|endswith("-x86_64.AppImage")) | {name: "github.releases.downloads", tags: ["file=AppImage", "version=\(.release)", "arch=amd64"], value: .downloads, interval: 86400, time: .time}' input.json >> output.json
 
-          RESULT=$(jq -s "." output.json)
+          RESULT=$(jq -s -c "." output.json)
           echo "::set-output name=result::${RESULT}"
         env:
           JSON_DATA: ${{ steps.get-stats.outputs.result }}

--- a/.github/workflows/dl-stats.yml
+++ b/.github/workflows/dl-stats.yml
@@ -1,7 +1,8 @@
 name: Report Download Stats
 
 on:
-  workflow_dispatch:
+  schedule:
+    - cron: '0/15 * * * *' # run every 15 min
 
 jobs:
   report-download-stats:


### PR DESCRIPTION
Adds a workflow that runs every 15 minutes:

Query download counts of most recent non-prerelease releases and report them to Graphite.