### PR TITLE
Use `coffeelibs-jdk-19` during PPA build

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   build:
     name: Build Debian Package
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:coffeelibs/openjdk
           sudo apt-get update
-          sudo apt-get install debhelper devscripts dput java-19-coffeelibs
+          sudo apt-get install debhelper devscripts dput coffeelibs-jdk-19
       - name: Setup Java
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -27,8 +27,9 @@ jobs:
           fetch-depth: 0
       - name: Install build tools
         run: |
+          sudo add-apt-repository ppa:coffeelibs/openjdk
           sudo apt-get update
-          sudo apt-get install debhelper devscripts dput
+          sudo apt-get install debhelper devscripts dput java-19-coffeelibs
       - name: Setup Java
         uses: actions/setup-java@v3
         with:

--- a/dist/linux/debian/changelog
+++ b/dist/linux/debian/changelog
@@ -1,4 +1,4 @@
-cryptomator (${PPA_VERSION}) bionic; urgency=low
+cryptomator (${PPA_VERSION}) focal; urgency=low
 
   * Full changelog can be found on https://github.com/cryptomator/cryptomator/releases
 

--- a/dist/linux/debian/control
+++ b/dist/linux/debian/control
@@ -2,7 +2,7 @@ Source: cryptomator
 Maintainer: Cryptobot <releases@cryptomator.org>
 Section: utils
 Priority: optional
-Build-Depends: debhelper (>=10), openjdk-17-jdk
+Build-Depends: debhelper (>=10), coffeelibs-jdk-19
 Standards-Version: 4.5.0
 Homepage: https://cryptomator.org
 Vcs-Git: https://github.com/cryptomator/cryptomator.git

--- a/dist/linux/debian/rules
+++ b/dist/linux/debian/rules
@@ -4,6 +4,8 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+JAVA_HOME = /usr/lib/jvm/java-19-coffeelibs
+
 %:
 	dh $@
 
@@ -16,7 +18,7 @@ override_dh_auto_clean:
 override_dh_auto_build:
 	mkdir resources
 	ln -s ../common/org.cryptomator.Cryptomator512.png resources/cryptomator.png
-	jlink \
+	$(JAVA_HOME)/bin/jlink \
 		--output runtime \
 		--add-modules java.base,java.desktop,java.instrument,java.logging,java.naming,java.net.http,java.scripting,java.sql,java.xml,jdk.unsupported,jdk.crypto.ec,jdk.accessibility,jdk.management.jfr \
 		--strip-native-commands \
@@ -24,7 +26,7 @@ override_dh_auto_build:
 		--no-man-pages \
 		--strip-debug \
 		--compress=2
-	jpackage \
+	$(JAVA_HOME)/bin/jpackage \
 		--type app-image \
 		--runtime-image runtime \
 		--input libs \


### PR DESCRIPTION
This increases the minimum supported Ubuntu version to 20.04.