### PR TITLE
Use Xcode Notarization Action

### DIFF
--- a/.github/workflows/mac-dmg.yml
+++ b/.github/workflows/mac-dmg.yml
@@ -189,7 +189,7 @@ jobs:
         env:
           VERSION_NO: ${{ steps.versions.outputs.semVerNum }}
       - name: Notarize .dmg
-        #if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/')
         uses: cocoalibs/xcode-notarization-action@v1
         with:
           app-path: 'Cryptomator-*.dmg'

--- a/.github/workflows/mac-dmg.yml
+++ b/.github/workflows/mac-dmg.yml
@@ -188,33 +188,14 @@ jobs:
           Cryptomator-${VERSION_NO}.dmg dmg
         env:
           VERSION_NO: ${{ steps.versions.outputs.semVerNum }}
-      - name: Install notarization credentials
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          # create temporary keychain
-          KEYCHAIN_PATH=$RUNNER_TEMP/notarization.keychain-db
-          security create-keychain -p "${NOTARIZATION_TMP_KEYCHAIN_PW}" ${KEYCHAIN_PATH}
-          security set-keychain-settings -lut 900 ${KEYCHAIN_PATH}
-          security unlock-keychain -p "${NOTARIZATION_TMP_KEYCHAIN_PW}" ${KEYCHAIN_PATH}
-
-          # import credentials from secrets
-          sudo xcode-select -s /Applications/Xcode_13.0.app
-          xcrun notarytool store-credentials "${NOTARIZATION_KEYCHAIN_PROFILE}" --apple-id "${NOTARIZATION_APPLE_ID}" --password "${NOTARIZATION_PW}" --team-id "${NOTARIZATION_TEAM_ID}" --keychain "${KEYCHAIN_PATH}"
-        env:
-          NOTARIZATION_KEYCHAIN_PROFILE: ${{ secrets.MACOS_NOTARIZATION_KEYCHAIN_PROFILE }}
-          NOTARIZATION_APPLE_ID: ${{ secrets.MACOS_NOTARIZATION_APPLE_ID }}
-          NOTARIZATION_PW: ${{ secrets.MACOS_NOTARIZATION_PW }}
-          NOTARIZATION_TEAM_ID: ${{ secrets.MACOS_NOTARIZATION_TEAM_ID }}
-          NOTARIZATION_TMP_KEYCHAIN_PW: ${{ secrets.MACOS_NOTARIZATION_TMP_KEYCHAIN_PW }}
       - name: Notarize .dmg
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          KEYCHAIN_PATH=$RUNNER_TEMP/notarization.keychain-db
-          sudo xcode-select -s /Applications/Xcode_13.0.app
-          xcrun notarytool submit Cryptomator-*.dmg --keychain-profile "${NOTARIZATION_KEYCHAIN_PROFILE}" --keychain "${KEYCHAIN_PATH}" --wait
-          xcrun stapler staple Cryptomator-*.dmg
-        env:
-          NOTARIZATION_KEYCHAIN_PROFILE: ${{ secrets.MACOS_NOTARIZATION_KEYCHAIN_PROFILE }}
+        #if: startsWith(github.ref, 'refs/tags/')
+        uses: cocoalibs/xcode-notarization-action@v1
+        with:
+          app-path: 'Cryptomator-*.dmg'
+          apple-id: ${{ secrets.MACOS_NOTARIZATION_APPLE_ID }}
+          password: ${{ secrets.MACOS_NOTARIZATION_PW }}
+          team-id: ${{ secrets.MACOS_NOTARIZATION_TEAM_ID }}
       - name: Add possible alpha/beta tags to installer name
         run: mv Cryptomator-*.dmg Cryptomator-${{ steps.versions.outputs.semVerStr }}.dmg
       - name: Create detached GPG signature with key 615D449FE6E6A235
@@ -227,10 +208,6 @@ jobs:
       - name: Clean up codesign certificate
         if: ${{ always() }}
         run: security delete-keychain $RUNNER_TEMP/codesign.keychain-db
-        continue-on-error: true
-      - name: Clean up notarization credentials
-        if: ${{ always() }}
-        run: security delete-keychain $RUNNER_TEMP/notarization.keychain-db
         continue-on-error: true
       - name: Upload artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Replaced custom steps with [`xcode-notarization-action`](https://github.com/cocoalibs/xcode-notarization-action).

Secrets `MACOS_NOTARIZATION_KEYCHAIN_PROFILE` and `MACOS_NOTARIZATION_TMP_KEYCHAIN_PW` are no longer required after merging.

Tested in [this build](https://github.com/cryptomator/cryptomator/runs/6607664627?check_suite_focus=true#step:17:1).