### PR TITLE
Refactor winget release to own workflow file

### DIFF
--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -195,7 +195,6 @@ jobs:
     uses: ./.github/workflows/winget.yml
     with:
       releaseTag: ${{ github.event.release.tag_name }}
-    secrets: inherit
 
 
   build-exe:

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -8,11 +8,6 @@ on:
       version:
         description: 'Version'
         required: false
-      winget-release:
-        description: 'Release artifacts to winget'
-        required: true
-        type: boolean
-        default: false
 
 env:
   JAVA_VERSION: 17
@@ -194,19 +189,14 @@ jobs:
       semVerStr: ${{ steps.versions.outputs.semVerStr }}
       revNum: ${{ steps.versions.outputs.revNum }}
 
-  publish-winget:
-    name: Publish on winget repo
-    runs-on: windows-latest
+  call-winget-flow:
     needs: [build-msi]
-    if: github.event.action == 'published' || inputs.winget-release
-    steps:
-      - name: Submit package to Windows Package Manager Community Repository
-        run: |
-          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-          $github = Get-Content '${{ github.event_path }}' | ConvertFrom-Json
-          $installerUrl = $github.release.assets | Where-Object -Property name -match '^Cryptomator-.*\.msi' | Select -ExpandProperty browser_download_url -First 1
-          .\wingetcreate.exe update Cryptomator.Cryptomator -s -v $github.release.tag_name -u $installerUrl -t ${{ secrets.CRYPTOBOT_WINGET_TOKEN }}
-        shell: pwsh
+    if: github.event.action == 'published'
+    uses: ./.github/workflows/winget.yml
+    with:
+      releaseTag: ${{ github.event.release.tag_name }}
+    secrets: inherit
+
 
   build-exe:
     name: Build .exe installer

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -39,20 +39,11 @@ jobs:
               tag: "${{ inputs.releaseTag }}"
             }
             return await github.graphql(query, variables)
-      - name: Debug Powershell
-        run: |
-          echo '$env:RELEASE_ASSETS'
-          echo '${{ steps.get-release-assets.outputs.result }}'
-        env:
-          RELEASE_ASSETS: steps.get-release-assets.outputs.result
       - name: Submit package to Windows Package Manager Community Repository
         id: submit-winget
         run: |
           iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-          $releaseAssets = (ConvertFrom-Json '$env:RELEASE_ASSETS').data.repository.release.releaseAssets.nodes
+          $releaseAssets = (ConvertFrom-Json ${{ steps.get-release-assets.outputs.result }}).data.repository.release.releaseAssets.nodes
           $installerUrl = $releaseAssets | Where-Object -Property name -match '^Cryptomator-.*\.msi$' | Select -ExpandProperty downloadUrl -First 1
-          .\wingetcreate.exe update Cryptomator.Cryptomator -s -v $env:RELEASE_TAG -u $installerUrl -t ${{ secrets.CRYPTOBOT_WINGET_TOKEN }}
+          .\wingetcreate.exe update Cryptomator.Cryptomator -s -v ${{ inputs.releaseTag }} -u $installerUrl -t ${{ secrets.CRYPTOBOT_WINGET_TOKEN }}
         shell: pwsh
-        env:
-          RELEASE_ASSETS: steps.get-release-assets.outputs.result
-          RELEASE_TAG: inputs.releaseTag

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -43,7 +43,7 @@ jobs:
         id: submit-winget
         run: |
           iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-          $releaseAssets = (ConvertFrom-Json ${{ steps.get-release-assets.outputs.result }}).data.repository.release.releaseAssets.nodes
+          $releaseAssets = (ConvertFrom-Json '${{ steps.get-release-assets.outputs.result }}').data.repository.release.releaseAssets.nodes
           $installerUrl = $releaseAssets | Where-Object -Property name -match '^Cryptomator-.*\.msi$' | Select -ExpandProperty downloadUrl -First 1
           .\wingetcreate.exe update Cryptomator.Cryptomator -s -v ${{ inputs.releaseTag }} -u $installerUrl -t ${{ secrets.CRYPTOBOT_WINGET_TOKEN }}
         shell: pwsh

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -45,5 +45,6 @@ jobs:
           iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
           $releaseAssets = (ConvertFrom-Json '${{ steps.get-release-assets.outputs.result }}').data.repository.release.releaseAssets.nodes
           $installerUrl = $releaseAssets | Where-Object -Property name -match '^Cryptomator-.*\.msi$' | Select -ExpandProperty downloadUrl -First 1
