### PR TITLE
Display Label when device name alread in use 

### DIFF
--- a/src/main/java/org/cryptomator/ui/keyloading/hub/RegisterDeviceController.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/RegisterDeviceController.java
@@ -81,6 +81,7 @@ public class RegisterDeviceController implements FxController {
 
 	public void initialize() {
 		deviceNameField.setText(determineHostname());
+		deviceNameField.textProperty().addListener(observable -> deviceNameAlreadyExists.set(false));
 	}
 
 	private String determineHostname() {

--- a/src/main/resources/fxml/hub_register_device.fxml
+++ b/src/main/resources/fxml/hub_register_device.fxml
@@ -12,6 +12,7 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.shape.Circle?>
+<?import org.cryptomator.ui.controls.FontAwesome5Spinner?>
 <HBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
 	  fx:controller="org.cryptomator.ui.keyloading.hub.RegisterDeviceController"
@@ -48,12 +49,26 @@
 				<Label text="%hub.register.nameLabel" labelFor="$deviceNameField"/>
 				<TextField fx:id="deviceNameField" HBox.hgrow="ALWAYS"/>
 			</HBox>
+			<HBox alignment="TOP_RIGHT">
+				<Label text="%hub.register.occupiedMsg" textAlignment="RIGHT" alignment="CENTER_RIGHT" visible="${controller.deviceNameAlreadyExists}" graphicTextGap="6">
+					<padding>
+						<Insets top="6"/>
+					</padding>
+					<graphic>
+						<FontAwesome5IconView glyph="TIMES" styleClass="glyph-icon-red"/>
+					</graphic>
+				</Label>
+			</HBox>
 
 			<Region VBox.vgrow="ALWAYS" minHeight="18"/>
 			<ButtonBar buttonMinWidth="120" buttonOrder="+CU">
 				<buttons>
-					<Button text="%generic.button.close" ButtonBar.buttonData="CANCEL_CLOSE" cancelButton="true" onAction="#close"/>
-					<Button text="%hub.register.registerBtn" ButtonBar.buttonData="OTHER" defaultButton="true" onAction="#register"/>
+					<Button text="%generic.button.cancel" ButtonBar.buttonData="CANCEL_CLOSE" cancelButton="true" onAction="#close"/>
+					<Button fx:id="registerBtn" text="%hub.register.registerBtn" ButtonBar.buttonData="OTHER" defaultButton="true" onAction="#register" contentDisplay="TEXT_ONLY" >
+						<graphic>
+							<FontAwesome5Spinner glyphSize="12" />
+						</graphic>
+					</Button>
 				</buttons>
 			</ButtonBar>
 		</VBox>

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -136,6 +136,7 @@ hub.receive.description=Cryptomator is receiving and processing the response fro
 hub.register.message=Device name required
 hub.register.description=This seems to be the first Hub access from this device. In order to identify it for access authorization, you need to name this device.
 hub.register.nameLabel=Device Name
+hub.register.occupiedMsg=Name already in use
 hub.register.registerBtn=Confirm
 ### Registration Success
 hub.registerSuccess.message=Device named


### PR DESCRIPTION
Improvement for the device registration workflow. A message below the textbox is shown, if the device name is already used for that user in the Hub instance. The message is hidden, when the user changes the text.

![grafik](https://user-images.githubusercontent.com/9036915/177970949-5c636c67-d0aa-4b0c-b535-747218776e0f.png)
