### PR TITLE
Update integrations-win lib

### DIFF
--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -93,11 +93,11 @@ jobs:
           --java-options "-Dcryptomator.pluginDir=\"~/AppData/Roaming/Cryptomator/Plugins\""
           --java-options "-Dcryptomator.settingsPath=\"~/AppData/Roaming/Cryptomator/settings.json\""
           --java-options "-Dcryptomator.ipcSocketPath=\"~/AppData/Roaming/Cryptomator/ipc.socket\""
-          --java-options "-Dcryptomator.keychainPath=\"~/AppData/Roaming/Cryptomator/keychain.json\""
           --java-options "-Dcryptomator.mountPointsDir=\"~/Cryptomator\""
           --java-options "-Dcryptomator.showTrayIcon=true"
           --java-options "-Dcryptomator.buildNumber=\"msi-${{ steps.versions.outputs.revNum }}\""
           --java-options "-Dcryptomator.integrationsWin.autoStartShellLinkName=\"Cryptomator\""
+          --java-options "-Dcryptomator.integrationsWin.keychainPaths=\"~/AppData/Roaming/Cryptomator/keychain.json\""
           --resource-dir dist/win/resources
           --icon dist/win/resources/Cryptomator.ico
       - name: Patch Application Directory

--- a/.idea/runConfigurations/Cryptomator_Windows.xml
+++ b/.idea/runConfigurations/Cryptomator_Windows.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Cryptomator Windows" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.cryptomator.launcher.Cryptomator" />
     <module name="cryptomator" />
-    <option name="VM_PARAMETERS" value="-Dcryptomator.settingsPath=&quot;~/AppData/Roaming/Cryptomator/settings.json&quot; -Dcryptomator.ipcSocketPath=&quot;~/AppData/Roaming/Cryptomator/ipc.socket&quot; -Dcryptomator.logDir=&quot;~/AppData/Roaming/Cryptomator&quot; -Dcryptomator.pluginDir=&quot;~/AppData/Roaming/Cryptomator/Plugins&quot; -Dcryptomator.keychainPath=&quot;~/AppData/Roaming/Cryptomator/keychain.json&quot; -Dcryptomator.mountPointsDir=&quot;~/Cryptomator&quot; -Dcryptomator.showTrayIcon=true -Xss2m -Xmx512m" />
+    <option name="VM_PARAMETERS" value="-Dcryptomator.settingsPath=&quot;~/AppData/Roaming/Cryptomator/settings.json&quot; -Dcryptomator.ipcSocketPath=&quot;~/AppData/Roaming/Cryptomator/ipc.socket&quot; -Dcryptomator.logDir=&quot;~/AppData/Roaming/Cryptomator&quot; -Dcryptomator.pluginDir=&quot;~/AppData/Roaming/Cryptomator/Plugins&quot; -Dcryptomator.integrationsWin.keychainPaths=&quot;~/AppData/Roaming/Cryptomator-Dev/keychain.json&quot; -Dcryptomator.mountPointsDir=&quot;~/Cryptomator&quot; -Dcryptomator.showTrayIcon=true -Xss2m -Xmx512m" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.idea/runConfigurations/Cryptomator_Windows_Dev.xml
+++ b/.idea/runConfigurations/Cryptomator_Windows_Dev.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Cryptomator Windows Dev" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.cryptomator.launcher.Cryptomator" />
     <module name="cryptomator" />
