### PR TITLE
Feature: Only require app restart if switching between macFUSE and FUSE-T

### DIFF
--- a/src/main/java/org/cryptomator/common/ObservableUtil.java
+++ b/src/main/java/org/cryptomator/common/ObservableUtil.java
@@ -2,7 +2,9 @@ package org.cryptomator.common;
 
 import javafx.beans.binding.Bindings;
 import javafx.beans.value.ObservableValue;
+import java.util.Objects;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 public class ObservableUtil {
 
@@ -10,6 +12,16 @@ public class ObservableUtil {
 		return Bindings.createObjectBinding(() -> {
 			if (observable.getValue() == null) {
 				return defaultValue;
+			} else {
+				return mapper.apply(observable.getValue());
+			}
+		}, observable);
+	}
+
+	public static <T, U> ObservableValue<U> mapWithDefault(ObservableValue<T> observable, Function<? super T, ? extends U> mapper, Supplier<U> defaultValue) {
+		return Bindings.createObjectBinding(() -> {
+			if (observable.getValue() == null) {
+				return defaultValue.get();
 			} else {
 				return mapper.apply(observable.getValue());
 			}

--- a/src/main/java/org/cryptomator/common/mount/MountModule.java
+++ b/src/main/java/org/cryptomator/common/mount/MountModule.java
@@ -57,7 +57,7 @@ public class MountModule {
 			firstUsedProblematicFuseMountService.set(targetedService);
 		}
 
-		//make sure that the first used problematic fuse service is always used
+		//do not use the targeted mount service and fallback to former one, if the service is problematic _and_ not the first problematic one used.
 		if (targetIsProblematicFuse && !firstUsedProblematicFuseMountService.get().equals(targetedService)) {
 			return new ActualMountService(formerSelectedMountService.get(), false);
 		} else {

--- a/src/main/java/org/cryptomator/common/mount/MountModule.java
+++ b/src/main/java/org/cryptomator/common/mount/MountModule.java
@@ -16,8 +16,8 @@ import java.util.concurrent.atomic.AtomicReference;
 public class MountModule {
 
 	private static final AtomicReference<MountService> formerSelectedMountService = new AtomicReference<>(null);
-	private static final AtomicBoolean<MountService> MAC_FUSE_SELECTED_ONCE = new AtomicBoolean(false);
-	private static final AtomicBoolean<MountService> FUSET_SELECTED_ONCE = new AtomicBoolean(false);
+	private static final AtomicBoolean MAC_FUSE_SELECTED_ONCE = new AtomicBoolean(false);
+	private static final AtomicBoolean FUSET_SELECTED_ONCE = new AtomicBoolean(false);
 
 	@Provides
 	@Singleton

--- a/src/main/java/org/cryptomator/common/mount/MountModule.java
+++ b/src/main/java/org/cryptomator/common/mount/MountModule.java
@@ -4,8 +4,10 @@ import dagger.Module;
 import dagger.Provides;
 import org.cryptomator.common.ObservableUtil;
 import org.cryptomator.common.settings.Settings;
+import org.cryptomator.integrations.mount.Mount;
 import org.cryptomator.integrations.mount.MountService;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 import javafx.beans.value.ObservableValue;
 import java.util.List;
@@ -15,7 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class MountModule {
 
 	private static final AtomicReference<MountService> formerSelectedMountService = new AtomicReference<>(null);
-	private static final AtomicReference<MountService> firstUsedProblematicFuseMountService = new AtomicReference<>(null);
+	private static final List<String> problematicFuseMountServices = List.of("org.cryptomator.frontend.fuse.mount.MacFuseMountProvider", "org.cryptomator.frontend.fuse.mount.FuseTMountProvider");
 
 	@Provides
 	@Singleton
@@ -25,23 +27,30 @@ public class MountModule {
 
 	@Provides
 	@Singleton
-	static ObservableValue<ActualMountService> provideMountService(Settings settings, List<MountService> serviceImpls) {
+	@Named("FUPFMS")
+	static AtomicReference<MountService> provideFirstUsedProblematicFuseMountService() {
+		return new AtomicReference<>(null);
+	}
+
+	@Provides
+	@Singleton
+	static ObservableValue<ActualMountService> provideMountService(Settings settings, List<MountService> serviceImpls, @Named("FUPFMS") AtomicReference<MountService> fupfms) {
 		var fallbackProvider = serviceImpls.stream().findFirst().orElse(null);
 
 		var observableMountService = ObservableUtil.mapWithDefault(settings.mountService(), //
 				desiredServiceImpl -> { //
 					var serviceFromSettings = serviceImpls.stream().filter(serviceImpl -> serviceImpl.getClass().getName().equals(desiredServiceImpl)).findAny(); //
 					var targetedService = serviceFromSettings.orElse(fallbackProvider);
-					return applyWorkaroundForProblematicFuse(targetedService, serviceFromSettings.isPresent());
+					return applyWorkaroundForProblematicFuse(targetedService, serviceFromSettings.isPresent(), fupfms);
 				}, //
 				() -> { //
-					return applyWorkaroundForProblematicFuse(fallbackProvider, true);
+					return applyWorkaroundForProblematicFuse(fallbackProvider, true, fupfms);
 				});
 		return observableMountService;
 	}
 
 	//see https://github.com/cryptomator/cryptomator/issues/2786
-	private synchronized static ActualMountService applyWorkaroundForProblematicFuse(MountService targetedService, boolean isDesired) {
+	private synchronized static ActualMountService applyWorkaroundForProblematicFuse(MountService targetedService, boolean isDesired, AtomicReference<MountService> firstUsedProblematicFuseMountService) {
 		//set the first used problematic fuse service if applicable
 		var targetIsProblematicFuse = isProblematicFuseService(targetedService);
 		if (targetIsProblematicFuse && firstUsedProblematicFuseMountService.get() == null) {
@@ -57,7 +66,7 @@ public class MountModule {
 		}
 	}
 
-	private static boolean isProblematicFuseService(MountService service) {
-		return List.of("org.cryptomator.frontend.fuse.mount.MacFuseMountProvider", "org.cryptomator.frontend.fuse.mount.FuseTMountProvider").contains(service.getClass().getName());
+	public static boolean isProblematicFuseService(MountService service) {
+		return problematicFuseMountServices.contains(service.getClass().getName());
 	}
 }

--- a/src/main/java/org/cryptomator/common/mount/MountModule.java
+++ b/src/main/java/org/cryptomator/common/mount/MountModule.java
@@ -11,8 +11,8 @@ import javafx.beans.value.ObservableValue;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.cryptomator.common.mount.MountModule.FirstUsedFuseOnMacOS.FUSET;
-import static org.cryptomator.common.mount.MountModule.FirstUsedFuseOnMacOS.MACFUSE;
+import static org.cryptomator.common.mount.MountModule.FirstUsedFuseOnMacOS.FUSE_T;
+import static org.cryptomator.common.mount.MountModule.FirstUsedFuseOnMacOS.MAC_FUSE;
 import static org.cryptomator.common.mount.MountModule.FirstUsedFuseOnMacOS.UNDEFINED;
 
 @Module
@@ -47,8 +47,8 @@ public class MountModule {
 
 	//see https://github.com/cryptomator/cryptomator/issues/2786
 	private synchronized static ActualMountService applyWorkaroundForFuseTMacFuse(MountService targetedService, boolean isDesired) {
-		var targetIsFuseT= isFuseTService(targetedService);
-		var targetIsMacFuse= isMacFuseService(targetedService);
+		var targetIsFuseT = isFuseTService(targetedService);
+		var targetIsMacFuse = isMacFuseService(targetedService);
 
 		//if none of macFUSE and FUSE-T were selected before, check if targetedService is macFUSE or FUSE-T
 		if (FIRST_USED.get() == UNDEFINED) {
@@ -60,7 +60,7 @@ public class MountModule {
 		}
 
 		//if one of both were selected before and now the other should be used
-		if ((FIRST_USED.get() == MAC_FUSE && targetIsFuseT) || (FIRST_USED.get() == FUSE_T && targetIsMacFuse )) {
+		if ((FIRST_USED.get() == MAC_FUSE && targetIsFuseT) || (FIRST_USED.get() == FUSE_T && targetIsMacFuse)) {
 			//return the former mount service
 			return new ActualMountService(formerSelectedMountService.get(), false); //
 		} else {
@@ -77,7 +77,7 @@ public class MountModule {
 		return "org.cryptomator.frontend.fuse.mount.MacFuseMountProvider".equals(service.getClass().getName());
 	}
 
-	private enum FirstUsedFuseOnMacOS {
+	enum FirstUsedFuseOnMacOS {
 		UNDEFINED,
 		MAC_FUSE,
 		FUSE_T;

--- a/src/main/java/org/cryptomator/common/mount/MountModule.java
+++ b/src/main/java/org/cryptomator/common/mount/MountModule.java
@@ -11,15 +11,11 @@ import javafx.beans.value.ObservableValue;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.cryptomator.common.mount.MountModule.FirstUsedFuseOnMacOS.FUSE_T;
-import static org.cryptomator.common.mount.MountModule.FirstUsedFuseOnMacOS.MAC_FUSE;
-import static org.cryptomator.common.mount.MountModule.FirstUsedFuseOnMacOS.UNDEFINED;
-
 @Module
 public class MountModule {
 
 	private static final AtomicReference<MountService> formerSelectedMountService = new AtomicReference<>(null);
-	private static final AtomicReference<FirstUsedFuseOnMacOS> FIRST_USED = new AtomicReference<>(UNDEFINED);
+	private static final AtomicReference<MountService> firstUsedFuseMountService = new AtomicReference<>(null);
 
 	@Provides
 	@Singleton
@@ -36,50 +32,32 @@ public class MountModule {
 				desiredServiceImpl -> { //
 					var serviceFromSettings = serviceImpls.stream().filter(serviceImpl -> serviceImpl.getClass().getName().equals(desiredServiceImpl)).findAny(); //
 					var targetedService = serviceFromSettings.orElse(fallbackProvider);
-					return applyWorkaroundForFuseTMacFuse(targetedService, serviceFromSettings.isPresent());
+					return applyWorkaroundForFuse(targetedService, serviceFromSettings.isPresent());
 				}, //
 				() -> { //
-					return applyWorkaroundForFuseTMacFuse(fallbackProvider, true);
+					return applyWorkaroundForFuse(fallbackProvider, true);
 				});
 		return observableMountService;
 	}
 
-
 	//see https://github.com/cryptomator/cryptomator/issues/2786
-	private synchronized static ActualMountService applyWorkaroundForFuseTMacFuse(MountService targetedService, boolean isDesired) {
-		var targetIsFuseT = isFuseTService(targetedService);
-		var targetIsMacFuse = isMacFuseService(targetedService);
-
-		//if none of macFUSE and FUSE-T were selected before, check if targetedService is macFUSE or FUSE-T
-		if (FIRST_USED.get() == UNDEFINED) {
-			if (targetIsMacFuse) {
-				FIRST_USED.set(MAC_FUSE);
-			} else if (targetIsFuseT) {
-				FIRST_USED.set(FUSE_T);
-			}
+	private synchronized static ActualMountService applyWorkaroundForFuse(MountService targetedService, boolean isDesired) {
+		//set the first used fuse service if applicable
+		var targetIsFuse = isFuseService(targetedService);
+		if (targetIsFuse && firstUsedFuseMountService.get() == null) {
+			firstUsedFuseMountService.set(targetedService);
 		}
 
-		//if one of both were selected before and now the other should be used
-		if ((FIRST_USED.get() == MAC_FUSE && targetIsFuseT) || (FIRST_USED.get() == FUSE_T && targetIsMacFuse)) {
-			//return the former mount service
-			return new ActualMountService(formerSelectedMountService.get(), false); //
+		//make sure that the first used fuse service is always used
+		if (targetIsFuse && !firstUsedFuseMountService.get().equals(targetedService)) {
+			return new ActualMountService(formerSelectedMountService.get(), false);
 		} else {
 			formerSelectedMountService.set(targetedService);
-			return new ActualMountService(targetedService, isDesired); //
+			return new ActualMountService(targetedService, isDesired);
 		}
 	}
 
-	private static boolean isFuseTService(MountService service) {
-		return "org.cryptomator.frontend.fuse.mount.FuseTMountProvider".equals(service.getClass().getName());
-	}
-
-	private static boolean isMacFuseService(MountService service) {
-		return "org.cryptomator.frontend.fuse.mount.MacFuseMountProvider".equals(service.getClass().getName());
-	}
-
-	enum FirstUsedFuseOnMacOS {
-		UNDEFINED,
-		MAC_FUSE,
-		FUSE_T;
+	private static boolean isFuseService(MountService service) {
+		return service.getClass().getName().startsWith("org.cryptomator.frontend.fuse.mount.");
 	}
 }

--- a/src/main/java/org/cryptomator/ui/preferences/VolumePreferencesController.java
+++ b/src/main/java/org/cryptomator/ui/preferences/VolumePreferencesController.java
@@ -33,6 +33,7 @@ public class VolumePreferencesController implements FxController {
 	private final ObservableValue<Boolean> mountToDriveLetterSupported;
 	private final ObservableValue<Boolean> mountFlagsSupported;
 	private final ObservableValue<Boolean> readonlySupported;
+	private final ObservableValue<Boolean> macFuseAndFUSETRestartRequired;
 	private final Lazy<Application> application;
 	private final List<MountService> mountProviders;
 	public ChoiceBox<MountService> volumeTypeChoiceBox;
@@ -53,6 +54,12 @@ public class VolumePreferencesController implements FxController {
 		this.mountToDriveLetterSupported = selectedMountService.map(s -> s.hasCapability(MountCapability.MOUNT_AS_DRIVE_LETTER));
 		this.mountFlagsSupported = selectedMountService.map(s -> s.hasCapability(MountCapability.MOUNT_FLAGS));
 		this.readonlySupported = selectedMountService.map(s -> s.hasCapability(MountCapability.READ_ONLY));
+		var mountServiceAtStart = selectedMountService.getValue();
+		this.macFuseAndFUSETRestartRequired = selectedMountService.map(s -> isFUSETOrMacFUSE(mountServiceAtStart) && isFUSETOrMacFUSE(s) && !mountServiceAtStart.equals(s));
+	}
+
+	private boolean isFUSETOrMacFUSE(MountService service) {
+		return List.of("org.cryptomator.frontend.fuse.mount.MacFuseMountProvider", "org.cryptomator.frontend.fuse.mount.FuseTMountProvider").contains(service.getClass().getName());
 	}
 
 	public void initialize() {
@@ -127,6 +134,14 @@ public class VolumePreferencesController implements FxController {
 
 	public boolean isMountFlagsSupported() {
 		return mountFlagsSupported.getValue();
+	}
+
+	public ObservableValue<Boolean> macFuseAndFUSETRestartRequiredProperty() {
+		return macFuseAndFUSETRestartRequired;
+	}
+
+	public boolean isMacFuseAndFUSETRestartRequired() {
+		return macFuseAndFUSETRestartRequired.getValue();
 	}
 
 	/* Helpers */

--- a/src/main/java/org/cryptomator/ui/preferences/VolumePreferencesController.java
+++ b/src/main/java/org/cryptomator/ui/preferences/VolumePreferencesController.java
@@ -55,11 +55,11 @@ public class VolumePreferencesController implements FxController {
 		this.mountFlagsSupported = selectedMountService.map(s -> s.hasCapability(MountCapability.MOUNT_FLAGS));
 		this.readonlySupported = selectedMountService.map(s -> s.hasCapability(MountCapability.READ_ONLY));
 		var mountServiceAtStart = selectedMountService.getValue();
-		this.fuseRestartRequired = selectedMountService.map(s -> isFuse(mountServiceAtStart) && isFuse(s) && !mountServiceAtStart.equals(s));
+		this.fuseRestartRequired = selectedMountService.map(s -> isProblematicFuse(mountServiceAtStart) && isProblematicFuse(s) && !mountServiceAtStart.equals(s));
 	}
 
-	private boolean isFuse(MountService service) {
-		return service.getClass().getName().startsWith("org.cryptomator.frontend.fuse.mount.");
+	private boolean isProblematicFuse(MountService service) {
+		return List.of("org.cryptomator.frontend.fuse.mount.MacFuseMountProvider", "org.cryptomator.frontend.fuse.mount.FuseTMountProvider").contains(service.getClass().getName());
 	}
 
 	public void initialize() {

--- a/src/main/java/org/cryptomator/ui/preferences/VolumePreferencesController.java
+++ b/src/main/java/org/cryptomator/ui/preferences/VolumePreferencesController.java
@@ -33,7 +33,7 @@ public class VolumePreferencesController implements FxController {
 	private final ObservableValue<Boolean> mountToDriveLetterSupported;
 	private final ObservableValue<Boolean> mountFlagsSupported;
 	private final ObservableValue<Boolean> readonlySupported;
-	private final ObservableValue<Boolean> macFuseAndFUSETRestartRequired;
+	private final ObservableValue<Boolean> fuseRestartRequired;
 	private final Lazy<Application> application;
 	private final List<MountService> mountProviders;
 	public ChoiceBox<MountService> volumeTypeChoiceBox;
@@ -55,11 +55,11 @@ public class VolumePreferencesController implements FxController {
 		this.mountFlagsSupported = selectedMountService.map(s -> s.hasCapability(MountCapability.MOUNT_FLAGS));
 		this.readonlySupported = selectedMountService.map(s -> s.hasCapability(MountCapability.READ_ONLY));
 		var mountServiceAtStart = selectedMountService.getValue();
-		this.macFuseAndFUSETRestartRequired = selectedMountService.map(s -> isFUSETOrMacFUSE(mountServiceAtStart) && isFUSETOrMacFUSE(s) && !mountServiceAtStart.equals(s));
+		this.fuseRestartRequired = selectedMountService.map(s -> isFuse(mountServiceAtStart) && isFuse(s) && !mountServiceAtStart.equals(s));
 	}
 
-	private boolean isFUSETOrMacFUSE(MountService service) {
-		return List.of("org.cryptomator.frontend.fuse.mount.MacFuseMountProvider", "org.cryptomator.frontend.fuse.mount.FuseTMountProvider").contains(service.getClass().getName());
+	private boolean isFuse(MountService service) {
+		return service.getClass().getName().startsWith("org.cryptomator.frontend.fuse.mount.");
 	}
 
 	public void initialize() {
@@ -136,12 +136,12 @@ public class VolumePreferencesController implements FxController {
 		return mountFlagsSupported.getValue();
 	}
 
-	public ObservableValue<Boolean> macFuseAndFUSETRestartRequiredProperty() {
-		return macFuseAndFUSETRestartRequired;
+	public ObservableValue<Boolean> fuseRestartRequiredProperty() {
+		return fuseRestartRequired;
 	}
 
-	public boolean isMacFuseAndFUSETRestartRequired() {
-		return macFuseAndFUSETRestartRequired.getValue();
+	public boolean getFuseRestartRequired() {
+		return fuseRestartRequired.getValue();
 	}
 
 	/* Helpers */

--- a/src/main/resources/css/dark_theme.css
+++ b/src/main/resources/css/dark_theme.css
@@ -116,6 +116,10 @@
 	-fx-font-size: 0.64em;
 }
 
+.label-red {
+	-fx-text-fill: RED_5;
+}
+
 .text-flow > * {
 	-fx-fill: TEXT_FILL;
 }

--- a/src/main/resources/css/light_theme.css
+++ b/src/main/resources/css/light_theme.css
@@ -116,6 +116,10 @@
 	-fx-font-size: 0.64em;
 }
 
+.label-red {
+	-fx-text-fill: RED_5;
+}
+
 .text-flow > * {
 	-fx-fill: TEXT_FILL;
 }

--- a/src/main/resources/fxml/preferences_volume.fxml
+++ b/src/main/resources/fxml/preferences_volume.fxml
@@ -32,6 +32,8 @@
 			</Hyperlink>
 		</HBox>
 
+		<Label styleClass="label-red" text="To apply the changes, Cryptomator needs to be restarted." visible="${controller.macFuseAndFUSETRestartRequired}" managed="${controller.macFuseAndFUSETRestartRequired}"/>
+
 		<HBox spacing="12" alignment="CENTER_LEFT" visible="${controller.loopbackPortSupported}" managed="${controller.loopbackPortSupported}">
 			<Label text="%preferences.volume.tcp.port"/>
 			<NumericTextField fx:id="loopbackPortField"/>

--- a/src/main/resources/fxml/preferences_volume.fxml
+++ b/src/main/resources/fxml/preferences_volume.fxml
@@ -8,9 +8,9 @@
 <?import javafx.scene.control.Hyperlink?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.Separator?>
+<?import javafx.scene.control.Tooltip?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
-<?import javafx.scene.control.Tooltip?>
 <VBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
 	  fx:controller="org.cryptomator.ui.preferences.VolumePreferencesController"
@@ -32,7 +32,7 @@
 			</Hyperlink>
 		</HBox>
 
-		<Label styleClass="label-red" text="To apply the changes, Cryptomator needs to be restarted." visible="${controller.macFuseAndFUSETRestartRequired}" managed="${controller.macFuseAndFUSETRestartRequired}"/>
+		<Label styleClass="label-red" text="%preferences.volume.fuseRestartRequired" visible="${controller.fuseRestartRequired}" managed="${controller.fuseRestartRequired}"/>
 
 		<HBox spacing="12" alignment="CENTER_LEFT" visible="${controller.loopbackPortSupported}" managed="${controller.loopbackPortSupported}">
 			<Label text="%preferences.volume.tcp.port"/>

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -275,7 +275,7 @@ preferences.interface.showMinimizeButton=Show minimize button
 preferences.interface.showTrayIcon=Show tray icon (requires restart)
 ## Volume
 preferences.volume=Virtual Drive
-preferences.volume.type=Volume Type (requires restart)
+preferences.volume.type=Volume Type
 preferences.volume.type.automatic=Automatic
 preferences.volume.docsTooltip=Open the documentation to learn more about the different volume types.
 preferences.volume.tcp.port=TCP Port

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -278,6 +278,7 @@ preferences.volume=Virtual Drive
 preferences.volume.type=Volume Type
 preferences.volume.type.automatic=Automatic
 preferences.volume.docsTooltip=Open the documentation to learn more about the different volume types.
+preferences.volume.fuseRestartRequired=To apply the changes, Cryptomator needs to be restarted.
 preferences.volume.tcp.port=TCP Port
 preferences.volume.supportedFeatures=The chosen volume type supports the following features:
 preferences.volume.feature.mountAuto=Automatic mount point selection


### PR DESCRIPTION
Closes #2786.

Adds some ugly workaround code, but increases UX for most of the users.

FUSE-T and macFUSE cannot be used in the same JVM due to loading the same symbols from different shared libraries and the inability to unload a shared library once loaded.

Workaround is as follows: In the UI, the user will be notified that the apps must be restartet if she switches from macFuse to FUSE-T (or vice versa). The change is still written to the settings file, but in the model, the change is blocked.