### PR TITLE
Fixed vault list refresh when tray icon is clicked on macOS

### DIFF
--- a/src/main/java/org/cryptomator/ui/traymenu/AwtTrayMenuController.java
+++ b/src/main/java/org/cryptomator/ui/traymenu/AwtTrayMenuController.java
@@ -77,7 +77,7 @@ public class AwtTrayMenuController implements TrayMenuController {
 		Preconditions.checkNotNull(this.trayIcon);
 		this.trayIcon.addMouseListener(new MouseAdapter() {
 			@Override
-			public void mouseClicked(MouseEvent e) {
+			public void mousePressed(MouseEvent e) {
 				listener.run();
 			}
 		});


### PR DESCRIPTION
Follow-up on: [#2489](https://github.com/cryptomator/cryptomator/pull/2489#issuecomment-1398575771)

It's a simple fix on macOS but I wanted to make sure it also works on Windows.

Edit: Confirmed at https://github.com/cryptomator/cryptomator/pull/2489#issuecomment-1399419068