### PR TITLE
Feature: Windows debug launcher

### DIFF
--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -166,6 +166,7 @@ jobs:
           --resource-dir dist/win/resources
           --license-file dist/win/resources/license.rtf
           --file-associations dist/win/resources/FAvaultFile.properties
+          --add-launcher jfxDebug=dist/wind/resources/jfxDebug.properties
         env:
           JP_WIXWIZARD_RESOURCES: ${{ github.workspace }}/dist/win/resources # requires abs path, used in resources/main.wxs
       - name: Codesign MSI

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -69,6 +69,12 @@ jobs:
           --no-man-pages
           --strip-debug
           --compress=1
+      - name: Prepare debug launcher config
+        shell: bash
+        run: envsubst '${SEMVER_STR} ${REVISION_NUM}' < dist/win/resources/debug-launcher.properties > debug-launcher.properties
+        env:
+          SEMVER_STR: ${{  needs.get-version.outputs.semVerStr }}
+          REVISION_NUM: ${{  needs.get-version.outputs.revNum }}
       - name: Run jpackage
         run: >
           ${JAVA_HOME}/bin/jpackage
@@ -102,6 +108,7 @@ jobs:
           --java-options "-Dcryptomator.integrationsWin.keychainPaths=\"~/AppData/Roaming/Cryptomator/keychain.json\""
           --resource-dir dist/win/resources
           --icon dist/win/resources/Cryptomator.ico
