### PR TITLE
Use OpenJFX jmods

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -35,9 +35,9 @@ jobs:
         shell: pwsh
         run: |
           $jfxPomVersion = (&mvn help:evaluate "-Dexpression=javafx.version" -q -DforceStdout) -split "\."
-          $jfxJdkVersion = (Get-Content -path "${env:JAVA_HOME}/lib/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=',''
+          $jfxJdkVersion = ((Get-Content -path "${env:JAVA_HOME}/lib/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=','') -split "\."
           if ($jfxPomVersion[0] -ne $jfxJdkVersion) {
-            Write-Error "Major part of JavaFX version in pom($($jfxPomVersion[0])) does not match the version in JDK(${jfxJdkVersion}) "
+            Write-Error "Major part of JavaFX version in pom($($jfxPomVersion[0])) does not match the version in JDK($($jfxJdkVersion[0])) "
             exit 1
           }
       - name: Set version

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}
+          java-package: 'jdk+fx'
           cache: 'maven'
       - name: Set version
         run : mvn versions:set -DnewVersion=${{ needs.get-version.outputs.semVerStr }}
@@ -45,7 +46,7 @@ jobs:
           --verbose
           --output runtime
           --module-path "${JAVA_HOME}/jmods"
-          --add-modules java.base,java.desktop,java.instrument,java.logging,java.naming,java.net.http,java.scripting,java.sql,java.xml,jdk.unsupported,jdk.crypto.ec,jdk.accessibility,jdk.management.jfr
+          --add-modules java.base,java.desktop,java.instrument,java.logging,java.naming,java.net.http,java.scripting,java.sql,java.xml,javafx.base,javafx.graphics,javafx.controls,javafx.fxml,jdk.unsupported,jdk.crypto.ec,jdk.accessibility,jdk.management.jfr
           --strip-native-commands
           --no-header-files
           --no-man-pages

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Ensure major jfx version in pom equals in jdk
         shell: pwsh
         run: |
-          $jfxPomVersion = (&mvn help:evaluate -Dexpression=javafx.version -q -DforceStdout) -split "\."
+          $jfxPomVersion = (&mvn help:evaluate "-Dexpression=javafx.version" -q -DforceStdout) -split "\."
           $jfxJdkVersion = (Get-Content -path "${env:JAVA_HOME}/lib/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=',''
           if ($jfxPomVersion[0] -ne $jfxJdkVersion) {
             Write-Error "Major part of JavaFX version in pom($($jfxPomVersion[0])) does not match the version in JDK(${jfxJdkVersion}) "

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           $jfxPomVersion = (&mvn help:evaluate "-Dexpression=javafx.version" -q -DforceStdout) -split "\."
           $jfxJdkVersion = ((Get-Content -path "${env:JAVA_HOME}/lib/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=','') -split "\."
-          if ($jfxPomVersion[0] -ne $jfxJdkVersion) {
+          if ($jfxPomVersion[0] -ne $jfxJdkVersion[0]) {
             Write-Error "Major part of JavaFX version in pom($($jfxPomVersion[0])) does not match the version in JDK($($jfxJdkVersion[0])) "
             exit 1
           }

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -31,6 +31,15 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           java-package: 'jdk+fx'
           cache: 'maven'
+      - name: Ensure major jfx version in pom equals in jdk
+        shell: pwsh
+        run: |
+          $jfxPomVersion = (&mvn help:evaluate -Dexpression=javafx.version -q -DforceStdout) -split "\."
+          $jfxJdkVersion = (Get-Content -path "${env:JAVA_HOME}/lib/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=',''
+          if ($jfxPomVersion[0] -ne $jfxJdkVersion) {
+            Out-Error "Major part of JavaFX version in pom($($jfxPomVersion[0])) does not match the version in JDK(${jfxJdkVersion}) "
+            exit 1
+          }
       - name: Set version
         run : mvn versions:set -DnewVersion=${{ needs.get-version.outputs.semVerStr }}
       - name: Run maven

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -37,7 +37,7 @@ jobs:
           $jfxPomVersion = (&mvn help:evaluate -Dexpression=javafx.version -q -DforceStdout) -split "\."
           $jfxJdkVersion = (Get-Content -path "${env:JAVA_HOME}/lib/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=',''
           if ($jfxPomVersion[0] -ne $jfxJdkVersion) {
-            Out-Error "Major part of JavaFX version in pom($($jfxPomVersion[0])) does not match the version in JDK(${jfxJdkVersion}) "
+            Write-Error "Major part of JavaFX version in pom($($jfxPomVersion[0])) does not match the version in JDK(${jfxJdkVersion}) "
             exit 1
           }
       - name: Set version

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -56,21 +56,23 @@ jobs:
           curl -L ${{ env.OPENJFX_JMODS_AMD64 }} -o openjfx-amd64.zip
           mkdir -p jmods/amd64
           unzip -j openjfx-amd64.zip \*/javafx.base.jmod \*/javafx.controls.jmod \*/javafx.fxml.jmod \*/javafx.graphics.jmod -d jmods/amd64
-          unzip -j jmods/amd64/javafx.base.jmod lib/javafx.properties -d jmods/amd64
           curl -L ${{ env.OPENJFX_JMODS_AARCH64 }} -o openjfx-aarch64.zip
           mkdir -p jmods/aarch64
           unzip -j openjfx-aarch64.zip \*/javafx.base.jmod \*/javafx.controls.jmod \*/javafx.fxml.jmod \*/javafx.graphics.jmod -d jmods/aarch64
-          unzip -j jmods/aarch64/javafx.base.jmod lib/javafx.properties -d jmods/aarch64
       - name: Ensure major jfx version in pom and in jmods is the same
         shell: pwsh
         run: |
-          $jfxPomVersion = (&mvn help:evaluate "-Dexpression=javafx.version" -q -DforceStdout) -split "\."
-          $jfxJmodVersionAmd64 = ((Get-Content -Path "jmods/aarch64/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=','') -split "\."
-          $jfxJmodVersionAarch64 = ((Get-Content -Path "jmods/aarch64/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=','') -split "\."
+          mkdir jfxBaseJmodAmd64
+          jmod extract --dir jfxBaseJmodAmd64 jmods/amd64/javafx.base.jmod
+          $jfxJmodVersionAmd64 = ((Get-Content -Path "jfxBaseJmodAmd64/lib/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=','') -split "\."
+          mkdir jfxBaseJmodAarch64
+          jmod extract --dir jfxBaseJmodAarch64 jmods/aarch64/javafx.base.jmod
+          $jfxJmodVersionAarch64 = ((Get-Content -Path "jfxBaseJmodAarch64/lib/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=','') -split "\."
           if ($jfxJmodVersionAmd64[0] -ne $jfxJmodVersionAarch64[0] ) {
             Write-Error "JavaFX Jmods for aarch64 and amd64 are different major versions"
             exit 1
           }
+          $jfxPomVersion = (&mvn help:evaluate "-Dexpression=javafx.version" -q -DforceStdout) -split "\."
           if ($jfxPomVersion[0] -ne $jfxJmodVersionAmd64[0]) {
             Out-Error "Major part of JavaFX version in pom($($jfxPomVersion[0])) does not match the version of Jmods($($jfxJmodVersionAmd64[0])) "
             exit 1

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:coffeelibs/openjdk
           sudo apt-get update
-          sudo apt-get install debhelper devscripts dput coffeelibs-jdk-19
+          sudo apt-get install debhelper devscripts dput coffeelibs-jdk-19 libgtk2.0-0
       - name: Setup Java
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -68,7 +68,7 @@ jobs:
           $jfxJmodVersionAmd64 = (Get-Content -Path "jmods/aarch64/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=',''
           $jfxJmodVersionAarch64 = (Get-Content -Path "jmods/aarch64/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=',''
           if ($jfxJmodVersionAmd64 -ne $jfxJmodVersionAarch64 ) {
-            Out-Error "JavaFX Jmods for aarch64 and amd64 are different major versions"
+            Write-Error "JavaFX Jmods for aarch64 and amd64 are different major versions"
             exit 1
           }
           if ($jfxPomVersion[0] -ne $jfxJmodVersionAmd64) {

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -74,7 +74,7 @@ jobs:
           }
           $jfxPomVersion = (&mvn help:evaluate "-Dexpression=javafx.version" -q -DforceStdout) -split "\."
           if ($jfxPomVersion[0] -ne $jfxJmodVersionAmd64[0]) {
-            Out-Error "Major part of JavaFX version in pom($($jfxPomVersion[0])) does not match the version of Jmods($($jfxJmodVersionAmd64[0])) "
+            Write-Error "Major part of JavaFX version in pom($($jfxPomVersion[0])) does not match the version of Jmods($($jfxJmodVersionAmd64[0])) "
             exit 1
           }
       - name: Create orig.tar.gz with common/ libs/ mods/ jmods/

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -64,15 +64,15 @@ jobs:
       - name: Ensure major jfx version in pom and in jmods is the same
         shell: pwsh
         run: |
-          $jfxPomVersion = (&mvn help:evaluate -Dexpression=javafx.version -q -DforceStdout) -split "\."
-          $jfxJmodVersionAmd64 = (Get-Content -Path "jmods/aarch64/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=',''
-          $jfxJmodVersionAarch64 = (Get-Content -Path "jmods/aarch64/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=',''
-          if ($jfxJmodVersionAmd64 -ne $jfxJmodVersionAarch64 ) {
+          $jfxPomVersion = (&mvn help:evaluate "-Dexpression=javafx.version" -q -DforceStdout) -split "\."
+          $jfxJmodVersionAmd64 = ((Get-Content -Path "jmods/aarch64/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=','') -split "\."
+          $jfxJmodVersionAarch64 = ((Get-Content -Path "jmods/aarch64/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=','') -split "\."
+          if ($jfxJmodVersionAmd64[0] -ne $jfxJmodVersionAarch64[0] ) {
             Write-Error "JavaFX Jmods for aarch64 and amd64 are different major versions"
             exit 1
           }
-          if ($jfxPomVersion[0] -ne $jfxJmodVersionAmd64) {
-            Out-Error "Major part of JavaFX version in pom($($jfxPomVersion[0])) does not match the version of Jmods(${jfxJmodVersion}) "
+          if ($jfxPomVersion[0] -ne $jfxJmodVersionAmd64[0]) {
+            Out-Error "Major part of JavaFX version in pom($($jfxPomVersion[0])) does not match the version of Jmods($($jfxJmodVersionAmd64[0])) "
             exit 1
           }
       - name: Create orig.tar.gz with common/ libs/ mods/ jmods/

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -51,13 +51,30 @@ jobs:
       - name: Run maven
         run: mvn -B clean package -Pdependency-check,linux -DskipTests
       - name: Download OpenJFX jmods
+        id: download-jmods
         run: |
           curl -L ${{ env.OPENJFX_JMODS_AMD64 }} -o openjfx-amd64.zip
           mkdir -p jmods/amd64
           unzip -j openjfx-amd64.zip \*/javafx.base.jmod \*/javafx.controls.jmod \*/javafx.fxml.jmod \*/javafx.graphics.jmod -d jmods/amd64
+          unzip -j jmods/amd64/javafx.base.jmod lib/javafx.properties -d jmods/amd64
           curl -L ${{ env.OPENJFX_JMODS_AARCH64 }} -o openjfx-aarch64.zip
           mkdir -p jmods/aarch64
           unzip -j openjfx-aarch64.zip \*/javafx.base.jmod \*/javafx.controls.jmod \*/javafx.fxml.jmod \*/javafx.graphics.jmod -d jmods/aarch64
+          unzip -j jmods/aarch64/javafx.base.jmod lib/javafx.properties -d jmods/aarch64
+      - name: Ensure major jfx version in pom and in jmods is the same
+        shell: pwsh
+        run: |
+          $jfxPomVersion = (&mvn help:evaluate -Dexpression=javafx.version -q -DforceStdout) -split "\."
+          $jfxJmodVersionAmd64 = (Get-Content -Path "jmods/aarch64/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=',''
+          $jfxJmodVersionAarch64 = (Get-Content -Path "jmods/aarch64/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=',''
+          if ($jfxJmodVersionAmd64 -ne $jfxJmodVersionAarch64 ) {
+            Out-Error "JavaFX Jmods for aarch64 and amd64 are different major versions"
+            exit 1
+          }
+          if ($jfxPomVersion[0] -ne $jfxJmodVersionAmd64) {
+            Out-Error "Major part of JavaFX version in pom($($jfxPomVersion[0])) does not match the version of Jmods(${jfxJmodVersion}) "
+            exit 1
+          }
       - name: Create orig.tar.gz with common/ libs/ mods/ jmods/
         run: |
           mkdir pkgdir

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -16,6 +16,8 @@ on:
 
 env:
   JAVA_VERSION: 19
+  OPENJFX_JMODS_AMD64: 'https://download2.gluonhq.com/openjfx/19/openjfx-19_linux-x64_bin-jmods.zip'
+  OPENJFX_JMODS_AARCH64: 'https://download2.gluonhq.com/openjfx/19/openjfx-19_linux-aarch64_bin-jmods.zip'
 
 jobs:
   get-version:
@@ -48,11 +50,20 @@ jobs:
           REVCOUNT: ${{ needs.get-version.outputs.revNum }}
       - name: Run maven
         run: mvn -B clean package -Pdependency-check,linux -DskipTests
-      - name: Create orig.tar.gz with common/ libs/ mods/
+      - name: Download OpenJFX jmods
+        run: |
+          curl -L ${{ env.OPENJFX_JMODS_AMD64 }} -o openjfx-amd64.zip
+          mkdir -p jmods/amd64
+          unzip -j openjfx-amd64.zip \*/javafx.base.jmod \*/javafx.controls.jmod \*/javafx.fxml.jmod \*/javafx.graphics.jmod -d jmods/amd64
+          curl -L ${{ env.OPENJFX_JMODS_AARCH64 }} -o openjfx-aarch64.zip
+          mkdir -p jmods/aarch64
+          unzip -j openjfx-aarch64.zip \*/javafx.base.jmod \*/javafx.controls.jmod \*/javafx.fxml.jmod \*/javafx.graphics.jmod -d jmods/aarch64
+      - name: Create orig.tar.gz with common/ libs/ mods/ jmods/
         run: |
           mkdir pkgdir
           cp -r target/libs pkgdir
           cp -r target/mods pkgdir
+          cp -r jmods pkgdir
           cp -r dist/linux/common/ pkgdir
           cp target/cryptomator-*.jar pkgdir/mods
           tar -cJf cryptomator_${{ steps.versions.outputs.ppaVerStr }}.orig.tar.xz -C pkgdir .

--- a/.github/workflows/mac-dmg.yml
+++ b/.github/workflows/mac-dmg.yml
@@ -47,10 +47,10 @@ jobs:
       - name: Ensure major jfx version in pom equals in jdk
         shell: pwsh
         run: |
-          $jfxPomVersion = (&mvn help:evaluate -Dexpression=javafx.version -q -DforceStdout) -split "\."
-          $jfxJdkVersion = (Get-Content -path "${env:JAVA_HOME}/lib/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=',''
-          if ($jfxPomVersion[0] -ne $jfxJdkVersion) {
-            Write-Error "Major part of JavaFX version in pom($($jfxPomVersion[0])) does not match the version in JDK(${jfxJdkVersion}) "
+          $jfxPomVersion = (&mvn help:evaluate "-Dexpression=javafx.version" -q -DforceStdout) -split "\."
+          $jfxJdkVersion = ((Get-Content -path "${env:JAVA_HOME}/lib/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=','') -split "\."
+          if ($jfxPomVersion[0] -ne $jfxJdkVersion[0]) {
+            Write-Error "Major part of JavaFX version in pom($($jfxPomVersion[0])) does not match the version in JDK($($jfxJdkVersion[0])) "
             exit 1
           }
       - name: Set version

--- a/.github/workflows/mac-dmg.yml
+++ b/.github/workflows/mac-dmg.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}
+          java-package: 'jdk+fx'
           architecture: ${{ matrix.architecture }}
           cache: 'maven'
       - name: Set version
@@ -58,7 +59,7 @@ jobs:
           --verbose
           --output runtime
           --module-path "${JAVA_HOME}/jmods"
-          --add-modules java.base,java.desktop,java.instrument,java.logging,java.naming,java.net.http,java.scripting,java.sql,java.xml,jdk.unsupported,jdk.crypto.ec,jdk.accessibility,jdk.management.jfr
+          --add-modules java.base,java.desktop,java.instrument,java.logging,java.naming,java.net.http,java.scripting,java.sql,java.xml,javafx.base,javafx.graphics,javafx.controls,javafx.fxml,jdk.unsupported,jdk.crypto.ec,jdk.accessibility,jdk.management.jfr
           --strip-native-commands
           --no-header-files
           --no-man-pages

--- a/.github/workflows/mac-dmg.yml
+++ b/.github/workflows/mac-dmg.yml
@@ -45,6 +45,7 @@ jobs:
           architecture: ${{ matrix.architecture }}
           cache: 'maven'
       - name: Ensure major jfx version in pom equals in jdk
+        if: ${{ matrix.architecture}} == 'x64'
         shell: pwsh
         run: |
           $jfxPomVersion = (&mvn help:evaluate "-Dexpression=javafx.version" -q -DforceStdout) -split "\."

--- a/.github/workflows/mac-dmg.yml
+++ b/.github/workflows/mac-dmg.yml
@@ -44,6 +44,15 @@ jobs:
           java-package: 'jdk+fx'
           architecture: ${{ matrix.architecture }}
           cache: 'maven'
+      - name: Ensure major jfx version in pom equals in jdk
+        shell: pwsh
+        run: |
+          $jfxPomVersion = (&mvn help:evaluate -Dexpression=javafx.version -q -DforceStdout) -split "\."
+          $jfxJdkVersion = (Get-Content -path "${env:JAVA_HOME}/lib/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=',''
+          if ($jfxPomVersion[0] -ne $jfxJdkVersion) {
+            Out-Error "Major part of JavaFX version in pom($($jfxPomVersion[0])) does not match the version in JDK(${jfxJdkVersion}) "
+            exit 1
+          }
       - name: Set version
         run : mvn versions:set -DnewVersion=${{ needs.get-version.outputs.semVerStr }}
       - name: Run maven

--- a/.github/workflows/mac-dmg.yml
+++ b/.github/workflows/mac-dmg.yml
@@ -50,7 +50,7 @@ jobs:
           $jfxPomVersion = (&mvn help:evaluate -Dexpression=javafx.version -q -DforceStdout) -split "\."
           $jfxJdkVersion = (Get-Content -path "${env:JAVA_HOME}/lib/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=',''
           if ($jfxPomVersion[0] -ne $jfxJdkVersion) {
-            Out-Error "Major part of JavaFX version in pom($($jfxPomVersion[0])) does not match the version in JDK(${jfxJdkVersion}) "
+            Write-Error "Major part of JavaFX version in pom($($jfxPomVersion[0])) does not match the version in JDK(${jfxJdkVersion}) "
             exit 1
           }
       - name: Set version

--- a/.github/workflows/mac-dmg.yml
+++ b/.github/workflows/mac-dmg.yml
@@ -45,7 +45,7 @@ jobs:
           architecture: ${{ matrix.architecture }}
           cache: 'maven'
       - name: Ensure major jfx version in pom equals in jdk
-        if: ${{ matrix.architecture}} == 'x64'
+        if: ${{ !contains(matrix.os, 'self-hosted') }}
         shell: pwsh
         run: |
           $jfxPomVersion = (&mvn help:evaluate "-Dexpression=javafx.version" -q -DforceStdout) -split "\."

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -42,10 +42,10 @@ jobs:
       - name: Ensure major jfx version in pom equals in jdk
         shell: pwsh
         run: |
-          $jfxPomVersion = (&mvn help:evaluate -Dexpression=javafx.version -q -DforceStdout) -split "\."
-          $jfxJdkVersion = (Get-Content -path "${env:JAVA_HOME}/lib/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=',''
-          if ($jfxPomVersion[0] -ne $jfxJdkVersion) {
-            Write-Error "Major part of JavaFX version in pom($($jfxPomVersion[0])) does not match the version in JDK(${jfxJdkVersion}) "
+          $jfxPomVersion = (&mvn help:evaluate "-Dexpression=javafx.version" -q -DforceStdout) -split "\."
+          $jfxJdkVersion = ((Get-Content -path "${env:JAVA_HOME}/lib/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=','') -split "\."
+          if ($jfxPomVersion[0] -ne $jfxJdkVersion[0]) {
+            Write-Error "Major part of JavaFX version in pom($($jfxPomVersion[0])) does not match the version in JDK($($jfxJdkVersion[0])) "
             exit 1
           }
       - name: Set version

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -39,6 +39,15 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           java-package: 'jdk+fx'
           cache: ${{ env.JAVA_CACHE }}
+      - name: Ensure major jfx version in pom equals in jdk
+        shell: pwsh
+        run: |
+          $jfxPomVersion = (&mvn help:evaluate -Dexpression=javafx.version -q -DforceStdout) -split "\."
+          $jfxJdkVersion = (Get-Content -path "${env:JAVA_HOME}/lib/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=',''
+          if ($jfxPomVersion[0] -ne $jfxJdkVersion) {
+            Out-Error "Major part of JavaFX version in pom($($jfxPomVersion[0])) does not match the version in JDK(${jfxJdkVersion}) "
+            exit 1
+          }
       - name: Set version
         run : mvn versions:set -DnewVersion=${{ needs.get-version.outputs.semVerStr }}
       - name: Run maven

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           distribution: ${{ env.JAVA_DIST }}
           java-version: ${{ env.JAVA_VERSION }}
+          java-package: 'jdk+fx'
           cache: ${{ env.JAVA_CACHE }}
       - name: Set version
         run : mvn versions:set -DnewVersion=${{ needs.get-version.outputs.semVerStr }}
@@ -53,7 +54,7 @@ jobs:
           --verbose
           --output runtime
           --module-path "${JAVA_HOME}/jmods"
-          --add-modules java.base,java.desktop,java.instrument,java.logging,java.naming,java.net.http,java.scripting,java.sql,java.xml,jdk.unsupported,jdk.crypto.ec,jdk.accessibility,jdk.management.jfr
+          --add-modules java.base,java.desktop,java.instrument,java.logging,java.naming,java.net.http,java.scripting,java.sql,java.xml,javafx.base,javafx.graphics,javafx.controls,javafx.fxml,jdk.unsupported,jdk.crypto.ec,jdk.accessibility,jdk.management.jfr
           --strip-native-commands
           --no-header-files
           --no-man-pages

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -45,7 +45,7 @@ jobs:
           $jfxPomVersion = (&mvn help:evaluate -Dexpression=javafx.version -q -DforceStdout) -split "\."
           $jfxJdkVersion = (Get-Content -path "${env:JAVA_HOME}/lib/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=',''
           if ($jfxPomVersion[0] -ne $jfxJdkVersion) {
-            Out-Error "Major part of JavaFX version in pom($($jfxPomVersion[0])) does not match the version in JDK(${jfxJdkVersion}) "
+            Write-Error "Major part of JavaFX version in pom($($jfxPomVersion[0])) does not match the version in JDK(${jfxJdkVersion}) "
             exit 1
           }
       - name: Set version

--- a/dist/linux/debian/control
+++ b/dist/linux/debian/control
@@ -2,7 +2,7 @@ Source: cryptomator
 Maintainer: Cryptobot <releases@cryptomator.org>
 Section: utils
 Priority: optional
-Build-Depends: debhelper (>=10), coffeelibs-jdk-19
+Build-Depends: debhelper (>=10), coffeelibs-jdk-19, libgtk2.0-0
 Standards-Version: 4.5.0
 Homepage: https://cryptomator.org
 Vcs-Git: https://github.com/cryptomator/cryptomator.git

--- a/dist/linux/debian/rules
+++ b/dist/linux/debian/rules
@@ -5,6 +5,12 @@
 #export DH_VERBOSE=1
 
 JAVA_HOME = /usr/lib/jvm/java-19-coffeelibs
+DEB_BUILD_ARCH ?= $(shell dpkg-architecture -qDEB_BUILD_ARCH)
+ifeq ($(DEB_BUILD_ARCH),amd64)
+JMODS_PATH = jmods/amd64:${JAVA_HOME}/jmods
+else ifeq ($(DEB_BUILD_ARCH),arm64)
+JMODS_PATH = jmods/aarch64:${JAVA_HOME}/jmods
+endif
 
 %:
 	dh $@
@@ -20,8 +26,8 @@ override_dh_auto_build:
 	ln -s ../common/org.cryptomator.Cryptomator512.png resources/cryptomator.png
 	$(JAVA_HOME)/bin/jlink \
 		--output runtime \
-		--module-path "jmods:${JAVA_HOME}/jmods" \
-		--add-modules java.base,java.desktop,java.instrument,java.logging,java.naming,java.net.http,java.scripting,java.sql,java.xml,jdk.unsupported,jdk.crypto.ec,jdk.accessibility,jdk.management.jfr \
+		--module-path "${JMODS_PATH}" \
+		--add-modules java.base,java.desktop,java.instrument,java.logging,java.naming,java.net.http,java.scripting,java.sql,java.xml,javafx.base,javafx.graphics,javafx.controls,javafx.fxml,jdk.unsupported,jdk.crypto.ec,jdk.accessibility,jdk.management.jfr \
 		--strip-native-commands \
 		--no-header-files \
 		--no-man-pages \

--- a/dist/linux/debian/rules
+++ b/dist/linux/debian/rules
@@ -20,6 +20,7 @@ override_dh_auto_build:
 	ln -s ../common/org.cryptomator.Cryptomator512.png resources/cryptomator.png
 	$(JAVA_HOME)/bin/jlink \
 		--output runtime \
+		--module-path "jmods:${JAVA_HOME}/jmods" \
 		--add-modules java.base,java.desktop,java.instrument,java.logging,java.naming,java.net.http,java.scripting,java.sql,java.xml,jdk.unsupported,jdk.crypto.ec,jdk.accessibility,jdk.management.jfr \
 		--strip-native-commands \
 		--no-header-files \

--- a/pom.xml
+++ b/pom.xml
@@ -371,6 +371,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
 				<executions>
+					<!-- sort jars into two buckets (classpath and modulepath). exclude openjfx, which gets jlinked separately -->
 					<execution>
 						<id>copy-mods</id>
 						<phase>prepare-package</phase>
@@ -380,7 +381,7 @@
 						<configuration>
 							<includeScope>runtime</includeScope>
 							<outputDirectory>${project.build.directory}/mods</outputDirectory>
-							<excludeGroupIds>${nonModularGroupIds}</excludeGroupIds>
+							<excludeGroupIds>org.openjfx,${nonModularGroupIds}</excludeGroupIds>
 						</configuration>
 					</execution>
 					<execution>


### PR DESCRIPTION
Instead of .jars, we now use jmods for `jlink`.

TODO @infeo this solves some problems. And is recommended (see link to openjfx mailing list?)