-          .\wingetcreate.exe update Cryptomator.Cryptomator -s -v ${{ inputs.releaseTag }} -u $installerUrl -t ${{ secrets.CRYPTOBOT_WINGET_TOKEN }}
+          echo $installerUrl
+          .\wingetcreate.exe update Cryptomator.Cryptomator -s -v "${{ inputs.releaseTag }}" -u "$installerUrl" -t ${{ secrets.CRYPTOBOT_WINGET_TOKEN }}
         shell: pwsh

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -24,8 +24,8 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const query =`query($owner:String!, $name:String!, $tag:String!) {
-              repository(owner:$owner, name:$name){
+            const query =`query($tag:String!) {
+              repository(owner:"cryptomator", name:"cryptomator"){
                 release(tagName: $tag) {
                     releaseAssets(first:20) {
                       nodes {
@@ -37,8 +37,6 @@ jobs:
               }
             }`;
             const variables = {
-              owner: context.repo.owner,
-              name: context.repo.repo
               tag: {{ inputs.releaseTag }}
             }
             return await github.graphql(query, variables)

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,55 @@
+name: Release Build artifacts to winget
+
+on:
+  workflow_call:
+    inputs:
+      releaseTag:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      releaseTag:
+        description: 'Release tag name'
+        required: true
+        type: string
+
+jobs:
+  publish-winget:
+    name: Publish on winget repo
+    runs-on: windows-latest
+    needs: [build-msi]
+    steps:
+      - name: Get download url for msi artifacts
+        id: get-release-assets
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const query =`query($owner:String!, $name:String!, $tag:String!) {
+              repository(owner:$owner, name:$name){
+                release(tagName: $tag) {
+                    releaseAssets(first:20) {
+                      nodes {
+                        name
+                        downloadUrl
+                      }
+                  }
+                }
+              }
+            }`;
+            const variables = {
+              owner: context.repo.owner,
+              name: context.repo.repo
+              tag: {{ inputs.releaseTag }}
+            }
+            return await github.graphql(query, variables)
+      - name: Submit package to Windows Package Manager Community Repository
+        id: submit-winget
+        run: |
+          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          $releaseAssets = (ConvertFrom-Json $env:RELEASE_ASSETS).data.repository.release.releaseAssets.nodes
+          $installerUrl = $releaseAssets | Where-Object -Property name -match '^Cryptomator-.*\.msi$' | Select -ExpandProperty downloadUrl -First 1
+          .\wingetcreate.exe update Cryptomator.Cryptomator -s -v $env:RELEASE_TAG -u $installerUrl -t ${{ secrets.CRYPTOBOT_WINGET_TOKEN }}
+        shell: pwsh
+        env:
+          RELEASE_ASSETS: steps.get-download-url.outputs.result
+          RELEASE_TAG: inputs.releaseTag

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -45,7 +45,7 @@ jobs:
         id: submit-winget
         run: |
           iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-          $releaseAssets = (ConvertFrom-Json $env:RELEASE_ASSETS).data.repository.release.releaseAssets.nodes
+          $releaseAssets = (ConvertFrom-Json '$env:RELEASE_ASSETS').data.repository.release.releaseAssets.nodes
           $installerUrl = $releaseAssets | Where-Object -Property name -match '^Cryptomator-.*\.msi$' | Select -ExpandProperty downloadUrl -First 1
           .\wingetcreate.exe update Cryptomator.Cryptomator -s -v $env:RELEASE_TAG -u $installerUrl -t ${{ secrets.CRYPTOBOT_WINGET_TOKEN }}
         shell: pwsh

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -51,5 +51,5 @@ jobs:
           .\wingetcreate.exe update Cryptomator.Cryptomator -s -v $env:RELEASE_TAG -u $installerUrl -t ${{ secrets.CRYPTOBOT_WINGET_TOKEN }}
         shell: pwsh
         env:
-          RELEASE_ASSETS: steps.get-download-url.outputs.result
+          RELEASE_ASSETS: steps.get-release-assets.outputs.result
           RELEASE_TAG: inputs.releaseTag

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -39,6 +39,8 @@ jobs:
               tag: "${{ inputs.releaseTag }}"
             }
             return await github.graphql(query, variables)
+      - name: Show query result
+        run: echo ${{ steps.get-release-assets.outputs.result }}
       - name: Submit package to Windows Package Manager Community Repository
         id: submit-winget
         run: |

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,6 +1,7 @@
 name: Release Build artifacts to winget
 
 on:
+  push:
   workflow_call:
     inputs:
       releaseTag:
@@ -15,6 +16,7 @@ on:
 
 jobs:
   publish-winget:
+    if: github.repository == 'octo-org/octo-repo-prod'
     name: Publish on winget repo
     runs-on: windows-latest
     needs: [build-msi]

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -39,8 +39,6 @@ jobs:
               tag: "${{ inputs.releaseTag }}"
             }
             return await github.graphql(query, variables)
-      - name: Show query result
-        run: echo ${{ steps.get-release-assets.outputs.result }}
       - name: Submit package to Windows Package Manager Community Repository
         id: submit-winget
         run: |

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -43,7 +43,7 @@ jobs:
         id: submit-winget
         run: |
           iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-          $releaseAssets = (ConvertFrom-Json '${{ steps.get-release-assets.outputs.result }}').data.repository.release.releaseAssets.nodes
+          $releaseAssets = (ConvertFrom-Json '${{ steps.get-release-assets.outputs.result }}').repository.release.releaseAssets.nodes
           $installerUrl = $releaseAssets | Where-Object -Property name -match '^Cryptomator-.*\.msi$' | Select -ExpandProperty downloadUrl -First 1
           echo $installerUrl
           .\wingetcreate.exe update Cryptomator.Cryptomator -s -v "${{ inputs.releaseTag }}" -u "$installerUrl" -t ${{ secrets.CRYPTOBOT_WINGET_TOKEN }}

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -39,6 +39,12 @@ jobs:
               tag: "${{ inputs.releaseTag }}"
             }
             return await github.graphql(query, variables)
+      - name: Debug Powershell
+        run: |
+          echo '$env:RELEASE_ASSETS'
+          echo '${{ steps.get-release-assets.outputs.result }}'
+        env:
+          RELEASE_ASSETS: steps.get-release-assets.outputs.result
       - name: Submit package to Windows Package Manager Community Repository
         id: submit-winget
         run: |

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -36,7 +36,7 @@ jobs:
               }
             }`;
             const variables = {
-              tag: {{ inputs.releaseTag }}
+              tag: ${{ inputs.releaseTag }}
             }
             return await github.graphql(query, variables)
       - name: Submit package to Windows Package Manager Community Repository

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,7 +1,6 @@
 name: Release Build artifacts to winget
 
 on:
-  push:
   workflow_call:
     inputs:
       releaseTag:
@@ -16,7 +15,6 @@ on:
 
 jobs:
   publish-winget:
-    if: github.repository == 'octo-org/octo-repo-prod'
     name: Publish on winget repo
     runs-on: windows-latest
     needs: [build-msi]

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,4 +1,4 @@
-name: Release Build artifacts to winget
+name: Release to Winget
 
 on:
   workflow_call:

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -45,6 +45,5 @@ jobs:
           iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
           $releaseAssets = (ConvertFrom-Json '${{ steps.get-release-assets.outputs.result }}').repository.release.releaseAssets.nodes
           $installerUrl = $releaseAssets | Where-Object -Property name -match '^Cryptomator-.*\.msi$' | Select -ExpandProperty downloadUrl -First 1
-          echo $installerUrl
           .\wingetcreate.exe update Cryptomator.Cryptomator -s -v "${{ inputs.releaseTag }}" -u "$installerUrl" -t ${{ secrets.CRYPTOBOT_WINGET_TOKEN }}
         shell: pwsh

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -17,7 +17,6 @@ jobs:
   publish-winget:
     name: Publish on winget repo
     runs-on: windows-latest
-    needs: [build-msi]
     steps:
       - name: Get download url for msi artifacts
         id: get-release-assets

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -36,7 +36,7 @@ jobs:
               }
             }`;
             const variables = {
-              tag: ${{ inputs.releaseTag }}
+              tag: "${{ inputs.releaseTag }}"
             }
             return await github.graphql(query, variables)
       - name: Submit package to Windows Package Manager Community Repository


### PR DESCRIPTION
With this PR the winget release task is refactored into its own workflow file. It is designed as a [reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow), so that the old build script can conveniently call it. Additionally, it can be called manually.

It was refactored out for two reasons:
* winget release task depends on _the download URL_ of the uploaded release artifact, not the build artifact itself
* manual trigger is possible without wasting cpu time or any flags to switch off other jobs
