### PR TITLE
Refactor CatchingScheduleExecutor to only execute One-Shot Tasks

### DIFF
--- a/src/main/java/org/cryptomator/common/CommonsModule.java
+++ b/src/main/java/org/cryptomator/common/CommonsModule.java
@@ -28,7 +28,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Comparator;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -92,9 +91,9 @@ public abstract class CommonsModule {
 
 	@Provides
 	@Singleton
-	static ScheduledExecutorService provideScheduledExecutorService(ShutdownHook shutdownHook) {
+	static OneShotScheduledExecutorService provideScheduledExecutorService(ShutdownHook shutdownHook) {
 		final AtomicInteger threadNumber = new AtomicInteger(1);
-		ScheduledExecutorService executorService = new CatchingExecutors.CatchingScheduledThreadPoolExecutor(NUM_SCHEDULER_THREADS, r -> {
+		OneShotScheduledExecutorService executorService = new CatchingExecutors.CatchingScheduledThreadPoolExecutor(NUM_SCHEDULER_THREADS, r -> {
 			String name = String.format("App Scheduled Executor %02d", threadNumber.getAndIncrement());
 			Thread t = new Thread(r);
 			t.setName(name);

--- a/src/main/java/org/cryptomator/common/OneShotScheduledExecutorService.java
+++ b/src/main/java/org/cryptomator/common/OneShotScheduledExecutorService.java
@@ -1,0 +1,12 @@
+package org.cryptomator.common;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Marker interface to indicate the used {@link ScheduledExecutorService} does not support repeated execution via {@link java.util.concurrent.ScheduledExecutorService#scheduleAtFixedRate(Runnable, long, long, TimeUnit)}} or {@link java.util.concurrent.ScheduledExecutorService#scheduleWithFixedDelay(Runnable, long, long, TimeUnit)}.
+ * Calling one of those methods must throw an {@link UnsupportedOperationException}.
+ */
+public interface OneShotScheduledExecutorService extends ScheduledExecutorService {
+
+}

--- a/src/main/java/org/cryptomator/common/settings/SettingsProvider.java
+++ b/src/main/java/org/cryptomator/common/settings/SettingsProvider.java
@@ -15,6 +15,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 import org.cryptomator.common.Environment;
+import org.cryptomator.common.OneShotScheduledExecutorService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +35,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.util.Optional;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -50,11 +50,11 @@ public class SettingsProvider implements Supplier<Settings> {
 	private final AtomicReference<ScheduledFuture<?>> scheduledSaveCmd = new AtomicReference<>();
 	private final Supplier<Settings> settings = Suppliers.memoize(this::load);
 	private final Environment env;
-	private final ScheduledExecutorService scheduler;
+	private final OneShotScheduledExecutorService scheduler;
 	private final Gson gson;
 
 	@Inject
-	public SettingsProvider(SettingsJsonAdapter settingsJsonAdapter, Environment env, ScheduledExecutorService scheduler) {
+	public SettingsProvider(SettingsJsonAdapter settingsJsonAdapter, Environment env, OneShotScheduledExecutorService scheduler) {
 		this.env = env;
 		this.scheduler = scheduler;
 		this.gson = new GsonBuilder() //


### PR DESCRIPTION
Fixes #2408.

WIth the introduction of `CatchingExecutorServices` in #2259, we improved debug information to find bugs. But this also introduced an unintended bottleneck: CatchingExecutor overrides the method [`afterExecute(...)`](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/ThreadPoolExecutor.html#afterExecute(java.lang.Runnable,java.lang.Throwable)), to log uncaught exceptions. For FutureTasks these exceptions needs to be extruded with calling `future.get()`. Normally, this works fine because due to the contract of afterExecute we can assert the future is done. Buuut when using repeated tasks, `future.isDone()` does not return `true`. Hence, such repeated tasks block a thread of our executorService and after a while, all threads of the service are blocked.

To solve this, the CatchingScheduledExecutor is refactored to only execute one-shot tasks and [Timer](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Timer.html) used for repeated tasks.
An alternative to Timer would be providing an additional scheduledExecutor for repeated tasks, but i decided against it to force the developer to use the CatchingExecutor as often as possible.