### PR TITLE
Windows Installer: Parameterize Hardcoded Values

### DIFF
--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -112,7 +112,7 @@ jobs:
         run: |
           $patchScript = "appdir\Cryptomator\patchWebDAV.bat"
           try {
-            (Get-Content $patchScript ) -replace '::REPLACE ME', "SET LOOPBACK_ALIAS=`"${{ evn.LOOPBACK_ALIAS}}`"" | Set-Content $patchScript
+            (Get-Content $patchScript ) -replace '::REPLACE ME', "SET LOOPBACK_ALIAS=`"${{ env.LOOPBACK_ALIAS}}`"" | Set-Content $patchScript
           } catch {
             Write-Host "Failed to set LOOPBACK_ALIAS for patchWebDAV.bat"
             exit 1

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -98,6 +98,7 @@ jobs:
           --java-options "-Dcryptomator.p12Path=\"~/AppData/Roaming/Cryptomator/key.p12\""
           --java-options "-Dcryptomator.ipcSocketPath=\"~/AppData/Roaming/Cryptomator/ipc.socket\""
           --java-options "-Dcryptomator.mountPointsDir=\"~/Cryptomator\""
+          --java-options "-Dcryptomator.loopbackAlias=\"${{ env.LOOPBACK_ALIAS }}\""
           --java-options "-Dcryptomator.showTrayIcon=true"
           --java-options "-Dcryptomator.buildNumber=\"msi-${{ steps.versions.outputs.revNum }}\""
           --java-options "-Dcryptomator.integrationsWin.autoStartShellLinkName=\"Cryptomator\""

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -22,6 +22,8 @@ jobs:
   build-msi:
     name: Build .msi Installer
     runs-on: windows-latest
+    env:
+      LOOPBACK_ALIAS: 'cryptomator-vault'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -105,6 +107,16 @@ jobs:
       - name: Patch Application Directory
         run: |
           cp dist/win/contrib/* appdir/Cryptomator
+      - name: Set LOOPBACK_ALIAS in patchWebDAV.bat
+        shell: pwsh
+        run: |
+          $patchScript = "appdir\Cryptomator\patchWebDAV.bat"
+          try {
+            (Get-Content $patchScript ) -replace '::REPLACE ME', "SET LOOPBACK_ALIAS=`"${{ evn.LOOPBACK_ALIAS}}`"" | Set-Content $patchScript
+          } catch {
+            Write-Host "Failed to set LOOPBACK_ALIAS for patchWebDAV.bat"
+            exit 1
+          }
       - name: Fix permissions
         run: attrib -r appdir/Cryptomator/Cryptomator.exe
         shell: pwsh

--- a/dist/win/build.bat
+++ b/dist/win/build.bat
@@ -9,8 +9,9 @@ SET ABOUT_URL="https://cryptomator.org"
 SET UPDATE_URL="https://cryptomator.org/downloads/"
 SET HELP_URL="https://cryptomator.org/contact/"
 SET MODULE_AND_MAIN_CLASS="org.cryptomator.desktop/org.cryptomator.launcher.Cryptomator"
+SET LOOPBACK_ALIAS="cryptomator-vault"
 
-powershell -NoLogo -NoExit -ExecutionPolicy Unrestricted -Command .\build.ps1^
+powershell -NoLogo -ExecutionPolicy Unrestricted -Command .\build.ps1^
  -AppName %APPNAME%^
  -MainJarGlob "%MAIN_JAR_GLOB%"^
  -ModuleAndMainClass "%MODULE_AND_MAIN_CLASS%"^
@@ -20,4 +21,5 @@ powershell -NoLogo -NoExit -ExecutionPolicy Unrestricted -Command .\build.ps1^
  -AboutUrl "%ABOUT_URL%"^
  -HelpUrl "%HELP_URL%"^
  -UpdateUrl "%UPDATE_URL%"^
+ -LoopbackAlias "%LOOPBACK_ALIAS%"^
  -Clean 1

--- a/dist/win/build.ps1
+++ b/dist/win/build.ps1
@@ -35,6 +35,7 @@ Write-Output "`$buildDir=$buildDir"
 Write-Output "`$Env:JAVA_HOME=$Env:JAVA_HOME"
 
 $copyright = "(C) $CopyrightStartYear - $((Get-Date).Year) $Vendor"
+$loopbackAlias = 'cryptomator-vault'
 
 # compile
 &mvn -B -f $buildDir/../../pom.xml clean package -DskipTests -Pwin
@@ -85,6 +86,7 @@ if ($clean -and (Test-Path -Path $appPath)) {
 	--java-options "-Dcryptomator.ipcSocketPath=`"~/AppData/Roaming/$AppName/ipc.socket`"" `
 	--java-options "-Dcryptomator.p12Path=`"~/AppData/Roaming/$AppName/key.p12`"" `
 	--java-options "-Dcryptomator.mountPointsDir=`"~/$AppName`"" `
+	--java-options "-Dcryptomator.loopbackAlias=`"$loopbackAlias`"" `
 	--java-options "-Dcryptomator.integrationsWin.autoStartShellLinkName=`"$AppName`"" `
 	--java-options "-Dcryptomator.integrationsWin.keychainPaths=`"~/AppData/Roaming/$AppName/keychain.json`"" `
 	--java-options "-Dcryptomator.showTrayIcon=true" `
@@ -107,9 +109,8 @@ Copy-Item "contrib\*" -Destination "$AppName"
 attrib -r "$AppName\$AppName.exe"
 # patch batch script to set hostfile
 $webDAVPatcher = "$AppName\patchWebDAV.bat"
-$alias = 'cryptomator-vault'
 try {
-	(Get-Content $webDAVPatcher ) -replace '::REPLACE ME', "SET LOOPBACK_ALIAS=`"$alias`"" | Set-Content $webDAVPatcher
+	(Get-Content $webDAVPatcher ) -replace '::REPLACE ME', "SET LOOPBACK_ALIAS=`"$loopbackAlias`"" | Set-Content $webDAVPatcher
 } catch {
    Write-Host "Failed to set LOOPBACK_ALIAS for patchWebDAV.bat"
    exit 1

--- a/dist/win/build.ps1
+++ b/dist/win/build.ps1
@@ -35,7 +35,7 @@ Write-Output "`$buildDir=$buildDir"
 Write-Output "`$Env:JAVA_HOME=$Env:JAVA_HOME"
 
 $copyright = "(C) $CopyrightStartYear - $((Get-Date).Year) $Vendor"
-$loopbackAlias = 'cryptomator-vault'
+$loopbackAlias = "$AppName-vault"
 
 # compile
 &mvn -B -f $buildDir/../../pom.xml clean package -DskipTests -Pwin

--- a/dist/win/build.ps1
+++ b/dist/win/build.ps1
@@ -105,6 +105,15 @@ if ($clean -and (Test-Path -Path $appPath)) {
 # patch app dir
 Copy-Item "contrib\*" -Destination "$AppName"
 attrib -r "$AppName\$AppName.exe"
+# patch batch script to set hostfile
+$webDAVPatcher = "$AppName\patchWebDAV.bat"
+$alias = 'cryptomator-vault'
+try {
+	(Get-Content $webDAVPatcher ) -replace '::REPLACE ME', "SET LOOPBACK_ALIAS=`"$alias`"" | Set-Content $webDAVPatcher
+} catch {
+   Write-Host "Failed to set LOOPBACK_ALIAS for patchWebDAV.bat"
+   exit 1
+}
 
 # create .msi
 $Env:JP_WIXWIZARD_RESOURCES = "$buildDir\resources"

--- a/dist/win/build.ps1
+++ b/dist/win/build.ps1
@@ -8,6 +8,7 @@ Param(
 	[Parameter(Mandatory, HelpMessage="Please provide a help url")][string] $HelpUrl,
 	[Parameter(Mandatory, HelpMessage="Please provide an update url")][string] $UpdateUrl,
 	[Parameter(Mandatory, HelpMessage="Please provide an about url")][string] $AboutUrl,
+	[Parameter(Mandatory, HelpMessage="Please provide an alias for localhost")][string] $LoopbackAlias,
 	[bool] $clean
 )
 
@@ -35,7 +36,6 @@ Write-Output "`$buildDir=$buildDir"
 Write-Output "`$Env:JAVA_HOME=$Env:JAVA_HOME"
 
 $copyright = "(C) $CopyrightStartYear - $((Get-Date).Year) $Vendor"
-$loopbackAlias = $AppName.toLower() + "-vault"
 
 # compile
 &mvn -B -f $buildDir/../../pom.xml clean package -DskipTests -Pwin
@@ -86,7 +86,7 @@ if ($clean -and (Test-Path -Path $appPath)) {
 	--java-options "-Dcryptomator.ipcSocketPath=`"~/AppData/Roaming/$AppName/ipc.socket`"" `
 	--java-options "-Dcryptomator.p12Path=`"~/AppData/Roaming/$AppName/key.p12`"" `
 	--java-options "-Dcryptomator.mountPointsDir=`"~/$AppName`"" `
-	--java-options "-Dcryptomator.loopbackAlias=`"$loopbackAlias`"" `
+	--java-options "-Dcryptomator.loopbackAlias=`"$LoopbackAlias`"" `
 	--java-options "-Dcryptomator.integrationsWin.autoStartShellLinkName=`"$AppName`"" `
 	--java-options "-Dcryptomator.integrationsWin.keychainPaths=`"~/AppData/Roaming/$AppName/keychain.json`"" `
 	--java-options "-Dcryptomator.showTrayIcon=true" `
@@ -110,7 +110,7 @@ attrib -r "$AppName\$AppName.exe"
 # patch batch script to set hostfile
 $webDAVPatcher = "$AppName\patchWebDAV.bat"
 try {
-	(Get-Content $webDAVPatcher ) -replace '::REPLACE ME', "SET LOOPBACK_ALIAS=`"$loopbackAlias`"" | Set-Content $webDAVPatcher
+	(Get-Content $webDAVPatcher ) -replace '::REPLACE ME', "SET LOOPBACK_ALIAS=`"$LoopbackAlias`"" | Set-Content $webDAVPatcher
 } catch {
    Write-Host "Failed to set LOOPBACK_ALIAS for patchWebDAV.bat"
    exit 1

--- a/dist/win/build.ps1
+++ b/dist/win/build.ps1
@@ -35,7 +35,7 @@ Write-Output "`$buildDir=$buildDir"
 Write-Output "`$Env:JAVA_HOME=$Env:JAVA_HOME"
 
 $copyright = "(C) $CopyrightStartYear - $((Get-Date).Year) $Vendor"
-$loopbackAlias = "$AppName-vault"
+$loopbackAlias = $AppName.toLower() + "-vault"
 
 # compile
 &mvn -B -f $buildDir/../../pom.xml clean package -DskipTests -Pwin

--- a/dist/win/contrib/patchWebDAV.bat
+++ b/dist/win/contrib/patchWebDAV.bat
@@ -1,6 +1,6 @@
 @echo off
 :: Default values for Cryptomator builds
-SET LOOPBACK_ALIAS="cryptomator-vault"
+::REPLACE ME
 
 cd %~dp0
 powershell -NoLogo -NonInteractive -ExecutionPolicy Unrestricted -Command .\patchWebDAV.ps1^

--- a/dist/win/resources/main.wxs
+++ b/dist/win/resources/main.wxs
@@ -23,6 +23,11 @@
     <?define JpUpgradeVersionOnlyDetectDowngrade="yes"?>
   <?endif?>
 
+  <!-- Cryptomator defaults -->
+  <?define IconFileEncryptedData= "Cryptomator-Vault.ico" ?>
+  <?define ProgIdContentType= "application/vnd.cryptomator.encrypted" ?>
+  <?define CloseApplicationTarget= "cryptomator.exe" ?>
+
   <?include $(var.JpConfigDir)/overrides.wxi ?>
 
   <Product
@@ -86,7 +91,7 @@
     <!-- Non-Opening ProgID -->
     <DirectoryRef Id="INSTALLDIR">
         <Component Win64="yes" Id="nonStartingProgID" >
-          <File Id="IconFileForEncryptedData" KeyPath="yes" Source="$(env.JP_WIXWIZARD_RESOURCES)\$(var.IconFileC9rC9s)" Name="$(var.IconFileC9rC9s)"></File>
+          <File Id="IconFileForEncryptedData" KeyPath="yes" Source="$(env.JP_WIXWIZARD_RESOURCES)\$(var.IconFileEncryptedData)" Name="$(var.IconFileEncryptedData)"></File>
           <ProgId Id="$(var.JpAppName).Encrypted.1" Description="$(var.JpAppName) Encrypted Data" Icon="IconFileForEncryptedData" IconIndex="0">
             <Extension Id="c9r" Advertise="no" ContentType="$(var.ProgIdContentType)">
               <MIME ContentType="$(var.ProgIdContentType)" Default="yes"></MIME>

--- a/dist/win/resources/main.wxs
+++ b/dist/win/resources/main.wxs
@@ -65,16 +65,16 @@
     <CustomAction Id="JpDisallowDowngrade" Error="!(loc.DowngradeErrorMessage)" />
     <?endif?>
 
-
-    <!-- Looking for legacy Cryptomator versions-->
-    <Property Id="OLDEXEINSTALLER">
-      <RegistrySearch Id="InnoSetupInstallation" Root="HKLM" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\Cryptomator_is1" Type="raw" Name="DisplayName" />
-    </Property>
-    <!-- Block installation if innosetup entry of Cryptomator is found -->
-    <!-- TODO: localize -->
-    <Condition Message="A lower version of [ProductName] is already installed. Uninstall it first and then start the setup again. Setup will now exit.">
-        <![CDATA[Installed OR NOT OLDEXEINSTALLER]]>
-    </Condition>
+    <?ifndef SkipCryptomatorLegacyCheck ?>
+      <!-- Block installation if innosetup entry of Cryptomator is found -->
+      <Property Id="OLDEXEINSTALLER">
+        <RegistrySearch Id="InnoSetupInstallation" Root="HKLM" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\Cryptomator_is1" Type="raw" Name="DisplayName" />
+      </Property>
+      <!-- TODO: localize -->
+      <Condition Message="A lower version of [ProductName] is already installed. Uninstall it first and then start the setup again. Setup will now exit.">
+          <![CDATA[Installed OR NOT OLDEXEINSTALLER]]>
+      </Condition>
+    <?endif?>
     <!-- Cryptomator uses UNIX Sockets, which are supported starting with Windows 10 v1803-->
     <Property Id="WINDOWSBUILDNUMBER" Secure="yes">
       <RegistrySearch Id="BuildNumberSearch" Root="HKLM" Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion" Name="CurrentBuildNumber" Type="raw" />

--- a/dist/win/resources/overrides.wxi
+++ b/dist/win/resources/overrides.wxi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Stub by design -->
 
-<!--
+<!-- jPackage Section
 overrides.wxi is a placeholder to set/alter WiX variables referenced from default
 main.wxs file.
 
@@ -30,14 +30,21 @@ Should be defined to enable upgrades and undefined to disable upgrades.
 Default value is `yes`.
 -->
 
-<!-- Non-opening ProgID settings-->
-<?define IconFileC9rC9s= "Cryptomator-Vault.ico" ?>
-<?define ProgIdContentType= "application/vnd.cryptomator.encrypted" ?>
+<!-- Cryptomator Section
 
-<!-- Close Application util -->
-<?define CloseApplicationTarget= "cryptomator.exe" ?>
+Non-opening ProgID settings:
+- IconFileEncryptedData
+Full file name of icon file used for encrypted data files. Default is "Cryptomator-Vault.ico"
 
-<!-- SkipCryptomatorLegacyCheck
+- ProgIdContentType
+Media Type of the encrypted data files. Default is "application/vnd.cryptomator.encrypted"
+
+Close Application settings:
+- CloseApplicationTarget
+Full name of executable to be checkd in the close application util. Default is "cryptomator.exe"
+
+Legacy Installation settings:
+- SkipCryptomatorLegacyCheck
 Should be defined to disable checking for the inno setup installation of Cryptomator and undefined, to enable it.
  -->
 <Include/>

--- a/dist/win/resources/overrides.wxi
+++ b/dist/win/resources/overrides.wxi
@@ -36,4 +36,8 @@ Default value is `yes`.
 
 <!-- Close Application util -->
 <?define CloseApplicationTarget= "cryptomator.exe" ?>
+
+<!-- SkipCryptomatorLegacyCheck
+Should be defined to disable checking for the inno setup installation of Cryptomator and undefined, to enable it.
+ -->
 <Include/>

--- a/src/main/java/org/cryptomator/common/Environment.java
+++ b/src/main/java/org/cryptomator/common/Environment.java
@@ -26,6 +26,7 @@ public class Environment {
 	private static final String KEYCHAIN_PATHS_PROP_NAME = "cryptomator.integrationsWin.keychainPaths";
 	private static final String P12_PATH_PROP_NAME = "cryptomator.p12Path";
 	private static final String LOG_DIR_PROP_NAME = "cryptomator.logDir";
+	private static final String LOOPBACK_ALIAS_PROP_NAME = "cryptomator.loopbackAlias";
 	private static final String MOUNTPOINT_DIR_PROP_NAME = "cryptomator.mountPointsDir";
 	private static final String MIN_PW_LENGTH_PROP_NAME = "cryptomator.minPwLength";
 	private static final String APP_VERSION_PROP_NAME = "cryptomator.appVersion";
@@ -45,6 +46,7 @@ public class Environment {
 		logCryptomatorSystemProperty(IPC_SOCKET_PATH_PROP_NAME);
 		logCryptomatorSystemProperty(KEYCHAIN_PATHS_PROP_NAME);
 		logCryptomatorSystemProperty(LOG_DIR_PROP_NAME);
+		logCryptomatorSystemProperty(LOOPBACK_ALIAS_PROP_NAME);
 		logCryptomatorSystemProperty(PLUGIN_DIR_PROP_NAME);
 		logCryptomatorSystemProperty(MOUNTPOINT_DIR_PROP_NAME);
 		logCryptomatorSystemProperty(MIN_PW_LENGTH_PROP_NAME);
@@ -90,6 +92,10 @@ public class Environment {
 		return getPath(LOG_DIR_PROP_NAME).map(this::replaceHomeDir);
 	}
 
+	public Optional<String> getLoopbackAlias() {
+		return Optional.ofNullable(System.getProperty(LOOPBACK_ALIAS_PROP_NAME));
+	}
+
 	public Optional<Path> getPluginDir() {
 		return getPath(PLUGIN_DIR_PROP_NAME).map(this::replaceHomeDir);
 	}
@@ -112,20 +118,11 @@ public class Environment {
 	}
 
 	public int getMinPwLength() {
-		return getInt(MIN_PW_LENGTH_PROP_NAME, DEFAULT_MIN_PW_LENGTH);
+		return Integer.getInteger(MIN_PW_LENGTH_PROP_NAME, DEFAULT_MIN_PW_LENGTH);
 	}
 
 	public boolean showTrayIcon() {
 		return Boolean.getBoolean(TRAY_ICON_PROP_NAME);
-	}
-
-	private int getInt(String propertyName, int defaultValue) {
-		String value = System.getProperty(propertyName);
-		try {
-			return Integer.parseInt(value);
-		} catch (NumberFormatException e) { // includes "null" values
-			return defaultValue;
-		}
 	}
 
 	private Optional<Path> getPath(String propertyName) {


### PR DESCRIPTION
This PR allows to set/overwrite more values of the windows installer during build, making the build easier to adapt to changes.

Affected parts are:
* Alias of the loopback device/localhost
* Legacy installation check
* Media type and file extension of encrypted data
* Name of application executable blocking installation