### PR TITLE
Improve Hub dialogs

### DIFF
--- a/src/main/java/org/cryptomator/ui/common/FxmlFile.java
+++ b/src/main/java/org/cryptomator/ui/common/FxmlFile.java
@@ -16,6 +16,7 @@ public enum FxmlFile {
 	HUB_AUTH_FLOW("/fxml/hub_auth_flow.fxml"), //
 	HUB_RECEIVE_KEY("/fxml/hub_receive_key.fxml"), //
 	HUB_REGISTER_DEVICE("/fxml/hub_register_device.fxml"), //
+	HUB_REGISTER_SUCCESS("/fxml/hub_register_success.fxml"), //
 	HUB_UNAUTHORIZED_DEVICE("/fxml/hub_unauthorized_device.fxml"), //
 	LOCK_FORCED("/fxml/lock_forced.fxml"), //
 	LOCK_FAILED("/fxml/lock_failed.fxml"), //

--- a/src/main/java/org/cryptomator/ui/common/FxmlFile.java
+++ b/src/main/java/org/cryptomator/ui/common/FxmlFile.java
@@ -17,6 +17,7 @@ public enum FxmlFile {
 	HUB_RECEIVE_KEY("/fxml/hub_receive_key.fxml"), //
 	HUB_REGISTER_DEVICE("/fxml/hub_register_device.fxml"), //
 	HUB_REGISTER_SUCCESS("/fxml/hub_register_success.fxml"), //
+	HUB_REGISTER_FAILED("/fxml/hub_register_failed.fxml"),
 	HUB_UNAUTHORIZED_DEVICE("/fxml/hub_unauthorized_device.fxml"), //
 	LOCK_FORCED("/fxml/lock_forced.fxml"), //
 	LOCK_FAILED("/fxml/lock_failed.fxml"), //

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/AuthFlowController.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/AuthFlowController.java
@@ -38,7 +38,6 @@ public class AuthFlowController implements FxController {
 	private final CompletableFuture<JWEObject> result;
 	private final Lazy<Scene> receiveKeyScene;
 	private final ObjectProperty<URI> authUri;
-	private final StringBinding authHost;
 	private AuthFlowTask task;
 
 	@Inject
@@ -52,7 +51,6 @@ public class AuthFlowController implements FxController {
 		this.result = result;
 		this.receiveKeyScene = receiveKeyScene;
 		this.authUri = new SimpleObjectProperty<>();
-		this.authHost = Bindings.createStringBinding(this::getAuthHost, authUri);
 		this.window.addEventHandler(WindowEvent.WINDOW_HIDING, this::windowClosed);
 	}
 
@@ -98,21 +96,6 @@ public class AuthFlowController implements FxController {
 		window.requestFocus();
 		var exception = workerStateEvent.getSource().getException();
 		result.completeExceptionally(exception);
-	}
-
-	/* Getter/Setter */
-
-	public StringBinding authHostProperty() {
-		return authHost;
-	}
-
-	public String getAuthHost() {
-		var uri = authUri.get();
-		if (uri == null) {
-			return "";
-		} else {
-			return uri.getAuthority().toString();
-		}
 	}
 
 }

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/HubKeyLoadingModule.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/HubKeyLoadingModule.java
@@ -114,6 +114,13 @@ public abstract class HubKeyLoadingModule {
 	}
 
 	@Provides
+	@FxmlScene(FxmlFile.HUB_REGISTER_FAILED)
+	@KeyLoadingScoped
+	static Scene provideHubRegisterFailedScene(@KeyLoading FxmlLoaderFactory fxmlLoaders) {
+		return fxmlLoaders.createScene(FxmlFile.HUB_REGISTER_FAILED);
+	}
+
+	@Provides
 	@FxmlScene(FxmlFile.HUB_UNAUTHORIZED_DEVICE)
 	@KeyLoadingScoped
 	static Scene provideHubUnauthorizedDeviceScene(@KeyLoading FxmlLoaderFactory fxmlLoaders) {
@@ -146,6 +153,11 @@ public abstract class HubKeyLoadingModule {
 	@IntoMap
 	@FxControllerKey(RegisterSuccessController.class)
 	abstract FxController bindRegisterSuccessController(RegisterSuccessController controller);
+
+	@Binds
+	@IntoMap
+	@FxControllerKey(RegisterFailedController.class)
+	abstract FxController bindRegisterFailedController(RegisterFailedController controller);
 
 	@Binds
 	@IntoMap

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/HubKeyLoadingModule.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/HubKeyLoadingModule.java
@@ -45,6 +45,14 @@ public abstract class HubKeyLoadingModule {
 
 	@Provides
 	@KeyLoadingScoped
+	@Named("windowTitle")
+	static String provideWindowTitle(@KeyLoading Vault vault, ResourceBundle resourceBundle) {
+		return String.format(resourceBundle.getString("unlock.title"), vault.getDisplayName());
+	}
+
+
+	@Provides
+	@KeyLoadingScoped
 	@Named("deviceId")
 	static String provideDeviceId(DeviceKey deviceKey) {
 		var publicKey = Objects.requireNonNull(deviceKey.get()).getPublic().getEncoded();

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/HubKeyLoadingModule.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/HubKeyLoadingModule.java
@@ -107,6 +107,13 @@ public abstract class HubKeyLoadingModule {
 	}
 
 	@Provides
+	@FxmlScene(FxmlFile.HUB_REGISTER_SUCCESS)
+	@KeyLoadingScoped
+	static Scene provideHubRegisterSuccessScene(@KeyLoading FxmlLoaderFactory fxmlLoaders) {
+		return fxmlLoaders.createScene(FxmlFile.HUB_REGISTER_SUCCESS);
+	}
+
+	@Provides
 	@FxmlScene(FxmlFile.HUB_UNAUTHORIZED_DEVICE)
 	@KeyLoadingScoped
 	static Scene provideHubUnauthorizedDeviceScene(@KeyLoading FxmlLoaderFactory fxmlLoaders) {
@@ -134,6 +141,11 @@ public abstract class HubKeyLoadingModule {
 	@IntoMap
 	@FxControllerKey(RegisterDeviceController.class)
 	abstract FxController bindRegisterDeviceController(RegisterDeviceController controller);
+
+	@Binds
+	@IntoMap
+	@FxControllerKey(RegisterSuccessController.class)
+	abstract FxController bindRegisterSuccessController(RegisterSuccessController controller);
 
 	@Binds
 	@IntoMap

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/HubKeyLoadingStrategy.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/HubKeyLoadingStrategy.java
@@ -13,6 +13,7 @@ import org.cryptomator.ui.keyloading.KeyLoadingStrategy;
 import org.cryptomator.ui.unlock.UnlockCancelledException;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
@@ -35,8 +36,9 @@ public class HubKeyLoadingStrategy implements KeyLoadingStrategy {
 	private final DeviceKey deviceKey;
 
 	@Inject
-	public HubKeyLoadingStrategy(@KeyLoading Stage window, @FxmlScene(FxmlFile.HUB_AUTH_FLOW) Lazy<Scene> authFlowScene, CompletableFuture<JWEObject> result, DeviceKey deviceKey) {
+	public HubKeyLoadingStrategy(@KeyLoading Stage window, @FxmlScene(FxmlFile.HUB_AUTH_FLOW) Lazy<Scene> authFlowScene, CompletableFuture<JWEObject> result, DeviceKey deviceKey, @Named("windowTitle") String windowTitle) {
 		this.window = window;
+		window.setTitle(windowTitle);
 		this.authFlowScene = authFlowScene;
 		this.result = result;
 		this.deviceKey = deviceKey;

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/ReceiveKeyController.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/ReceiveKeyController.java
@@ -35,7 +35,6 @@ import java.util.concurrent.atomic.AtomicReference;
 @KeyLoadingScoped
 public class ReceiveKeyController implements FxController {
 
-	private static final Logger LOG = LoggerFactory.getLogger(ReceiveKeyController.class);
 	private static final String SCHEME_PREFIX = "hub+";
 
 	private final Stage window;

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/RegisterDeviceController.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/RegisterDeviceController.java
@@ -25,6 +25,9 @@ import javafx.scene.Scene;
 import javafx.scene.control.TextField;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -33,6 +36,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
 
 @KeyLoadingScoped
@@ -69,6 +73,18 @@ public class RegisterDeviceController implements FxController {
 		this.httpClient = HttpClient.newBuilder().executor(executor).build();
 	}
 
+	public void initialize() {
+		deviceNameField.setText(System.getProperty("user.name") + "-" + determineHostname());
+	}
+
+	private String determineHostname() {
+		try {
+			return new BufferedReader(new InputStreamReader(Runtime.getRuntime().exec("hostname").getInputStream())).readLine();
+		} catch (IOException e) {
+			return String.valueOf(ThreadLocalRandom.current().nextInt());
+		}
+	}
+
 	@FXML
 	public void register() {
 		var keyUri = URI.create(hubConfig.devicesResourceUrl + deviceId);
@@ -84,7 +100,7 @@ public class RegisterDeviceController implements FxController {
 				.build();
 		httpClient.sendAsync(request, HttpResponse.BodyHandlers.discarding()) //
 				.handleAsync((response, throwable) -> {
-					if( response != null) {
+					if (response != null) {
 						this.registrationSucceeded(response);
 					} else {
 						this.registrationFailed(throwable);

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/RegisterDeviceController.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/RegisterDeviceController.java
@@ -78,8 +78,10 @@ public class RegisterDeviceController implements FxController {
 	}
 
 	private String determineHostname() {
-		try {
-			return new BufferedReader(new InputStreamReader(Runtime.getRuntime().exec("hostname").getInputStream())).readLine();
+		try (var inputStream = Runtime.getRuntime().exec("hostname").getInputStream(); //
+			 var streamReader = new InputStreamReader(inputStream); //
+			 var bufferedReader = new BufferedReader(streamReader)) {
+			return bufferedReader.readLine();
 		} catch (IOException e) {
 			return String.valueOf(ThreadLocalRandom.current().nextInt());
 		}

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/RegisterDeviceController.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/RegisterDeviceController.java
@@ -25,9 +25,8 @@ import javafx.scene.Scene;
 import javafx.scene.control.TextField;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -36,7 +35,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
 
 @KeyLoadingScoped
@@ -74,16 +72,15 @@ public class RegisterDeviceController implements FxController {
 	}
 
 	public void initialize() {
-		deviceNameField.setText(System.getProperty("user.name") + "-" + determineHostname());
+		deviceNameField.setText(determineHostname());
 	}
 
 	private String determineHostname() {
-		try (var inputStream = Runtime.getRuntime().exec("hostname").getInputStream(); //
-			 var streamReader = new InputStreamReader(inputStream); //
-			 var bufferedReader = new BufferedReader(streamReader)) {
-			return bufferedReader.readLine();
+		try {
+			var hostName = InetAddress.getLocalHost().getHostName();
+			return Objects.requireNonNullElse(hostName, "");
 		} catch (IOException e) {
-			return String.valueOf(ThreadLocalRandom.current().nextInt());
+			return "";
 		}
 	}
 

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/RegisterFailedController.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/RegisterFailedController.java
@@ -1,0 +1,29 @@
+package org.cryptomator.ui.keyloading.hub;
+
+import com.nimbusds.jose.JWEObject;
+import org.cryptomator.ui.common.FxController;
+import org.cryptomator.ui.keyloading.KeyLoading;
+
+import javax.inject.Inject;
+import javafx.fxml.FXML;
+import javafx.stage.Stage;
+import java.util.concurrent.CompletableFuture;
+
+public class RegisterFailedController implements FxController {
+
+	private final Stage window;
+	private final CompletableFuture<JWEObject> result;
+
+	@Inject
+	public RegisterFailedController(@KeyLoading Stage window, CompletableFuture<JWEObject> result) {
+		this.window = window;
+		this.result = result;
+	}
+
+	@FXML
+	public void close() {
+		window.close();
+	}
+
+
+}

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/RegisterSuccessController.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/RegisterSuccessController.java
@@ -1,0 +1,24 @@
+package org.cryptomator.ui.keyloading.hub;
+
+import org.cryptomator.ui.common.FxController;
+import org.cryptomator.ui.keyloading.KeyLoading;
+
+import javax.inject.Inject;
+import javafx.fxml.FXML;
+import javafx.stage.Stage;
+
+public class RegisterSuccessController implements FxController {
+
+	private final Stage window;
+
+	@Inject
+	public RegisterSuccessController(@KeyLoading Stage window) {
+		this.window = window;
+	}
+
+	@FXML
+	public void close() {
+		window.close();
+	}
+
+}

--- a/src/main/resources/fxml/hub_auth_flow.fxml
+++ b/src/main/resources/fxml/hub_auth_flow.fxml
@@ -1,37 +1,58 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import org.cryptomator.ui.controls.FontAwesome5Spinner?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.ButtonBar?>
 <?import javafx.scene.control.Hyperlink?>
-<?import javafx.scene.image.Image?>
-<?import javafx.scene.image.ImageView?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.Group?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
-<?import javafx.scene.text.Text?>
+<?import javafx.scene.shape.Circle?>
 <?import javafx.scene.text.TextFlow?>
-<VBox xmlns:fx="http://javafx.com/fxml"
+<?import org.cryptomator.ui.controls.FontAwesome5IconView?>
+<HBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
 	  fx:controller="org.cryptomator.ui.keyloading.hub.AuthFlowController"
 	  minWidth="400"
 	  maxWidth="400"
 	  minHeight="145"
-	  spacing="12">
+	  spacing="12"
+	  alignment="TOP_LEFT">
 	<padding>
 		<Insets topRightBottomLeft="12"/>
 	</padding>
 	<children>
-		<HBox spacing="12" VBox.vgrow="ALWAYS">
-			<ImageView VBox.vgrow="ALWAYS" fitWidth="64" preserveRatio="true" cache="true">
-				<Image url="@../img/bot/bot.png"/>
-			</ImageView>
-			<TextFlow visible="${!controller.authHost.empty}" managed="${!controller.authHost.empty}">
-				<Text text="TODO: please login via " />
-				<Hyperlink styleClass="hyperlink-underline" text="${controller.authHost}" onAction="#browse"/>
-			</TextFlow>
-		</HBox>
+		<Group>
+			<StackPane>
+				<padding>
+					<Insets topRightBottomLeft="6"/>
+				</padding>
+				<Circle styleClass="glyph-icon-primary" radius="24"/>
+				<FontAwesome5Spinner styleClass="glyph-icon-white" glyphSize="24"/>
+			</StackPane>
+		</Group>
 
-		<VBox alignment="BOTTOM_CENTER" VBox.vgrow="ALWAYS">
+		<VBox HBox.hgrow="ALWAYS">
+			<Label styleClass="label-large" text="%hub.auth.message" wrapText="true" textAlignment="LEFT">
+				<padding>
+					<Insets bottom="6" top="6"/>
+				</padding>
+			</Label>
+			<Label text="%hub.auth.description" wrapText="true"/>
+			<Hyperlink styleClass="hyperlink-underline" text="%hub.auth.loginLink" onAction="#browse">
+				<graphic>
+					<FontAwesome5IconView glyph="LINK" glyphSize="12"/>
+				</graphic>
+				<padding>
+					<Insets top="12"/>
+				</padding>
+			</Hyperlink>
+
+			<Region VBox.vgrow="ALWAYS" minHeight="18"/>
 			<ButtonBar buttonMinWidth="120" buttonOrder="+C">
 				<buttons>
 					<Button text="%generic.button.cancel" ButtonBar.buttonData="CANCEL_CLOSE" cancelButton="true" onAction="#cancel"/>
@@ -39,4 +60,4 @@
 			</ButtonBar>
 		</VBox>
 	</children>
-</VBox>
+</HBox>

--- a/src/main/resources/fxml/hub_receive_key.fxml
+++ b/src/main/resources/fxml/hub_receive_key.fxml
@@ -4,30 +4,44 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.ButtonBar?>
-<?import javafx.scene.image.Image?>
-<?import javafx.scene.image.ImageView?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.Group?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
-<VBox xmlns:fx="http://javafx.com/fxml"
+<?import javafx.scene.shape.Circle?>
+<HBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
 	  fx:controller="org.cryptomator.ui.keyloading.hub.ReceiveKeyController"
 	  minWidth="400"
 	  maxWidth="400"
 	  minHeight="145"
-	  spacing="12">
+	  spacing="12"
+	  alignment="TOP_LEFT">
 	<padding>
 		<Insets topRightBottomLeft="12"/>
 	</padding>
 	<children>
-		<HBox spacing="12" VBox.vgrow="ALWAYS">
-			<ImageView VBox.vgrow="ALWAYS" fitWidth="64" preserveRatio="true" cache="true">
-				<Image url="@../img/bot/bot.png"/>
-			</ImageView>
+		<Group>
+			<StackPane>
+				<padding>
+					<Insets topRightBottomLeft="6"/>
+				</padding>
+				<Circle styleClass="glyph-icon-primary" radius="24"/>
+				<FontAwesome5Spinner styleClass="glyph-icon-white" glyphSize="24"/>
+			</StackPane>
+		</Group>
 
-			<FontAwesome5Spinner glyphSize="12"/>
-		</HBox>
+		<VBox HBox.hgrow="ALWAYS">
+			<Label styleClass="label-large" text="%hub.receive.message" wrapText="true" textAlignment="LEFT">
+				<padding>
+					<Insets bottom="6" top="6"/>
+				</padding>
+			</Label>
+			<Label text="%hub.receive.description" wrapText="true"/>
 
-		<VBox alignment="BOTTOM_CENTER" VBox.vgrow="ALWAYS">
+			<Region VBox.vgrow="ALWAYS" minHeight="18"/>
 			<ButtonBar buttonMinWidth="120" buttonOrder="+C">
 				<buttons>
 					<Button text="%generic.button.cancel" ButtonBar.buttonData="CANCEL_CLOSE" cancelButton="true" onAction="#cancel"/>
@@ -35,4 +49,4 @@
 			</ButtonBar>
 		</VBox>
 	</children>
-</VBox>
+</HBox>

--- a/src/main/resources/fxml/hub_register_device.fxml
+++ b/src/main/resources/fxml/hub_register_device.fxml
@@ -1,52 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import org.cryptomator.ui.controls.FormattedLabel?>
+<?import org.cryptomator.ui.controls.FontAwesome5IconView?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.ButtonBar?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.TextField?>
-<?import javafx.scene.image.Image?>
-<?import javafx.scene.image.ImageView?>
+<?import javafx.scene.Group?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
-<VBox xmlns:fx="http://javafx.com/fxml"
+<?import javafx.scene.shape.Circle?>
+<HBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
 	  fx:controller="org.cryptomator.ui.keyloading.hub.RegisterDeviceController"
 	  minWidth="400"
 	  maxWidth="400"
 	  minHeight="145"
-	  spacing="12">
+	  spacing="12"
+	  alignment="TOP_LEFT">
 	<padding>
 		<Insets topRightBottomLeft="12"/>
 	</padding>
 	<children>
-		<HBox spacing="12" VBox.vgrow="ALWAYS">
-			<HBox alignment="CENTER">
-				<ImageView VBox.vgrow="ALWAYS" fitWidth="64" preserveRatio="true" cache="true">
-					<Image url="@../img/bot/bot.png"/>
-				</ImageView>
+		<Group>
+			<StackPane>
+				<padding>
+					<Insets topRightBottomLeft="6"/>
+				</padding>
+				<Circle styleClass="glyph-icon-primary" radius="24"/>
+				<FontAwesome5IconView styleClass="glyph-icon-white" glyph="INFO" glyphSize="24"/>
+			</StackPane>
+		</Group>
+
+		<VBox HBox.hgrow="ALWAYS">
+			<Label styleClass="label-large" text="%hub.register.message" wrapText="true" textAlignment="LEFT">
+				<padding>
+					<Insets bottom="6" top="6"/>
+				</padding>
+			</Label>
+			<Label text="%hub.register.description" wrapText="true"/>
+			<HBox spacing="6" alignment="CENTER_LEFT">
+				<padding>
+					<Insets top="12"/>
+				</padding>
+				<Label text="%hub.register.nameLabel" labelFor="$deviceNameField"/>
+				<TextField fx:id="deviceNameField" HBox.hgrow="ALWAYS"/>
 			</HBox>
 
-			<VBox spacing="6">
-				<Label text="TODO This device is not yet known to Cryptomator Hub. Please register this device first." wrapText="true"/>
-				<HBox spacing="6" alignment="CENTER_LEFT">
-					<FormattedLabel format="TODO User %s" arg1="${controller.userName}"/>
-				</HBox>
-				<HBox spacing="6" alignment="CENTER_LEFT">
-					<Label text="TODO Device Name" labelFor="$deviceNameField"/>
-					<TextField fx:id="deviceNameField"/>
-				</HBox>
-			</VBox>
-		</HBox>
-
-		<VBox alignment="BOTTOM_CENTER" VBox.vgrow="ALWAYS">
+			<Region VBox.vgrow="ALWAYS" minHeight="18"/>
 			<ButtonBar buttonMinWidth="120" buttonOrder="+CU">
 				<buttons>
 					<Button text="%generic.button.close" ButtonBar.buttonData="CANCEL_CLOSE" cancelButton="true" onAction="#close"/>
-					<Button text="TODO Register Device" ButtonBar.buttonData="OTHER" defaultButton="true" onAction="#register"/>
+					<Button text="%hub.register.registerBtn" ButtonBar.buttonData="OTHER" defaultButton="true" onAction="#register"/>
 				</buttons>
 			</ButtonBar>
 		</VBox>
 	</children>
-</VBox>
+</HBox>

--- a/src/main/resources/fxml/hub_register_failed.fxml
+++ b/src/main/resources/fxml/hub_register_failed.fxml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import org.cryptomator.ui.controls.FontAwesome5IconView?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.ButtonBar?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.Group?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.shape.Circle?>
+<HBox xmlns:fx="http://javafx.com/fxml"
+	  xmlns="http://javafx.com/javafx"
+	  fx:controller="org.cryptomator.ui.keyloading.hub.RegisterFailedController"
+	  minWidth="400"
+	  maxWidth="400"
+	  minHeight="145"
+	  spacing="12"
+	  alignment="TOP_LEFT">
+	<padding>
+		<Insets topRightBottomLeft="12"/>
+	</padding>
+	<children>
+		<Group>
+			<StackPane>
+				<padding>
+					<Insets topRightBottomLeft="6"/>
+				</padding>
+				<Circle styleClass="glyph-icon-primary" radius="24"/>
+				<FontAwesome5IconView styleClass="glyph-icon-white" glyph="EXCLAMATION" glyphSize="24"/>
+			</StackPane>
+		</Group>
+		<VBox HBox.hgrow="ALWAYS">
+			<Label styleClass="label-large" text="%hub.registerFailed.message" wrapText="true" textAlignment="LEFT">
+				<padding>
+					<Insets bottom="6" top="6"/>
+				</padding>
+			</Label>
+			<Label text="%hub.registerFailed.description" wrapText="true"/>
+
+			<Region VBox.vgrow="ALWAYS" minHeight="18"/>
+			<ButtonBar buttonMinWidth="120" buttonOrder="+C">
+				<buttons>
+					<Button text="%generic.button.close" ButtonBar.buttonData="CANCEL_CLOSE" defaultButton="true" onAction="#close"/>
+				</buttons>
+			</ButtonBar>
+		</VBox>
+	</children>
+</HBox>

--- a/src/main/resources/fxml/hub_register_success.fxml
+++ b/src/main/resources/fxml/hub_register_success.fxml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import org.cryptomator.ui.controls.FontAwesome5IconView?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.ButtonBar?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.Group?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.shape.Circle?>
+<HBox xmlns:fx="http://javafx.com/fxml"
+	  xmlns="http://javafx.com/javafx"
+	  fx:controller="org.cryptomator.ui.keyloading.hub.RegisterSuccessController"
+	  minWidth="400"
+	  maxWidth="400"
+	  minHeight="145"
+	  spacing="12"
+	  alignment="TOP_LEFT">
+	<padding>
+		<Insets topRightBottomLeft="12"/>
+	</padding>
+	<children>
+		<Group>
+			<StackPane>
+				<padding>
+					<Insets topRightBottomLeft="6"/>
+				</padding>
+				<Circle styleClass="glyph-icon-primary" radius="24"/>
+				<FontAwesome5IconView styleClass="glyph-icon-white" glyph="CHECK" glyphSize="24"/>
+			</StackPane>
+		</Group>
+		<VBox HBox.hgrow="ALWAYS">
+			<Label styleClass="label-large" text="%hub.registerSuccess.message" wrapText="true" textAlignment="LEFT">
+				<padding>
+					<Insets bottom="6" top="6"/>
+				</padding>
+			</Label>
+			<Label text="%hub.registerSuccess.description" wrapText="true"/>
+
+			<Region VBox.vgrow="ALWAYS" minHeight="18"/>
+			<ButtonBar buttonMinWidth="120" buttonOrder="+C">
+				<buttons>
+					<Button text="%generic.button.close" ButtonBar.buttonData="CANCEL_CLOSE" defaultButton="true" onAction="#close"/>
+					<!-- TODO: add request access button -->
+				</buttons>
+			</ButtonBar>
+		</VBox>
+	</children>
+</HBox>

--- a/src/main/resources/fxml/hub_unauthorized_device.fxml
+++ b/src/main/resources/fxml/hub_unauthorized_device.fxml
@@ -1,40 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import org.cryptomator.ui.controls.FontAwesome5IconView?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.ButtonBar?>
 <?import javafx.scene.control.Label?>
-<?import javafx.scene.image.Image?>
-<?import javafx.scene.image.ImageView?>
+<?import javafx.scene.Group?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
-<VBox xmlns:fx="http://javafx.com/fxml"
+<?import javafx.scene.shape.Circle?>
+<HBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
 	  fx:controller="org.cryptomator.ui.keyloading.hub.UnauthorizedDeviceController"
 	  minWidth="400"
 	  maxWidth="400"
 	  minHeight="145"
-	  spacing="12">
+	  spacing="12"
+	  alignment="TOP_LEFT">
 	<padding>
 		<Insets topRightBottomLeft="12"/>
 	</padding>
 	<children>
-		<HBox spacing="12" VBox.vgrow="ALWAYS">
-			<ImageView VBox.vgrow="ALWAYS" fitWidth="64" preserveRatio="true" cache="true">
-				<Image url="@../img/bot/bot.png"/>
-			</ImageView>
+		<Group>
+			<StackPane>
+				<padding>
+					<Insets topRightBottomLeft="6"/>
+				</padding>
+				<Circle styleClass="glyph-icon-primary" radius="24"/>
+				<FontAwesome5IconView styleClass="glyph-icon-white" glyph="BAN" glyphSize="24"/>
+			</StackPane>
+		</Group>
+		<VBox HBox.hgrow="ALWAYS">
+			<Label styleClass="label-large" text="%hub.unauthorized.message" wrapText="true" textAlignment="LEFT">
+				<padding>
+					<Insets bottom="6" top="6"/>
+				</padding>
+			</Label>
+			<Label text="%hub.unauthorized.description" wrapText="true"/>
 
-			<VBox spacing="12">
-				<Label text="TODO: Your device has not yet been authorized to access this vault. Ask the vault owner to authorize it." wrapText="true"/>
-			</VBox>
-		</HBox>
-
-		<VBox alignment="BOTTOM_CENTER" VBox.vgrow="ALWAYS">
+			<Region VBox.vgrow="ALWAYS" minHeight="18"/>
 			<ButtonBar buttonMinWidth="120" buttonOrder="+C">
 				<buttons>
 					<Button text="%generic.button.close" ButtonBar.buttonData="CANCEL_CLOSE" defaultButton="true" onAction="#close"/>
+					<!-- TODO: add request access button -->
+					<!--Button text="%generic.button.close" ButtonBar.buttonData="CANCEL_CLOSE" defaultButton="true" onAction="#close"/-->
 				</buttons>
 			</ButtonBar>
 		</VBox>
 	</children>
-</VBox>
+</HBox>

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -129,6 +129,11 @@ unlock.error.invalidMountPoint.driveLetterOccupied=Drive Letter "%s" is already 
 hub.auth.message=Waiting for authentication…
 hub.auth.description=You should automatically be redirected to the login page.
 hub.auth.loginLink=Not redirected? Click here to open it.
+### Register Device
+hub.register.message=Device unknown
+hub.register.description=Cryptomator Hub does not recognize this device. Please register it.
+hub.register.nameLabel=Device Name
+hub.register.registerBtn=Register
 
 # Lock
 ## Force

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -129,6 +129,9 @@ unlock.error.invalidMountPoint.driveLetterOccupied=Drive Letter "%s" is already 
 hub.auth.message=Waiting for authentication…
 hub.auth.description=You should automatically be redirected to the login page.
 hub.auth.loginLink=Not redirected? Click here to open it.
+### Receive Key
+hub.receive.message=Processing response…
+hub.receive.description=Cryptomator is receiving and processing the response from Hub. Please wait.
 ### Register Device
 hub.register.message=Device unknown
 hub.register.description=Cryptomator Hub does not recognize this device. Please register it.

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -140,6 +140,9 @@ hub.register.registerBtn=Register
 ### Registration Success
 hub.registerSuccess.message=Device registered
 hub.registerSuccess.description=To access the vault, your device needs to be authorized by the vault owner.
+### Registration Failed
+hub.registerFailed.message=Device registration failed
+hub.registerFailed.description=An error was thrown in the registration process. For more details, look into the application log.
 ### Unauthorized
 hub.unauthorized.message=Access denied
 hub.unauthorized.description=Your device has not yet been authorized to access this vault. Ask the vault owner to authorize it.

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -134,6 +134,10 @@ hub.register.message=Device unknown
 hub.register.description=Cryptomator Hub does not recognize this device. Please register it.
 hub.register.nameLabel=Device Name
 hub.register.registerBtn=Register
+### Unauthorized
+hub.unauthorized.message=Access denied
+hub.unauthorized.description=Your device has not yet been authorized to access this vault. Ask the vault owner to authorize it.
+
 
 # Lock
 ## Force

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -133,8 +133,8 @@ hub.auth.loginLink=Not redirected? Click here to open it.
 hub.receive.message=Processing response…
 hub.receive.description=Cryptomator is receiving and processing the response from Hub. Please wait.
 ### Register Device
-hub.register.message=Device unknown
-hub.register.description=Cryptomator Hub does not recognize this device. Please register it.
+hub.register.message=Register device?
+hub.register.description=This seems to be the first access from this device to Cryptomator Hub. In order to unlock any vault, you need to choose a name and register it.
 hub.register.nameLabel=Device Name
 hub.register.registerBtn=Register
 ### Registration Success

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -133,16 +133,16 @@ hub.auth.loginLink=Not redirected? Click here to open it.
 hub.receive.message=Processing response…
 hub.receive.description=Cryptomator is receiving and processing the response from Hub. Please wait.
 ### Register Device
-hub.register.message=Register device?
-hub.register.description=This seems to be the first access from this device to Cryptomator Hub. In order to unlock any vault, you need to choose a name and register it.
+hub.register.message=Device name required
+hub.register.description=This seems to be the first Hub access from this device. In order to identify it for access authorization, you need to name this device.
 hub.register.nameLabel=Device Name
-hub.register.registerBtn=Register
+hub.register.registerBtn=Confirm
 ### Registration Success
-hub.registerSuccess.message=Device registered
+hub.registerSuccess.message=Device named
 hub.registerSuccess.description=To access the vault, your device needs to be authorized by the vault owner.
 ### Registration Failed
-hub.registerFailed.message=Device registration failed
-hub.registerFailed.description=An error was thrown in the registration process. For more details, look into the application log.
+hub.registerFailed.message=Device naming failed
+hub.registerFailed.description=An error was thrown in the naming process. For more details, look into the application log.
 ### Unauthorized
 hub.unauthorized.message=Access denied
 hub.unauthorized.description=Your device has not yet been authorized to access this vault. Ask the vault owner to authorize it.

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -124,6 +124,11 @@ unlock.error.message=Unable to unlock vault
 unlock.error.invalidMountPoint.notExisting=Mount point "%s" is not a directory, not empty or does not exist.
 unlock.error.invalidMountPoint.existing=Mount point "%s" already exists or parent folder is missing.
 unlock.error.invalidMountPoint.driveLetterOccupied=Drive Letter "%s" is already in use.
+## Hub
+### Waiting
+hub.auth.message=Waiting for authentication…
+hub.auth.description=You should automatically be redirected to the login page.
+hub.auth.loginLink=Not redirected? Click here to open it.
 
 # Lock
 ## Force

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -137,6 +137,9 @@ hub.register.message=Device unknown
 hub.register.description=Cryptomator Hub does not recognize this device. Please register it.
 hub.register.nameLabel=Device Name
 hub.register.registerBtn=Register
+### Registration Success
+hub.registerSuccess.message=Device registered
+hub.registerSuccess.description=To access the vault, your device needs to be authorized by the vault owner.
 ### Unauthorized
 hub.unauthorized.message=Access denied
 hub.unauthorized.description=Your device has not yet been authorized to access this vault. Ask the vault owner to authorize it.


### PR DESCRIPTION
WIth this PR the new dialogs required for the hub project are adjusted to the new designed fixed in #2311 and their texts are added to the translations file.
Additionally, two new dialogs are added to give the user better feedback.

## Dialogs
### Authentication
![grafik](https://user-images.githubusercontent.com/9036915/177310604-80bda09e-ce5b-4888-ac1e-32f75c88be83.png)

### Retrieve Key
![grafik](https://user-images.githubusercontent.com/9036915/177311055-cc02c7c3-63df-42dd-ba3b-c95561bdaf98.png)

### Device Registration (updated)
![grafik](https://user-images.githubusercontent.com/9036915/177751893-7a37c517-8b95-402e-8793-0842add2bf74.png)

### Registration Success (updated)
![grafik](https://user-images.githubusercontent.com/9036915/177751936-8cd3c9ec-e446-401b-af21-922b921c6372.png)

### Access Denied
![grafik](https://user-images.githubusercontent.com/9036915/177311905-8670ab2f-a82f-4111-912c-5bca2db8e376.png)
