### PR TITLE
Add automatic release to winget to msi/exe ci job

### DIFF
--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -188,6 +188,21 @@ jobs:
       semVerStr: ${{ steps.versions.outputs.semVerStr }}
       revNum: ${{ steps.versions.outputs.revNum }}
 
+  publish-winget:
+    name: Publish on winget repo
+    runs-on: windows-latest
+    needs: [build-msi]
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Submit package to Windows Package Manager Community Repository
+        run: |
+          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          $github = Get-Content '${{ github.event_path }}' | ConvertFrom-Json
+          $installerUrl = $github.release.assets | Where-Object -Property name -match 'Cryptomator-*.msi' | Select -ExpandProperty browser_download_url -First 1
+          .\wingetcreate.exe update Cryptomator.Cryptomator -s -v $github.release.tag_name -u $installerUrl -t ${{ secrets.CRYPTOBOT_WINGET_TOKEN }}
+
   build-exe:
     name: Build .exe installer
     runs-on: windows-latest

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -192,9 +192,6 @@ jobs:
     name: Publish on winget repo
     runs-on: windows-latest
     needs: [build-msi]
-    defaults:
-      run:
-        shell: pwsh
     steps:
       - name: Submit package to Windows Package Manager Community Repository
         run: |
@@ -202,6 +199,7 @@ jobs:
           $github = Get-Content '${{ github.event_path }}' | ConvertFrom-Json
           $installerUrl = $github.release.assets | Where-Object -Property name -match 'Cryptomator-*.msi' | Select -ExpandProperty browser_download_url -First 1
           .\wingetcreate.exe update Cryptomator.Cryptomator -s -v $github.release.tag_name -u $installerUrl -t ${{ secrets.CRYPTOBOT_WINGET_TOKEN }}
+        shell: pwsh
 
   build-exe:
     name: Build .exe installer


### PR DESCRIPTION
Merging this PR will on every release automatically create a PR in the Windows Package Manager Community repository (https://github.com/microsoft/winget-pkgs), updating to the latest MSI build by the release.

It is based on [this article](https://www.techwatching.dev/posts/wingetcreate).

What is still required for a successful run:

* [x] Add personal access token of @cryptobot named `CRYPTOBOT_WINGET_TOKEN`