-    <option name="VM_PARAMETERS" value="-Dcryptomator.settingsPath=&quot;~/AppData/Roaming/Cryptomator-Dev/settings.json&quot; -Dcryptomator.ipcSocketPath=&quot;~/AppData/Roaming/Cryptomator-Dev/ipc.socket&quot; -Dcryptomator.logDir=&quot;~/AppData/Roaming/Cryptomator-Dev&quot; -Dcryptomator.pluginDir=&quot;~/AppData/Roaming/Cryptomator-Dev/Plugins&quot; -Dcryptomator.keychainPath=&quot;~/AppData/Roaming/Cryptomator-Dev/keychain.json&quot; -Dcryptomator.mountPointsDir=&quot;~/Cryptomator-Dev&quot; -Dcryptomator.showTrayIcon=true -Xss2m -Xmx512m" />
+    <option name="VM_PARAMETERS" value="-Dcryptomator.settingsPath=&quot;~/AppData/Roaming/Cryptomator-Dev/settings.json&quot; -Dcryptomator.ipcSocketPath=&quot;~/AppData/Roaming/Cryptomator-Dev/ipc.socket&quot; -Dcryptomator.logDir=&quot;~/AppData/Roaming/Cryptomator-Dev&quot; -Dcryptomator.pluginDir=&quot;~/AppData/Roaming/Cryptomator-Dev/Plugins&quot; -Dcryptomator.integrationsWin.keychainPaths=&quot;~/AppData/Roaming/Cryptomator-Dev/keychain.json&quot; -Dcryptomator.mountPointsDir=&quot;~/Cryptomator-Dev&quot; -Dcryptomator.showTrayIcon=true -Xss2m -Xmx512m" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/dist/win/build.ps1
+++ b/dist/win/build.ps1
@@ -83,9 +83,9 @@ if ($clean -and (Test-Path -Path $appPath)) {
 	--java-options "-Dcryptomator.pluginDir=`"~/AppData/Roaming/$AppName/Plugins`"" `
 	--java-options "-Dcryptomator.settingsPath=`"~/AppData/Roaming/$AppName/settings.json`"" `
 	--java-options "-Dcryptomator.ipcSocketPath=`"~/AppData/Roaming/$AppName/ipc.socket`"" `
-	--java-options "-Dcryptomator.keychainPath=`"~/AppData/Roaming/$AppName/keychain.json`"" `
 	--java-options "-Dcryptomator.mountPointsDir=`"~/$AppName`"" `
 	--java-options "-Dcryptomator.integrationsWin.autoStartShellLinkName=`"$AppName`"" `
+	--java-options "-Dcryptomator.integrationsWin.keychainPaths=`"~/AppData/Roaming/$AppName/keychain.json`"" `
 	--java-options "-Dcryptomator.showTrayIcon=true" `
 	--java-options "-Dcryptomator.buildNumber=`"msi-$revisionNo`"" `
 	--resource-dir resources `

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<!-- cryptomator dependencies -->
 		<cryptomator.cryptofs.version>2.4.2</cryptomator.cryptofs.version>
 		<cryptomator.integrations.version>1.1.0</cryptomator.integrations.version>
-		<cryptomator.integrations.win.version>1.1.1</cryptomator.integrations.win.version>
+		<cryptomator.integrations.win.version>1.1.2</cryptomator.integrations.win.version>
 		<cryptomator.integrations.mac.version>1.1.1</cryptomator.integrations.mac.version>
 		<cryptomator.integrations.linux.version>1.1.0</cryptomator.integrations.linux.version>
 		<cryptomator.fuse.version>1.3.4</cryptomator.fuse.version>

--- a/src/main/java/org/cryptomator/common/Constants.java
+++ b/src/main/java/org/cryptomator/common/Constants.java
@@ -9,4 +9,6 @@ public interface Constants {
 	String CRYPTOMATOR_FILENAME_GLOB = "*.cryptomator";
 	byte[] PEPPER = new byte[0];
 
+	//TODO: DOC base URL hier hinzufügen und dann abhängig von der Version verlinken (version gibts aus environment)
+
 }

--- a/src/main/java/org/cryptomator/common/Constants.java
+++ b/src/main/java/org/cryptomator/common/Constants.java
@@ -9,6 +9,4 @@ public interface Constants {
 	String CRYPTOMATOR_FILENAME_GLOB = "*.cryptomator";
 	byte[] PEPPER = new byte[0];
 
-	//TODO: DOC base URL hier hinzufügen und dann abhängig von der Version verlinken (version gibts aus environment)
-
 }

--- a/src/main/java/org/cryptomator/common/Environment.java
+++ b/src/main/java/org/cryptomator/common/Environment.java
@@ -24,6 +24,16 @@ public class Environment {
 	private static final Path RELATIVE_HOME_DIR = Paths.get("~");
 	private static final char PATH_LIST_SEP = ':';
 	private static final int DEFAULT_MIN_PW_LENGTH = 8;
+	private static final String SETTINGS_PATH_PROP_NAME = "cryptomator.settingsPath";
+	private static final String IPC_SOCKET_PATH_PROP_NAME = "cryptomator.ipcSocketPath";
+	private static final String KEYCHAIN_PATHS_PROP_NAME = "cryptomator.integrationsWin.keychainPaths";
+	private static final String LOG_DIR_PROP_NAME = "cryptomator.logDir";
+	private static final String MOUNTPOINT_DIR_PROP_NAME = "cryptomator.mountPointsDir";
+	private static final String MIN_PW_LENGTH_PROP_NAME = "cryptomator.minPwLength";
+	private static final String APP_VERSION_PROP_NAME = "cryptomator.appVersion";
+	private static final String BUILD_NUMBER_PROP_NAME = "cryptomator.buildNumber";
+	private static final String PLUGIN_DIR_PROP_NAME = "cryptomator.pluginDir";
+	private static final String TRAY_ICON_PROP_NAME = "cryptomator.showTrayIcon";
 
 	@Inject
 	public Environment() {
@@ -32,16 +42,16 @@ public class Environment {
 		LOG.debug("user.language: {}", System.getProperty("user.language"));
 		LOG.debug("user.region: {}", System.getProperty("user.region"));
 		LOG.debug("logback.configurationFile: {}", System.getProperty("logback.configurationFile"));
-		LOG.debug("cryptomator.settingsPath: {}", System.getProperty("cryptomator.settingsPath"));
-		LOG.debug("cryptomator.ipcSocketPath: {}", System.getProperty("cryptomator.ipcSocketPath"));
-		LOG.debug("cryptomator.integrationsWin.keychainPaths: {}", System.getProperty("cryptomator.integrationsWin.keychainPaths"));
-		LOG.debug("cryptomator.logDir: {}", System.getProperty("cryptomator.logDir"));
-		LOG.debug("cryptomator.pluginDir: {}", System.getProperty("cryptomator.pluginDir"));
-		LOG.debug("cryptomator.mountPointsDir: {}", System.getProperty("cryptomator.mountPointsDir"));
-		LOG.debug("cryptomator.minPwLength: {}", System.getProperty("cryptomator.minPwLength"));
-		LOG.debug("cryptomator.appVersion: {}", System.getProperty("cryptomator.appVersion"));
-		LOG.debug("cryptomator.buildNumber: {}", System.getProperty("cryptomator.buildNumber"));
-		LOG.debug("cryptomator.showTrayIcon: {}", System.getProperty("cryptomator.showTrayIcon"));
+		LOG.debug("{}: {}", SETTINGS_PATH_PROP_NAME, System.getProperty(SETTINGS_PATH_PROP_NAME));
+		LOG.debug("{}: {}", IPC_SOCKET_PATH_PROP_NAME, System.getProperty(IPC_SOCKET_PATH_PROP_NAME));
+		LOG.debug("{}: {}", KEYCHAIN_PATHS_PROP_NAME, System.getProperty(KEYCHAIN_PATHS_PROP_NAME));
+		LOG.debug("{}: {}", LOG_DIR_PROP_NAME, System.getProperty(LOG_DIR_PROP_NAME));
+		LOG.debug("{}: {}", PLUGIN_DIR_PROP_NAME, System.getProperty(PLUGIN_DIR_PROP_NAME));
+		LOG.debug("{} {}", MOUNTPOINT_DIR_PROP_NAME, System.getProperty(MOUNTPOINT_DIR_PROP_NAME));
+		LOG.debug("{}: {}", MIN_PW_LENGTH_PROP_NAME, System.getProperty(MIN_PW_LENGTH_PROP_NAME));
+		LOG.debug("{}: {}", APP_VERSION_PROP_NAME, System.getProperty(APP_VERSION_PROP_NAME));
+		LOG.debug("{}: {}", BUILD_NUMBER_PROP_NAME, System.getProperty(BUILD_NUMBER_PROP_NAME));
+		LOG.debug("{}: {}", TRAY_ICON_PROP_NAME, System.getProperty(TRAY_ICON_PROP_NAME));
 	}
 
 	public boolean useCustomLogbackConfig() {
@@ -49,43 +59,43 @@ public class Environment {
 	}
 
 	public Stream<Path> getSettingsPath() {
-		return getPaths("cryptomator.settingsPath");
+		return getPaths(SETTINGS_PATH_PROP_NAME);
 	}
 
 	public Stream<Path> ipcSocketPath() {
-		return getPaths("cryptomator.ipcSocketPath");
+		return getPaths(IPC_SOCKET_PATH_PROP_NAME);
 	}
 
 	public Stream<Path> getKeychainPath() {
-		return getPaths("cryptomator.integrationsWin.keychainPaths");
+		return getPaths(KEYCHAIN_PATHS_PROP_NAME);
 	}
 
 	public Optional<Path> getLogDir() {
-		return getPath("cryptomator.logDir").map(this::replaceHomeDir);
+		return getPath(LOG_DIR_PROP_NAME).map(this::replaceHomeDir);
 	}
 
 	public Optional<Path> getPluginDir() {
-		return getPath("cryptomator.pluginDir").map(this::replaceHomeDir);
+		return getPath(PLUGIN_DIR_PROP_NAME).map(this::replaceHomeDir);
 	}
 
 	public Optional<Path> getMountPointsDir() {
-		return getPath("cryptomator.mountPointsDir").map(this::replaceHomeDir);
+		return getPath(MOUNTPOINT_DIR_PROP_NAME).map(this::replaceHomeDir);
 	}
 
 	public Optional<String> getAppVersion() {
-		return Optional.ofNullable(System.getProperty("cryptomator.appVersion"));
+		return Optional.ofNullable(System.getProperty(APP_VERSION_PROP_NAME));
 	}
 
 	public Optional<String> getBuildNumber() {
-		return Optional.ofNullable(System.getProperty("cryptomator.buildNumber"));
+		return Optional.ofNullable(System.getProperty(BUILD_NUMBER_PROP_NAME));
 	}
 
 	public int getMinPwLength() {
-		return getInt("cryptomator.minPwLength", DEFAULT_MIN_PW_LENGTH);
+		return getInt(MIN_PW_LENGTH_PROP_NAME, DEFAULT_MIN_PW_LENGTH);
 	}
 
 	public boolean showTrayIcon() {
-		return Boolean.getBoolean("cryptomator.showTrayIcon");
+		return Boolean.getBoolean(TRAY_ICON_PROP_NAME);
 	}
 
 	private int getInt(String propertyName, int defaultValue) {

--- a/src/main/java/org/cryptomator/common/Environment.java
+++ b/src/main/java/org/cryptomator/common/Environment.java
@@ -34,7 +34,7 @@ public class Environment {
 		LOG.debug("logback.configurationFile: {}", System.getProperty("logback.configurationFile"));
 		LOG.debug("cryptomator.settingsPath: {}", System.getProperty("cryptomator.settingsPath"));
 		LOG.debug("cryptomator.ipcSocketPath: {}", System.getProperty("cryptomator.ipcSocketPath"));
-		LOG.debug("cryptomator.keychainPath: {}", System.getProperty("cryptomator.keychainPath"));
+		LOG.debug("cryptomator.integrationsWin.keychainPaths: {}", System.getProperty("cryptomator.integrationsWin.keychainPaths"));
 		LOG.debug("cryptomator.logDir: {}", System.getProperty("cryptomator.logDir"));
 		LOG.debug("cryptomator.pluginDir: {}", System.getProperty("cryptomator.pluginDir"));
 		LOG.debug("cryptomator.mountPointsDir: {}", System.getProperty("cryptomator.mountPointsDir"));
@@ -57,7 +57,7 @@ public class Environment {
 	}
 
 	public Stream<Path> getKeychainPath() {
-		return getPaths("cryptomator.keychainPath");
+		return getPaths("cryptomator.integrationsWin.keychainPaths");
 	}
 
 	public Optional<Path> getLogDir() {

--- a/src/main/java/org/cryptomator/common/Environment.java
+++ b/src/main/java/org/cryptomator/common/Environment.java
@@ -47,7 +47,7 @@ public class Environment {
 		LOG.debug("{}: {}", KEYCHAIN_PATHS_PROP_NAME, System.getProperty(KEYCHAIN_PATHS_PROP_NAME));
 		LOG.debug("{}: {}", LOG_DIR_PROP_NAME, System.getProperty(LOG_DIR_PROP_NAME));
 		LOG.debug("{}: {}", PLUGIN_DIR_PROP_NAME, System.getProperty(PLUGIN_DIR_PROP_NAME));
-		LOG.debug("{} {}", MOUNTPOINT_DIR_PROP_NAME, System.getProperty(MOUNTPOINT_DIR_PROP_NAME));
+		LOG.debug("{}: {}", MOUNTPOINT_DIR_PROP_NAME, System.getProperty(MOUNTPOINT_DIR_PROP_NAME));
 		LOG.debug("{}: {}", MIN_PW_LENGTH_PROP_NAME, System.getProperty(MIN_PW_LENGTH_PROP_NAME));
 		LOG.debug("{}: {}", APP_VERSION_PROP_NAME, System.getProperty(APP_VERSION_PROP_NAME));
 		LOG.debug("{}: {}", BUILD_NUMBER_PROP_NAME, System.getProperty(BUILD_NUMBER_PROP_NAME));

--- a/src/test/java/org/cryptomator/common/EnvironmentTest.java
+++ b/src/test/java/org/cryptomator/common/EnvironmentTest.java
@@ -48,9 +48,9 @@ public class EnvironmentTest {
 	}
 
 	@Test
-	@DisplayName("cryptomator.keychainPath=~/AppData/Roaming/Cryptomator/keychain.json")
+	@DisplayName("cryptomator.integrationsWin.keychainPaths=~/AppData/Roaming/Cryptomator/keychain.json")
 	public void testKeychainPath() {
-		System.setProperty("cryptomator.keychainPath", "~/AppData/Roaming/Cryptomator/keychain.json");
+		System.setProperty("cryptomator.integrationsWin.keychainPaths", "~/AppData/Roaming/Cryptomator/keychain.json");
 
 		List<Path> result = env.getKeychainPath().toList();
 		MatcherAssert.assertThat(result, Matchers.hasSize(1));


### PR DESCRIPTION
Closes #2260 

The new library version renamed a JVM property, which is used in Cryptomator. I renamed (assumingly) all occurences of that property.