### PR TITLE
Feature/2652 migrate dir mounts

### DIFF
--- a/dist/win/contrib/170FuseMigration.ps1
+++ b/dist/win/contrib/170FuseMigration.ps1
@@ -1,0 +1,12 @@
+$settingsPath = 'C:\Users\Arbeit\AppData\Roaming\Cryptomator-Dev\settings1617.json'
+$settings = Get-Content -Path $settingsPath | ConvertFrom-Json
+$atLeastOneCustomPath = $false;
+foreach ($vault in $settings.directories){
+    $atLeastOneCustomPath = $atLeastOneCustomPath -or ($vault.useCustomMountPath -eq "True")
+}
+
+if( $atLeastOneCustomPath -and ($settings.preferredVolumeImpl -eq "FUSE")) {
+    Add-Member -Force -InputObject $settings -Name "mountService" -Value "org.cryptomator.frontend.fuse.mount.WinFspMountProvider" -MemberType NoteProperty
+    $newSettings  = $settings | Select-Object * -ExcludeProperty "preferredVolumeImpl"
+    ConvertTo-Json $newSettings | Set-Content -Path $settingsPath
+}

--- a/dist/win/contrib/170FuseMigration.ps1
+++ b/dist/win/contrib/170FuseMigration.ps1
@@ -1,12 +1,39 @@
-$settingsPath = 'C:\Users\Arbeit\AppData\Roaming\Cryptomator-Dev\settings1617.json'
-$settings = Get-Content -Path $settingsPath | ConvertFrom-Json
-$atLeastOneCustomPath = $false;
-foreach ($vault in $settings.directories){
-    $atLeastOneCustomPath = $atLeastOneCustomPath -or ($vault.useCustomMountPath -eq "True")
-}
+# This script migrates Cryptomator settings for all local users on Windows in case a custom directory is used
+#Requires -RunAsAdministrator
 
