### PR TITLE
Enumeenize well-known local cloud storage paths

### DIFF
--- a/src/main/java/org/cryptomator/common/LocationPreset.java
+++ b/src/main/java/org/cryptomator/common/LocationPreset.java
@@ -1,0 +1,60 @@
+package org.cryptomator.common;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Enum of common cloud providers and their default local storage location path.
+ */
+public enum LocationPreset {
+
+	DROPBOX("Dropbox", "~/Dropbox"),
+	ICLOUD("iCloud Drive", "~/Library/Mobile Documents/com~apple~CloudDocs", "~/iCloudDrive"),
+	GDRIVE("Google Drive", "~/Google Drive/My Drive", "~/Google Drive"),
+	MEGA("MEGA", "~/MEGA"),
+	ONEDRIVE("OneDrive", "~/OneDrive"),
+	PCLOUD("pCloud", "~/pCloudDrive"),
+
+	LOCAL("local");
+
+	final String name;
+	final List<Path> candidates;
+
+	LocationPreset(String name, String... candidates) {
+		this.name = name;
+
+		String userHome = System.getProperty("user.home");
+		this.candidates = Arrays.stream(candidates).map(c -> LocationPreset.resolveHomePath(userHome, c)).map(Path::of).toList();
+	}
+
+	private static String resolveHomePath(String home, String path) {
+		if (path.startsWith("~/")) {
+			return home + path.substring(1);
+		} else {
+			return path;
+		}
+	}
+
+	/**
+	 * Checks for this LocationPreset if any of the associated paths exist.
+	 *
+	 * @return the first existing path or null, if none exists.
+	 */
+	public Path existingPath() {
+		for (Path candidate : candidates) {
+			if (Files.isDirectory(candidate)) {
+				return candidate;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public String toString() {
+		return name;
+	}
+
+}
+

--- a/src/main/java/org/cryptomator/common/LocationPreset.java
+++ b/src/main/java/org/cryptomator/common/LocationPreset.java
@@ -19,22 +19,12 @@ public enum LocationPreset {
 
 	LOCAL("local");
 
-	final String name;
-	final List<Path> candidates;
+	private final String name;
+	private final List<Path> candidates;
 
 	LocationPreset(String name, String... candidates) {
 		this.name = name;
-
-		String userHome = System.getProperty("user.home");
-		this.candidates = Arrays.stream(candidates).map(c -> LocationPreset.resolveHomePath(userHome, c)).map(Path::of).toList();
-	}
-
-	private static String resolveHomePath(String home, String path) {
-		if (path.startsWith("~/")) {
-			return home + path.substring(1);
-		} else {
-			return path;
-		}
+		this.candidates = Arrays.stream(candidates).map(UserHome::resolve).map(Path::of).toList();
 	}
 
 	/**
@@ -46,9 +36,28 @@ public enum LocationPreset {
 		return candidates.stream().filter(Files::isDirectory).findFirst().orElse(null);
 	}
 
+	public String getDisplayName() {
+		return name;
+	}
+
 	@Override
 	public String toString() {
-		return name;
+		return getDisplayName();
+	}
+
+	//this contruct is needed, since static members are initialized after every enum member is initialized
+	//TODO: refactor this to normal class and use this also in different parts of the project
+	private static class UserHome {
+
+		private static final String USER_HOME = System.getProperty("user.home");
+
+		private static String resolve(String path) {
+			if (path.startsWith("~/")) {
+				return UserHome.USER_HOME + path.substring(1);
+			} else {
+				return path;
+			}
+		}
 	}
 
 }

--- a/src/main/java/org/cryptomator/common/LocationPreset.java
+++ b/src/main/java/org/cryptomator/common/LocationPreset.java
@@ -11,7 +11,7 @@ import java.util.List;
 public enum LocationPreset {
 
 	DROPBOX("Dropbox", "~/Dropbox"),
-	ICLOUD("iCloud Drive", "~/Library/Mobile Documents/com~apple~CloudDocs", "~/iCloudDrive"),
+	ICLOUDDRIVE("iCloud Drive", "~/Library/Mobile Documents/com~apple~CloudDocs", "~/iCloudDrive"),
 	GDRIVE("Google Drive", "~/Google Drive/My Drive", "~/Google Drive"),
 	MEGA("MEGA", "~/MEGA"),
 	ONEDRIVE("OneDrive", "~/OneDrive"),
@@ -43,12 +43,7 @@ public enum LocationPreset {
 	 * @return the first existing path or null, if none exists.
 	 */
 	public Path existingPath() {
-		for (Path candidate : candidates) {
-			if (Files.isDirectory(candidate)) {
-				return candidate;
-			}
-		}
-		return null;
+		return candidates.stream().filter(Files::isDirectory).findFirst().orElse(null);
 	}
 
 	@Override

--- a/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
+++ b/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
@@ -46,7 +46,7 @@ public class CreateNewVaultLocationController implements FxController {
 	private final Stage window;
 	private final Lazy<Scene> chooseNameScene;
 	private final Lazy<Scene> choosePasswordScene;
-	private final LocationPresets locationPresets;
+	private final ObservedLocationPresets locationPresets;
 	private final ObjectProperty<Path> vaultPath;
 	private final StringProperty vaultName;
 	private final ResourceBundle resourceBundle;
@@ -71,7 +71,7 @@ public class CreateNewVaultLocationController implements FxController {
 	public FontAwesome5IconView badLocation;
 
 	@Inject
-	CreateNewVaultLocationController(@AddVaultWizardWindow Stage window, @FxmlScene(FxmlFile.ADDVAULT_NEW_NAME) Lazy<Scene> chooseNameScene, @FxmlScene(FxmlFile.ADDVAULT_NEW_PASSWORD) Lazy<Scene> choosePasswordScene, LocationPresets locationPresets, ObjectProperty<Path> vaultPath, @Named("vaultName") StringProperty vaultName, ResourceBundle resourceBundle) {
+	CreateNewVaultLocationController(@AddVaultWizardWindow Stage window, @FxmlScene(FxmlFile.ADDVAULT_NEW_NAME) Lazy<Scene> chooseNameScene, @FxmlScene(FxmlFile.ADDVAULT_NEW_PASSWORD) Lazy<Scene> choosePasswordScene, ObservedLocationPresets locationPresets, ObjectProperty<Path> vaultPath, @Named("vaultName") StringProperty vaultName, ResourceBundle resourceBundle) {
 		this.window = window;
 		this.chooseNameScene = chooseNameScene;
 		this.choosePasswordScene = choosePasswordScene;
@@ -197,7 +197,7 @@ public class CreateNewVaultLocationController implements FxController {
 		return validVaultPath.get();
 	}
 
-	public LocationPresets getLocationPresets() {
+	public ObservedLocationPresets getObservedLocationPresets() {
 		return locationPresets;
 	}
 

--- a/src/main/java/org/cryptomator/ui/addvaultwizard/ObservedLocationPresets.java
+++ b/src/main/java/org/cryptomator/ui/addvaultwizard/ObservedLocationPresets.java
@@ -1,23 +1,15 @@
 package org.cryptomator.ui.addvaultwizard;
 
+import org.cryptomator.common.LocationPreset;
+
 import javax.inject.Inject;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 @AddVaultWizardScoped
-public class LocationPresets {
-
-	private static final String USER_HOME = System.getProperty("user.home");
-	private static final String[] ICLOUDDRIVE_LOCATIONS = {"~/Library/Mobile Documents/iCloud~com~setolabs~Cryptomator/Documents", "~/iCloudDrive/iCloud~com~setolabs~Cryptomator"};
-	private static final String[] DROPBOX_LOCATIONS = {"~/Dropbox"};
-	private static final String[] GDRIVE_LOCATIONS = {"~/Google Drive/My Drive", "~/Google Drive"};
-	private static final String[] ONEDRIVE_LOCATIONS = {"~/OneDrive"};
-	private static final String[] MEGA_LOCATIONS = {"~/MEGA"};
-	private static final String[] PCLOUD_LOCATIONS = {"~/pCloudDrive"};
+public class ObservedLocationPresets {
 
 	private final ReadOnlyObjectProperty<Path> iclouddriveLocation;
 	private final ReadOnlyObjectProperty<Path> dropboxLocation;
@@ -33,37 +25,19 @@ public class LocationPresets {
 	private final BooleanBinding foundPcloud;
 
 	@Inject
-	public LocationPresets() {
-		this.iclouddriveLocation = new SimpleObjectProperty<>(existingWritablePath(ICLOUDDRIVE_LOCATIONS));
-		this.dropboxLocation = new SimpleObjectProperty<>(existingWritablePath(DROPBOX_LOCATIONS));
-		this.gdriveLocation = new SimpleObjectProperty<>(existingWritablePath(GDRIVE_LOCATIONS));
-		this.onedriveLocation = new SimpleObjectProperty<>(existingWritablePath(ONEDRIVE_LOCATIONS));
-		this.megaLocation = new SimpleObjectProperty<>(existingWritablePath(MEGA_LOCATIONS));
-		this.pcloudLocation = new SimpleObjectProperty<>(existingWritablePath(PCLOUD_LOCATIONS));
+	public ObservedLocationPresets() {
+		this.iclouddriveLocation = new SimpleObjectProperty<>(LocationPreset.ICLOUD.existingPath());
+		this.dropboxLocation = new SimpleObjectProperty<>(LocationPreset.DROPBOX.existingPath());
+		this.gdriveLocation = new SimpleObjectProperty<>(LocationPreset.GDRIVE.existingPath());
+		this.onedriveLocation = new SimpleObjectProperty<>(LocationPreset.ONEDRIVE.existingPath());
+		this.megaLocation = new SimpleObjectProperty<>(LocationPreset.MEGA.existingPath());
+		this.pcloudLocation = new SimpleObjectProperty<>(LocationPreset.PCLOUD.existingPath());
 		this.foundIclouddrive = iclouddriveLocation.isNotNull();
 		this.foundDropbox = dropboxLocation.isNotNull();
 		this.foundGdrive = gdriveLocation.isNotNull();
 		this.foundOnedrive = onedriveLocation.isNotNull();
 		this.foundMega = megaLocation.isNotNull();
 		this.foundPcloud = pcloudLocation.isNotNull();
-	}
-
-	private static Path existingWritablePath(String... candidates) {
-		for (String candidate : candidates) {
-			Path path = Paths.get(resolveHomePath(candidate));
-			if (Files.isDirectory(path)) {
-				return path;
-			}
-		}
-		return null;
-	}
-
-	private static String resolveHomePath(String path) {
-		if (path.startsWith("~/")) {
-			return USER_HOME + path.substring(1);
-		} else {
-			return path;
-		}
 	}
 
 	/* Observables */

--- a/src/main/java/org/cryptomator/ui/addvaultwizard/ObservedLocationPresets.java
+++ b/src/main/java/org/cryptomator/ui/addvaultwizard/ObservedLocationPresets.java
@@ -26,7 +26,7 @@ public class ObservedLocationPresets {
 
 	@Inject
 	public ObservedLocationPresets() {
-		this.iclouddriveLocation = new SimpleObjectProperty<>(LocationPreset.ICLOUD.existingPath());
+		this.iclouddriveLocation = new SimpleObjectProperty<>(LocationPreset.ICLOUDDRIVE.existingPath());
 		this.dropboxLocation = new SimpleObjectProperty<>(LocationPreset.DROPBOX.existingPath());
 		this.gdriveLocation = new SimpleObjectProperty<>(LocationPreset.GDRIVE.existingPath());
 		this.onedriveLocation = new SimpleObjectProperty<>(LocationPreset.ONEDRIVE.existingPath());

--- a/src/main/resources/fxml/addvault_new_location.fxml
+++ b/src/main/resources/fxml/addvault_new_location.fxml
@@ -31,12 +31,12 @@
 
 		<VBox spacing="6">
 			<Label wrapText="true" text="%addvaultwizard.new.locationInstruction"/>
-			<RadioButton fx:id="iclouddriveRadioButton" toggleGroup="${predefinedLocationToggler}" text="iCloud Drive" visible="${controller.locationPresets.foundIclouddrive}" managed="${controller.locationPresets.foundIclouddrive}"/>
-			<RadioButton fx:id="dropboxRadioButton" toggleGroup="${predefinedLocationToggler}" text="Dropbox" visible="${controller.locationPresets.foundDropbox}" managed="${controller.locationPresets.foundDropbox}"/>
-			<RadioButton fx:id="gdriveRadioButton" toggleGroup="${predefinedLocationToggler}" text="Google Drive" visible="${controller.locationPresets.foundGdrive}" managed="${controller.locationPresets.foundGdrive}"/>
-			<RadioButton fx:id="onedriveRadioButton" toggleGroup="${predefinedLocationToggler}" text="OneDrive" visible="${controller.locationPresets.foundOnedrive}" managed="${controller.locationPresets.foundOnedrive}"/>
-			<RadioButton fx:id="megaRadioButton" toggleGroup="${predefinedLocationToggler}" text="MEGA" visible="${controller.locationPresets.foundMega}" managed="${controller.locationPresets.foundMega}"/>
-			<RadioButton fx:id="pcloudRadioButton" toggleGroup="${predefinedLocationToggler}" text="pCloud" visible="${controller.locationPresets.foundPcloud}" managed="${controller.locationPresets.foundPcloud}"/>
+			<RadioButton fx:id="iclouddriveRadioButton" toggleGroup="${predefinedLocationToggler}" text="iCloud Drive" visible="${controller.observedLocationPresets.foundIclouddrive}" managed="${controller.observedLocationPresets.foundIclouddrive}"/>
+			<RadioButton fx:id="dropboxRadioButton" toggleGroup="${predefinedLocationToggler}" text="Dropbox" visible="${controller.observedLocationPresets.foundDropbox}" managed="${controller.observedLocationPresets.foundDropbox}"/>
+			<RadioButton fx:id="gdriveRadioButton" toggleGroup="${predefinedLocationToggler}" text="Google Drive" visible="${controller.observedLocationPresets.foundGdrive}" managed="${controller.observedLocationPresets.foundGdrive}"/>
+			<RadioButton fx:id="onedriveRadioButton" toggleGroup="${predefinedLocationToggler}" text="OneDrive" visible="${controller.observedLocationPresets.foundOnedrive}" managed="${controller.observedLocationPresets.foundOnedrive}"/>
+			<RadioButton fx:id="megaRadioButton" toggleGroup="${predefinedLocationToggler}" text="MEGA" visible="${controller.observedLocationPresets.foundMega}" managed="${controller.observedLocationPresets.foundMega}"/>
+			<RadioButton fx:id="pcloudRadioButton" toggleGroup="${predefinedLocationToggler}" text="pCloud" visible="${controller.observedLocationPresets.foundPcloud}" managed="${controller.observedLocationPresets.foundPcloud}"/>
 			<HBox spacing="12" alignment="CENTER_LEFT">
 				<RadioButton fx:id="customRadioButton" toggleGroup="${predefinedLocationToggler}" text="%addvaultwizard.new.directoryPickerLabel"/>
 				<Button contentDisplay="LEFT" text="%addvaultwizard.new.directoryPickerButton" onAction="#chooseCustomVaultPath" disable="${controller.usePresetPath}">


### PR DESCRIPTION
With this PR the formerly used `LocationPresets` class is just an observable wrapper for the new `LocationPreset` enum, which encapsulates for different cloud storage providers their normally used local paths.