### PR TITLE
Windows: Add additional launcher to debug jfx problems

### DIFF
--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -166,6 +166,7 @@ jobs:
           --resource-dir dist/win/resources
           --license-file dist/win/resources/license.rtf
           --file-associations dist/win/resources/FAvaultFile.properties
+          --add-launcher jfxDebug=dist/wind/resources/jfxDebug.properties
         env:
           JP_WIXWIZARD_RESOURCES: ${{ github.workspace }}/dist/win/resources # requires abs path, used in resources/main.wxs
       - name: Codesign MSI

--- a/dist/win/build.ps1
+++ b/dist/win/build.ps1
@@ -93,6 +93,7 @@ if ($clean -and (Test-Path -Path $appPath)) {
 	--java-options "-Dcryptomator.integrationsWin.keychainPaths=`"~/AppData/Roaming/$AppName/keychain.json`"" `
 	--java-options "-Dcryptomator.showTrayIcon=true" `
 	--java-options "-Dcryptomator.buildNumber=`"msi-$revisionNo`"" `
+	--add-launcher jfxDebug=$buildDir\resources\jfxDebug.properties `
 	--resource-dir resources `
 	--icon resources/$AppName.ico
 

--- a/dist/win/resources/jfxDebug.properties
+++ b/dist/win/resources/jfxDebug.properties
@@ -1,0 +1,19 @@
+win-console=true
+java-options=--enable-preview \
+             --enable-native-access=org.cryptomator.jfuse.win \
+             -Xss5m \
+             -Xmx256m \
+             -Dcryptomator.appVersion="$semVerNo" \
+             -Dfile.encoding="utf-8" \
+             -Dcryptomator.logDir="~/AppData/Roaming/$AppName" \
+             -Dcryptomator.pluginDir="~/AppData/Roaming/$AppName/Plugins" \
+             -Dcryptomator.settingsPath="~/AppData/Roaming/$AppName/settings.json" \
+             -Dcryptomator.ipcSocketPath="~/AppData/Roaming/$AppName/ipc.socket" \
+             -Dcryptomator.p12Path="~/AppData/Roaming/$AppName/key.p12" \
+             -Dcryptomator.mountPointsDir="~/$AppName" \
+             -Dcryptomator.loopbackAlias="$LoopbackAlias" \
+             -Dcryptomator.integrationsWin.autoStartShellLinkName="$AppName" \
+             -Dcryptomator.integrationsWin.keychainPaths="~/AppData/Roaming/$AppName/keychain.json" \
+             -Dcryptomator.showTrayIcon=true \
+             -Dcryptomator.buildNumber="msi-$revisionNo" \
+             -Djavafx.verbose=true


### PR DESCRIPTION
On windows, we are facing different JavaFX-related issues: #2606, https://github.com/cryptomator/cryptomator/issues/2373, https://github.com/cryptomator/cryptomator/issues/2610

Since for the normal windows app we do not get any terminal output, also debugging is very difficult, requiring a lot of user cooperation and some skill/support manuals. And since version 1.6.16 the launcher script does not work either, it is impossible to easily get debugging info and analyze (graphical) problems.

This PR alleviates the situation by providing an additional windows launcher (EXE), which logs to the terminal (including stderr!) and enables the javafx debug logging. In the end, the user has to start the debug-launcher and pipe all output to a file and upload the file. No configuration needed, no admin rights needed, minimal user effort.