### PR TITLE
Move release precondition checks to own workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ defaults:
 jobs:
   test:
     name: Compile and Test
-    needs: release-check-precondition
     runs-on: ubuntu-latest
     if: "always()
       && (needs.release-check-precondition.result=='success' || needs.release-check-precondition.result=='skipped')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,37 +13,6 @@ defaults:
     shell: bash
 
 jobs:
-  release-check-precondition:
-    name: Validate pushed commit to release/hotfix branch or pushed tag
-    runs-on: ubuntu-latest
-    if: "(startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/hotfix/') || startsWith(github.ref, 'refs/heads/release/'))
-      && !(contains(github.event.head_commit.message, '[ci skip]') || contains(github.event.head_commit.message, '[skip ci]'))"
-    steps:
-      - uses: actions/checkout@v2
-      - id: validate-pom-version
-        name: Validate POM version
-        run: |
-          if [[ $GITHUB_REF =~ refs/heads/(hotfix|release)/[0-9]+\.[0-9]+\.[0-9]+.* ]]; then
-            SEM_VER_STR=${GITHUB_REF##*/}
-          elif [[ $GITHUB_REF =~ refs/tags/[0-9]+\.[0-9]+\.[0-9]+.* ]]; then
-            SEM_VER_STR=${GITHUB_REF##*/}
-          else
-            echo "Failed to parse version"
-            exit 1
-          fi
-
-          if [[ ${SEM_VER_STR} == `mvn help:evaluate -Dexpression=project.version -q -DforceStdout` ]]; then
-            echo "::set-output name=semVerStr::${SEM_VER_STR}"
-          else
-            echo "Version not set in POM"
-            exit 1
-          fi
-      - name: Validate release in org.cryptomator.Cryptomator.metainfo.xml file
-        run: |
-          if ! grep -q "<release date=\".*\" version=\"${{ steps.validate-pom-version.outputs.semVerStr }}\"/>" dist/linux/common/org.cryptomator.Cryptomator.metainfo.xml; then
-            echo "Release not set in dist/linux/common/org.cryptomator.Cryptomator.metainfo.xml"
-            exit 1
-          fi
   test:
     name: Compile and Test
     needs: release-check-precondition

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,6 @@ jobs:
   test:
     name: Compile and Test
     runs-on: ubuntu-latest
-    if: "always()
-      && (needs.release-check-precondition.result=='success' || needs.release-check-precondition.result=='skipped')
-      && !(contains(github.event.head_commit.message, '[ci skip]') || contains(github.event.head_commit.message, '[skip ci]'))"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -24,8 +24,6 @@ jobs:
         run: |
           if [[ $GITHUB_REF =~ refs/heads/(hotfix|release)/[0-9]+\.[0-9]+\.[0-9]+.* ]]; then
             SEM_VER_STR=${GITHUB_REF##*/}
-          elif [[ $GITHUB_REF =~ refs/tags/[0-9]+\.[0-9]+\.[0-9]+.* ]]; then
-            SEM_VER_STR=${GITHUB_REF##*/}
           else
             echo "Failed to parse version"
             exit 1

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,0 +1,45 @@
+name: Release Check
+
+on:
+  push:
+    branches:
+      - 'release/**'
+      - 'hotfix/**'
+
+env:
+  JAVA_VERSION: 19
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  release-check-precondition:
+    name: Validate pushed commit to release/hotfix branch or pushed tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: validate-pom-version
+        name: Validate POM version
+        run: |
+          if [[ $GITHUB_REF =~ refs/heads/(hotfix|release)/[0-9]+\.[0-9]+\.[0-9]+.* ]]; then
+            SEM_VER_STR=${GITHUB_REF##*/}
+          elif [[ $GITHUB_REF =~ refs/tags/[0-9]+\.[0-9]+\.[0-9]+.* ]]; then
+            SEM_VER_STR=${GITHUB_REF##*/}
+          else
+            echo "Failed to parse version"
+            exit 1
+          fi
+
+          if [[ ${SEM_VER_STR} == `mvn help:evaluate -Dexpression=project.version -q -DforceStdout` ]]; then
+            echo "::set-output name=semVerStr::${SEM_VER_STR}"
+          else
+            echo "Version not set in POM"
+            exit 1
+          fi
+      - name: Validate release in org.cryptomator.Cryptomator.metainfo.xml file
+        run: |
+          if ! grep -q "<release date=\".*\" version=\"${{ steps.validate-pom-version.outputs.semVerStr }}\"/>" dist/linux/common/org.cryptomator.Cryptomator.metainfo.xml; then
+            echo "Release not set in dist/linux/common/org.cryptomator.Cryptomator.metainfo.xml"
+            exit 1
+          fi

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -15,7 +15,7 @@ defaults:
 
 jobs:
   release-check-precondition:
-    name: Validate pushed commit to release/hotfix branch or pushed tag
+    name: Validate commits pushed to release/hotfix branch to fulfill release requirements
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR moves the check for required prerelease changes to it's own worklfow file.

With this change, release branches can normally pass CI without the requirement to enforce the validation success by all means (i.e. add fake info to a version file).

Before merging, the a branch protection rule for the main branch must be activated with the following settings:
![grafik](https://user-images.githubusercontent.com/9036915/202477330-5064e10c-f75a-4988-bf82-4672b8dda9b2.png)

Note: the status check has to match the name field of the job in the release-check.yml file.