+          --add-launcher debug=debug-launcher.properties
       - name: Patch Application Directory
         run: |
           cp dist/win/contrib/* appdir/Cryptomator
@@ -166,7 +173,6 @@ jobs:
           --resource-dir dist/win/resources
           --license-file dist/win/resources/license.rtf
           --file-associations dist/win/resources/FAvaultFile.properties
-          --add-launcher jfxDebug=dist/wind/resources/jfxDebug.properties
         env:
           JP_WIXWIZARD_RESOURCES: ${{ github.workspace }}/dist/win/resources # requires abs path, used in resources/main.wxs
       - name: Codesign MSI

--- a/dist/win/.gitignore
+++ b/dist/win/.gitignore
@@ -5,3 +5,4 @@ installer
 *.pdb
 *.msi
 license.rtf
+debug.properties

--- a/dist/win/build.ps1
+++ b/dist/win/build.ps1
@@ -63,6 +63,12 @@ if ($clean -and (Test-Path -Path $appPath)) {
 	Remove-Item -Path $appPath -Force -Recurse
 }
 
+# prepare additional launcher
+$debugProps = Get-Content -Path $buildDir\resources\debug-launcher.properties
+$debugProps = $debugProps -replace '\${SEM_VER_STR}', "$semVerNo"
+$debugProps = $debugProps -replace '\${REVISION_NUM}', "$revisionNo"
+Set-Content -Path $buildDir\resources\debug.properties -Value $debugProps
+
 # create app dir
 & "$Env:JAVA_HOME\bin\jpackage" `
 	--verbose `
@@ -93,7 +99,7 @@ if ($clean -and (Test-Path -Path $appPath)) {
 	--java-options "-Dcryptomator.integrationsWin.keychainPaths=`"~/AppData/Roaming/$AppName/keychain.json`"" `
 	--java-options "-Dcryptomator.showTrayIcon=true" `
 	--java-options "-Dcryptomator.buildNumber=`"msi-$revisionNo`"" `
-	--add-launcher jfxDebug=$buildDir\resources\jfxDebug.properties `
+	--add-launcher debug=$buildDir\resources\debug.properties `
 	--resource-dir resources `
 	--icon resources/$AppName.ico
 

--- a/dist/win/build.ps1
+++ b/dist/win/build.ps1
@@ -93,6 +93,7 @@ if ($clean -and (Test-Path -Path $appPath)) {
 	--java-options "-Dcryptomator.integrationsWin.keychainPaths=`"~/AppData/Roaming/$AppName/keychain.json`"" `
 	--java-options "-Dcryptomator.showTrayIcon=true" `
 	--java-options "-Dcryptomator.buildNumber=`"msi-$revisionNo`"" `
+	--add-launcher jfxDebug=$buildDir\resources\jfxDebug.properties `
 	--resource-dir resources `
 	--icon resources/$AppName.ico
 

--- a/dist/win/resources/debug-launcher.properties
+++ b/dist/win/resources/debug-launcher.properties
@@ -15,5 +15,4 @@ java-options=--enable-preview \
              -Dcryptomator.integrationsWin.autoStartShellLinkName="$AppName" \
              -Dcryptomator.integrationsWin.keychainPaths="~/AppData/Roaming/$AppName/keychain.json" \
              -Dcryptomator.showTrayIcon=true \
-             -Dcryptomator.buildNumber="msi-${REVISION_NUM}" \
-             -Djavafx.verbose=true
+             -Dcryptomator.buildNumber="msi-${REVISION_NUM}"

--- a/dist/win/resources/debug-launcher.properties
+++ b/dist/win/resources/debug-launcher.properties
@@ -3,7 +3,7 @@ java-options=--enable-preview \
              --enable-native-access=org.cryptomator.jfuse.win \
              -Xss5m \
              -Xmx256m \
-             -Dcryptomator.appVersion="$semVerNo" \
+             -Dcryptomator.appVersion="${SEM_VER_STR}" \
              -Dfile.encoding="utf-8" \
              -Dcryptomator.logDir="~/AppData/Roaming/$AppName" \
              -Dcryptomator.pluginDir="~/AppData/Roaming/$AppName/Plugins" \
@@ -15,5 +15,5 @@ java-options=--enable-preview \
              -Dcryptomator.integrationsWin.autoStartShellLinkName="$AppName" \
              -Dcryptomator.integrationsWin.keychainPaths="~/AppData/Roaming/$AppName/keychain.json" \
              -Dcryptomator.showTrayIcon=true \
-             -Dcryptomator.buildNumber="msi-$revisionNo" \
+             -Dcryptomator.buildNumber="msi-${REVISION_NUM}" \
              -Djavafx.verbose=true

--- a/dist/win/resources/jfxDebug.properties
+++ b/dist/win/resources/jfxDebug.properties
@@ -1,0 +1,19 @@
+win-console=true
+java-options=--enable-preview \
+             --enable-native-access=org.cryptomator.jfuse.win \
+             -Xss5m \
+             -Xmx256m \
+             -Dcryptomator.appVersion="$semVerNo" \
+             -Dfile.encoding="utf-8" \
+             -Dcryptomator.logDir="~/AppData/Roaming/$AppName" \
+             -Dcryptomator.pluginDir="~/AppData/Roaming/$AppName/Plugins" \
+             -Dcryptomator.settingsPath="~/AppData/Roaming/$AppName/settings.json" \
+             -Dcryptomator.ipcSocketPath="~/AppData/Roaming/$AppName/ipc.socket" \
+             -Dcryptomator.p12Path="~/AppData/Roaming/$AppName/key.p12" \
+             -Dcryptomator.mountPointsDir="~/$AppName" \
+             -Dcryptomator.loopbackAlias="$LoopbackAlias" \
+             -Dcryptomator.integrationsWin.autoStartShellLinkName="$AppName" \
+             -Dcryptomator.integrationsWin.keychainPaths="~/AppData/Roaming/$AppName/keychain.json" \
+             -Dcryptomator.showTrayIcon=true \
+             -Dcryptomator.buildNumber="msi-$revisionNo" \
+             -Djavafx.verbose=true


### PR DESCRIPTION
This PR is a follow up of https://github.com/cryptomator/cryptomator/pull/2661.

It was evaluated, if we could simply add `--win-console` (see [jpackage doc](https://docs.oracle.com/en/java/javase/19/docs/specs/man/jpackage.html#windows-platform-options-available-only-when-running-on-windows)) to our main application and avoid an additional launcher. But doing so would result in bad user experience: Everytime Cryptomator is started, also a `cmd` Terminal is started.

Hence, to gather extended debug output on windows, we need the launcher. But we decided use it as _general_ debug launcher (in contrast to former PR). This increases maintenance, but we'll be able to analyze with the help of users certain windows-related problems in more detail.