### PR TITLE
handle 402 error when authenticating with Cryptomator Hub

### DIFF
--- a/src/main/java/org/cryptomator/ui/common/FxmlFile.java
+++ b/src/main/java/org/cryptomator/ui/common/FxmlFile.java
@@ -14,6 +14,7 @@ public enum FxmlFile {
 	HEALTH_START("/fxml/health_start.fxml"), //
 	HEALTH_CHECK_LIST("/fxml/health_check_list.fxml"), //
 	HUB_AUTH_FLOW("/fxml/hub_auth_flow.fxml"), //
+	HUB_LICENSE_EXCEEDED("/fxml/hub_license_exceeded.fxml"), //
 	HUB_RECEIVE_KEY("/fxml/hub_receive_key.fxml"), //
 	HUB_REGISTER_DEVICE("/fxml/hub_register_device.fxml"), //
 	HUB_REGISTER_SUCCESS("/fxml/hub_register_success.fxml"), //

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/HubKeyLoadingModule.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/HubKeyLoadingModule.java
@@ -93,6 +93,13 @@ public abstract class HubKeyLoadingModule {
 	}
 
 	@Provides
+	@FxmlScene(FxmlFile.HUB_LICENSE_EXCEEDED)
+	@KeyLoadingScoped
+	static Scene provideLicenseExceededScene(@KeyLoading FxmlLoaderFactory fxmlLoaders) {
+		return fxmlLoaders.createScene(FxmlFile.HUB_LICENSE_EXCEEDED);
+	}
+
+	@Provides
 	@FxmlScene(FxmlFile.HUB_RECEIVE_KEY)
 	@KeyLoadingScoped
 	static Scene provideHubReceiveKeyScene(@KeyLoading FxmlLoaderFactory fxmlLoaders) {
@@ -138,6 +145,11 @@ public abstract class HubKeyLoadingModule {
 	static FxController provideNewPasswordController(ResourceBundle resourceBundle, PasswordStrengthUtil strengthRater) {
 		return new NewPasswordController(resourceBundle, strengthRater);
 	}
+
+	@Binds
+	@IntoMap
+	@FxControllerKey(LicenseExceededController.class)
+	abstract FxController bindLicenseExceededController(LicenseExceededController controller);
 
 	@Binds
 	@IntoMap

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/LicenseExceededController.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/LicenseExceededController.java
@@ -1,0 +1,23 @@
+package org.cryptomator.ui.keyloading.hub;
+
+import org.cryptomator.ui.common.FxController;
+import org.cryptomator.ui.keyloading.KeyLoading;
+
+import javax.inject.Inject;
+import javafx.fxml.FXML;
+import javafx.stage.Stage;
+
+public class LicenseExceededController implements FxController {
+
+	private final Stage window;
+
+	@Inject
+	public LicenseExceededController(@KeyLoading Stage window) {
+		this.window = window;
+	}
+
+	@FXML
+	public void close() {
+		window.close();
+	}
+}

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/ReceiveKeyController.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/ReceiveKeyController.java
@@ -8,8 +8,6 @@ import org.cryptomator.ui.common.FxmlFile;
 import org.cryptomator.ui.common.FxmlScene;
 import org.cryptomator.ui.keyloading.KeyLoading;
 import org.cryptomator.ui.keyloading.KeyLoadingScoped;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -44,10 +42,11 @@ public class ReceiveKeyController implements FxController {
 	private final Lazy<Scene> registerDeviceScene;
 	private final Lazy<Scene> unauthorizedScene;
 	private final URI vaultBaseUri;
+	private final Lazy<Scene> licenseExceededScene;
 	private final HttpClient httpClient;
 
 	@Inject
-	public ReceiveKeyController(@KeyLoading Vault vault, ExecutorService executor, @KeyLoading Stage window, @Named("deviceId") String deviceId, @Named("bearerToken") AtomicReference<String> tokenRef, CompletableFuture<JWEObject> result, @FxmlScene(FxmlFile.HUB_REGISTER_DEVICE) Lazy<Scene> registerDeviceScene, @FxmlScene(FxmlFile.HUB_UNAUTHORIZED_DEVICE) Lazy<Scene> unauthorizedScene) {
+	public ReceiveKeyController(@KeyLoading Vault vault, ExecutorService executor, @KeyLoading Stage window, @Named("deviceId") String deviceId, @Named("bearerToken") AtomicReference<String> tokenRef, CompletableFuture<JWEObject> result, @FxmlScene(FxmlFile.HUB_REGISTER_DEVICE) Lazy<Scene> registerDeviceScene, @FxmlScene(FxmlFile.HUB_UNAUTHORIZED_DEVICE) Lazy<Scene> unauthorizedScene, @FxmlScene(FxmlFile.HUB_LICENSE_EXCEEDED) Lazy<Scene> licenseExceededScene) {
 		this.window = window;
 		this.deviceId = deviceId;
 		this.bearerToken = Objects.requireNonNull(tokenRef.get());
@@ -55,6 +54,7 @@ public class ReceiveKeyController implements FxController {
 		this.registerDeviceScene = registerDeviceScene;
 		this.unauthorizedScene = unauthorizedScene;
 		this.vaultBaseUri = getVaultBaseUri(vault);
+		this.licenseExceededScene = licenseExceededScene;
 		this.window.addEventHandler(WindowEvent.WINDOW_HIDING, this::windowClosed);
 		this.httpClient = HttpClient.newBuilder().executor(executor).build();
 	}
@@ -92,6 +92,10 @@ public class ReceiveKeyController implements FxController {
 		} catch (ParseException e) {
 			throw new IOException("Failed to parse JWE", e);
 		}
+	}
+
+	private void hubLicenseInsufficient() {
+		window.setScene(licenseExceededScene.get());
 	}
 
 	private void needsDeviceRegistration() {

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/ReceiveKeyController.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/ReceiveKeyController.java
@@ -75,7 +75,7 @@ public class ReceiveKeyController implements FxController {
 		try {
 			switch (response.statusCode()) {
 				case 200 -> retrievalSucceeded(response);
-				case 402 -> hubLicenseExceeded();
+				case 402 -> licenseExceeded();
 				case 403 -> accessNotGranted();
 				case 404 -> needsDeviceRegistration();
 				default -> throw new IOException("Unexpected response " + response.statusCode());
@@ -95,7 +95,7 @@ public class ReceiveKeyController implements FxController {
 		}
 	}
 
-	private void hubLicenseExceeded() {
+	private void licenseExceeded() {
 		window.setScene(licenseExceededScene.get());
 	}
 

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/ReceiveKeyController.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/ReceiveKeyController.java
@@ -75,6 +75,7 @@ public class ReceiveKeyController implements FxController {
 		try {
 			switch (response.statusCode()) {
 				case 200 -> retrievalSucceeded(response);
+				case 402 -> hubLicenseExceeded();
 				case 403 -> accessNotGranted();
 				case 404 -> needsDeviceRegistration();
 				default -> throw new IOException("Unexpected response " + response.statusCode());
@@ -94,7 +95,7 @@ public class ReceiveKeyController implements FxController {
 		}
 	}
 
-	private void hubLicenseInsufficient() {
+	private void hubLicenseExceeded() {
 		window.setScene(licenseExceededScene.get());
 	}
 

--- a/src/main/resources/fxml/hub_license_exceeded.fxml
+++ b/src/main/resources/fxml/hub_license_exceeded.fxml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import org.cryptomator.ui.controls.FontAwesome5IconView?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.ButtonBar?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.Group?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.shape.Circle?>
+<HBox xmlns:fx="http://javafx.com/fxml"
+	  xmlns="http://javafx.com/javafx"
+	  fx:controller="org.cryptomator.ui.keyloading.hub.LicenseExceededController"
+	  minWidth="400"
+	  maxWidth="400"
+	  minHeight="145"
+	  spacing="12"
+	  alignment="TOP_LEFT">
+	<padding>
+		<Insets topRightBottomLeft="12"/>
+	</padding>
+	<children>
+		<Group>
+			<StackPane>
+				<padding>
+					<Insets topRightBottomLeft="6"/>
+				</padding>
+				<Circle styleClass="glyph-icon-orange" radius="24"/>
+				<FontAwesome5IconView styleClass="glyph-icon-white" glyph="EXCLAMATION" glyphSize="24"/>
+			</StackPane>
+		</Group>
+		<VBox HBox.hgrow="ALWAYS">
+			<Label styleClass="label-large" text="%hub.licenseExceeded.message" wrapText="true" textAlignment="LEFT">
+				<padding>
+					<Insets bottom="6" top="6"/>
+				</padding>
+			</Label>
+			<Label text="%hub.licenseExceeded.description" wrapText="true"/>
+
+			<Region VBox.vgrow="ALWAYS" minHeight="18"/>
+			<ButtonBar buttonMinWidth="120" buttonOrder="+C">
+				<buttons>
+					<Button text="%generic.button.close" ButtonBar.buttonData="CANCEL_CLOSE" defaultButton="true" onAction="#close"/>
+				</buttons>
+			</ButtonBar>
+		</VBox>
+	</children>
+</HBox>

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -152,6 +152,9 @@ hub.registerFailed.description=An error was thrown in the naming process. For mo
 ### Unauthorized
 hub.unauthorized.message=Access denied
 hub.unauthorized.description=Your device has not yet been authorized to access this vault. Ask the vault owner to authorize it.
+### License Exceeded
+hub.licenseExceeded.message=License exceeded
+hub.licenseExceeded.description=Cryptomator Hub has more vault users than the license permits. To enable unlock and other management functions again, please contact your hub administrator to upgrade the license or remove users from vaults.
 
 
 # Lock

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -154,7 +154,7 @@ hub.unauthorized.message=Access denied
 hub.unauthorized.description=Your device has not yet been authorized to access this vault. Ask the vault owner to authorize it.
 ### License Exceeded
 hub.licenseExceeded.message=License exceeded
-hub.licenseExceeded.description=Cryptomator Hub has more vault users than the license permits. To enable unlock and other management functions again, please contact your hub administrator to upgrade the license or remove users from vaults.
+hub.licenseExceeded.description=Cryptomator Hub has given access to more users than its license permits. Please contact your Hub admin to upgrade the license or a vault admin to remove users from vaults.
 
 
 # Lock


### PR DESCRIPTION
This PR enables handling a 402 response from the hub instance within the ui:
![grafik](https://user-images.githubusercontent.com/9036915/183443889-04dd85de-fc69-4737-9469-5f7d2d091bdf.png)