-if( $atLeastOneCustomPath -and ($settings.preferredVolumeImpl -eq "FUSE")) {
-    Add-Member -Force -InputObject $settings -Name "mountService" -Value "org.cryptomator.frontend.fuse.mount.WinFspMountProvider" -MemberType NoteProperty
-    $newSettings  = $settings | Select-Object * -ExcludeProperty "preferredVolumeImpl"
-    ConvertTo-Json $newSettings | Set-Content -Path $settingsPath
+#Get all active, local user profiles
+$profileList = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList'
+$localUsers = Get-LocalUser | Where-Object {$_.Enabled} | ForEach-Object { $_.Name}
+
+Get-ChildItem $profileList | ForEach-Object { $_.GetValue("ProfileImagePath") } | Where-Object {
+    $matches = ($_ | Select-String -Pattern "\\([^\\]+)$").Matches
+    if($matches.Count -eq 1) {
+        return $localUsers.Contains($matches[0].Groups[1].Value)
+    }
+    return $false;
+} | ForEach-Object {
+    $settingsPath = "$_\AppData\Roaming\Cryptomator\settings.json"
+    if(!(Test-Path -Path $settingsPath)) {
+        #No settings file, nothing to do.
+        return;
+    }
+
+    $settings = Get-Content -Path $settingsPath | ConvertFrom-Json
+    if($settings.preferredVolumeImpl -eq "FUSE") {
+        #Fuse not used, nothing to do
+        return;
+    }
+
+    #check if customMountPoints are used
+    $atLeastOneCustomPath = $false;
+    foreach ($vault in $settings.directories){
+        $atLeastOneCustomPath = $atLeastOneCustomPath -or ($vault.useCustomMountPath -eq "True")
+    }
+
+    #if so, use WinFsp Local Drive
+    if( $atLeastOneCustomPath ) {
+        Add-Member -Force -InputObject $settings -Name "mountService" -Value "org.cryptomator.frontend.fuse.mount.WinFspMountProvider" -MemberType NoteProperty
+        $newSettings  = $settings | Select-Object * -ExcludeProperty "preferredVolumeImpl"
+        ConvertTo-Json $newSettings | Set-Content -Path $settingsPath
+    }
 }

--- a/dist/win/contrib/version170-migrate-settings.bat
+++ b/dist/win/contrib/version170-migrate-settings.bat
@@ -1,4 +1,5 @@
 @echo off
+:: see comments in file ./version170-migrate-settings.ps1
 
 cd %~dp0
 powershell -NoLogo -NonInteractive -ExecutionPolicy Unrestricted -Command .\version170-migrate-settings.ps1

--- a/dist/win/contrib/version170-migrate-settings.bat
+++ b/dist/win/contrib/version170-migrate-settings.bat
@@ -1,0 +1,4 @@
+@echo off
+
+cd %~dp0
+powershell -NoLogo -NonInteractive -ExecutionPolicy Unrestricted -Command .\version170-migrate-settings.ps1

--- a/dist/win/contrib/version170-migrate-settings.ps1
+++ b/dist/win/contrib/version170-migrate-settings.ps1
@@ -1,4 +1,5 @@
 # This script migrates Cryptomator settings for all local users on Windows in case the users uses custom directories as mountpoint
+# See also https://github.com/cryptomator/cryptomator/issues/2652
 #
 #Requires -RunAsAdministrator
 

--- a/dist/win/contrib/version170-migrate-settings.ps1
+++ b/dist/win/contrib/version170-migrate-settings.ps1
@@ -18,7 +18,7 @@ Get-ChildItem $profileList | ForEach-Object { $_.GetValue("ProfileImagePath") } 
     }
 } | ForEach-Object {
     $settingsPath = "$_\AppData\Roaming\Cryptomator\settings.json"
-    if(!(Test-Path -Path $settingsPath)) {
+    if(!(Test-Path -Path $settingsPath -PathType Leaf)) {
         #No settings file, nothing to do.
         return;
     }

--- a/dist/win/contrib/version170-migrate-settings.ps1
+++ b/dist/win/contrib/version170-migrate-settings.ps1
@@ -1,5 +1,7 @@
 # This script migrates Cryptomator settings for all local users on Windows in case the users uses custom directories as mountpoint
-# See also https://github.com/cryptomator/cryptomator/issues/2652
+# See also https://github.com/cryptomator/cryptomator/pull/2654.
+#
+# TODO: This script should be evaluated in a yearly interval if it is still needed and if not, should be removed
 #
 #Requires -RunAsAdministrator
 

--- a/dist/win/contrib/version170-migrate-settings.ps1
+++ b/dist/win/contrib/version170-migrate-settings.ps1
@@ -12,7 +12,7 @@ Get-ChildItem $profileList | ForEach-Object { $_.GetValue("ProfileImagePath") } 
     if($profileNameMatches.Count -eq 1) {
         #check if the last path part is contained in the local user name list
         #otherwise do not touch it
-        return $localUsers.Contains($matches[0].Groups[1].Value)
+        return $localUsers.Contains($profileNameMatches[0].Groups[1].Value)
     } else {
         return $false;
     }
@@ -22,9 +22,8 @@ Get-ChildItem $profileList | ForEach-Object { $_.GetValue("ProfileImagePath") } 
         #No settings file, nothing to do.
         return;
     }
-
     $settings = Get-Content -Path $settingsPath | ConvertFrom-Json
-    if($settings.preferredVolumeImpl -eq "FUSE") {
+    if($settings.preferredVolumeImpl -ne "FUSE") {
         #Fuse not used, nothing to do
         return;
     }

--- a/dist/win/resources/main.wxs
+++ b/dist/win/resources/main.wxs
@@ -132,6 +132,9 @@
     <!-- WebDAV patches -->
     <CustomAction Id="PatchWebDAV" Impersonate="no" ExeCommand="[INSTALLDIR]patchWebDAV.bat" Directory="INSTALLDIR" Execute="deferred" Return="asyncWait" />
 
+    <!-- Special Settings migration for 1.7.0 -->
+    <CustomAction Id="170MigrateSettings" Impersonate="no" ExeCommand="[INSTALLDIR]version170-migrate-settings.bat" Directory="INSTALLDIR" Execute="deferred" Return="asyncWait" />
+
     <!-- Running App detection and exit -->
     <Property Id="FOUNDRUNNINGAPP" Admin="yes"/>
     <util:CloseApplication
@@ -182,6 +185,7 @@
       <RemoveExistingProducts After="InstallValidate"/>
 
       <Custom Action="PatchWebDAV" After="InstallFiles">NOT Installed OR REINSTALL</Custom>
+      <Custom Action="170MigrateSettings" After="InstallFiles">NOT Installed OR REINSTALL</Custom>
     </InstallExecuteSequence>
 
     <WixVariable Id="WixUIBannerBmp" Value="$(env.JP_WIXWIZARD_RESOURCES)\banner.bmp" />

--- a/dist/win/resources/main.wxs
+++ b/dist/win/resources/main.wxs
@@ -133,7 +133,7 @@
     <CustomAction Id="PatchWebDAV" Impersonate="no" ExeCommand="[INSTALLDIR]patchWebDAV.bat" Directory="INSTALLDIR" Execute="deferred" Return="asyncWait" />
 
     <!-- Special Settings migration for 1.7.0 -->
-    <CustomAction Id="170MigrateSettings" Impersonate="no" ExeCommand="[INSTALLDIR]version170-migrate-settings.bat" Directory="INSTALLDIR" Execute="deferred" Return="asyncWait" />
+    <CustomAction Id="V170MigrateSettings" Impersonate="no" ExeCommand="[INSTALLDIR]version170-migrate-settings.bat" Directory="INSTALLDIR" Execute="deferred" Return="asyncWait" />
 
     <!-- Running App detection and exit -->
     <Property Id="FOUNDRUNNINGAPP" Admin="yes"/>
@@ -185,7 +185,7 @@
       <RemoveExistingProducts After="InstallValidate"/>
 
       <Custom Action="PatchWebDAV" After="InstallFiles">NOT Installed OR REINSTALL</Custom>
-      <Custom Action="170MigrateSettings" After="InstallFiles">NOT Installed OR REINSTALL</Custom>
+      <Custom Action="V170MigrateSettings" After="InstallFiles">NOT Installed OR REINSTALL</Custom>
     </InstallExecuteSequence>
 
     <WixVariable Id="WixUIBannerBmp" Value="$(env.JP_WIXWIZARD_RESOURCES)\banner.bmp" />

--- a/dist/win/resources/main.wxs
+++ b/dist/win/resources/main.wxs
@@ -132,7 +132,7 @@
     <!-- WebDAV patches -->
     <CustomAction Id="PatchWebDAV" Impersonate="no" ExeCommand="[INSTALLDIR]patchWebDAV.bat" Directory="INSTALLDIR" Execute="deferred" Return="asyncWait" />
 
-    <!-- Special Settings migration for 1.7.0 -->
+    <!-- Special Settings migration for 1.7.0,. Should be removed eventually, for more info, see ../contrib/version170-migrate-settings.ps1-->
     <CustomAction Id="V170MigrateSettings" Impersonate="no" ExeCommand="[INSTALLDIR]version170-migrate-settings.bat" Directory="INSTALLDIR" Execute="deferred" Return="asyncWait" />
 
     <!-- Running App detection and exit -->


### PR DESCRIPTION
Closes #2652 

This PR mitigates significantly the occurence of the aforementioned error screen. It does that by migrating the settings outside the app during the installation of Cryptomator.

A powershell script is invoked, which parses the json setting file, searches for the usage of FUSE and if custom mountpoint is used. If so, the mountService is set to "Winfsp(Local Drive)". Since the installtion is system wide and not per user, for all enabled, local users the migration is performed.

We decided to go over the installer, to prevent using a complex workaround in our main app. The migration is safe, since only under a certain conditions the settings are changed (settings have to exist,  use of FUSE and custom mount point). If it fails, the installation is still successful and the user sees the specialized error dialog.