### PR TITLE
Respect user's locale when sorting language list

### DIFF
--- a/src/main/java/org/cryptomator/launcher/Cryptomator.java
+++ b/src/main/java/org/cryptomator/launcher/Cryptomator.java
@@ -35,13 +35,15 @@ public class Cryptomator {
 	private static final Logger LOG = LoggerFactory.getLogger(Cryptomator.class);
 
 	private final DebugMode debugMode;
+	private final SupportedLanguages supportedLanguages;
 	private final Environment env;
 	private final Lazy<IpcMessageHandler> ipcMessageHandler;
 	private final ShutdownHook shutdownHook;
 
 	@Inject
-	Cryptomator(DebugMode debugMode, Environment env, Lazy<IpcMessageHandler> ipcMessageHandler, ShutdownHook shutdownHook) {
+	Cryptomator(DebugMode debugMode, SupportedLanguages supportedLanguages, Environment env, Lazy<IpcMessageHandler> ipcMessageHandler, ShutdownHook shutdownHook) {
 		this.debugMode = debugMode;
+		this.supportedLanguages = supportedLanguages;
 		this.env = env;
 		this.ipcMessageHandler = ipcMessageHandler;
 		this.shutdownHook = shutdownHook;
@@ -78,6 +80,7 @@ public class Cryptomator {
 		LOG.debug("Dagger graph initialized after {}ms", System.currentTimeMillis() - STARTUP_TIME);
 		LOG.info("Starting Cryptomator {} on {} {} ({})", env.getAppVersion(), SystemUtils.OS_NAME, SystemUtils.OS_VERSION, SystemUtils.OS_ARCH);
 		debugMode.initialize();
+		supportedLanguages.applyPreferred();
 
 		/*
 		 * Attempts to create an IPC connection to a running Cryptomator instance and sends it the given args.

--- a/src/main/java/org/cryptomator/launcher/Cryptomator.java
+++ b/src/main/java/org/cryptomator/launcher/Cryptomator.java
@@ -35,15 +35,13 @@ public class Cryptomator {
 	private static final Logger LOG = LoggerFactory.getLogger(Cryptomator.class);
 
 	private final DebugMode debugMode;
-	private final SupportedLanguages supportedLanguages;
 	private final Environment env;
 	private final Lazy<IpcMessageHandler> ipcMessageHandler;
 	private final ShutdownHook shutdownHook;
 
 	@Inject
-	Cryptomator(DebugMode debugMode, SupportedLanguages supportedLanguages, Environment env, Lazy<IpcMessageHandler> ipcMessageHandler, ShutdownHook shutdownHook) {
+	Cryptomator(DebugMode debugMode, Environment env, Lazy<IpcMessageHandler> ipcMessageHandler, ShutdownHook shutdownHook) {
 		this.debugMode = debugMode;
-		this.supportedLanguages = supportedLanguages;
 		this.env = env;
 		this.ipcMessageHandler = ipcMessageHandler;
 		this.shutdownHook = shutdownHook;
@@ -80,7 +78,6 @@ public class Cryptomator {
 		LOG.debug("Dagger graph initialized after {}ms", System.currentTimeMillis() - STARTUP_TIME);
 		LOG.info("Starting Cryptomator {} on {} {} ({})", env.getAppVersion(), SystemUtils.OS_NAME, SystemUtils.OS_VERSION, SystemUtils.OS_ARCH);
 		debugMode.initialize();
-		supportedLanguages.applyPreferred();
 
 		/*
 		 * Attempts to create an IPC connection to a running Cryptomator instance and sends it the given args.

--- a/src/main/java/org/cryptomator/launcher/SupportedLanguages.java
+++ b/src/main/java/org/cryptomator/launcher/SupportedLanguages.java
@@ -1,16 +1,16 @@
 package org.cryptomator.launcher;
 
 import org.cryptomator.common.settings.Settings;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.text.Collator;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 @Singleton
 public class SupportedLanguages {
@@ -18,20 +18,16 @@ public class SupportedLanguages {
 	private static final Logger LOG = LoggerFactory.getLogger(SupportedLanguages.class);
 	// these are BCP 47 language codes, not ISO. Note the "-" instead of the "_".
 	// "en" is not part of this list - it is always inserted at the top.
-	public static final List<String> LANGUAGE_TAGS = Arrays.asList("ar", "be", "bn", "bs", "ca", "cs", "da", "de", "el", "es", "fil", "fa", "fr", "gl", "he", //
+	public static final List<String> LANGUAGE_TAGS = List.of("ar", "be", "bn", "bs", "ca", "cs", "da", "de", "el", "es", "fil", "fa", "fr", "gl", "he", //
 			"hi", "hr", "hu", "id", "it", "ja", "ko", "lv", "mk", "nb", "nl", "nn", "no", "pa", "pl", "pt", "pt-BR", "ro", "ru", "si", "sk", "sr", "sr-Latn", "sv", "sw", //
 			"ta", "te", "th", "tr", "uk", "vi", "zh", "zh-HK", "zh-TW");
-	public  static final String ENGLISH = "en";
+	public static final String ENGLISH = "en";
 
-	@Nullable
-	private final String preferredLanguage;
+	private final List<String> sortedLanguageTags;
 
 	@Inject
 	public SupportedLanguages(Settings settings) {
-		this.preferredLanguage = settings.languageProperty().get();
-	}
-
-	public void applyPreferred() {
+		var preferredLanguage = settings.languageProperty().get();
 		if (preferredLanguage == null) {
 			LOG.debug("Using system locale");
 		} else {
@@ -39,10 +35,18 @@ public class SupportedLanguages {
 			LOG.debug("Applying preferred locale {}", preferredLocale.getDisplayName(Locale.ENGLISH));
 			Locale.setDefault(preferredLocale);
 		}
-		SupportedLanguages.LANGUAGE_TAGS.sort((a, b) -> {
+		sortedLanguageTags = LANGUAGE_TAGS.stream().sorted((a, b) -> {
 			var collator = Collator.getInstance(Locale.getDefault());
 			collator.setStrength(Collator.PRIMARY);
 			return collator.compare(Locale.forLanguageTag(a).getDisplayName(), Locale.forLanguageTag(b).getDisplayName());
-		});
+		}).collect(Collectors.toList());
+		sortedLanguageTags.add(0, Settings.DEFAULT_LANGUAGE);
+		sortedLanguageTags.add(1, ENGLISH);
+
 	}
+
+	public List<String> getLanguageTags() {
+		return Collections.unmodifiableList(sortedLanguageTags);
+	}
+
 }

--- a/src/main/java/org/cryptomator/launcher/SupportedLanguages.java
+++ b/src/main/java/org/cryptomator/launcher/SupportedLanguages.java
@@ -31,11 +31,11 @@ public class SupportedLanguages {
 	public SupportedLanguages(Settings settings) {
 		var preferredLanguage = settings.languageProperty().get();
 		preferredLocale = preferredLanguage == null ? Locale.getDefault() : Locale.forLanguageTag(preferredLanguage);
-		var sorted = LANGUAGE_TAGS.stream().sorted((a, b) -> {
-			var collator = Collator.getInstance(preferredLocale);
-			collator.setStrength(Collator.PRIMARY);
-			return collator.compare(Locale.forLanguageTag(a).getDisplayName(), Locale.forLanguageTag(b).getDisplayName());
-		}).collect(Collectors.toList());
+		var collator = Collator.getInstance(preferredLocale);
+		collator.setStrength(Collator.PRIMARY);
+		var sorted = LANGUAGE_TAGS.stream() //
+				.sorted((a, b) -> collator.compare(Locale.forLanguageTag(a).getDisplayName(), Locale.forLanguageTag(b).getDisplayName())) //
+				.collect(Collectors.toList());
 		sorted.add(0, Settings.DEFAULT_LANGUAGE);
 		sorted.add(1, ENGLISH);
 		sortedLanguageTags = Collections.unmodifiableList(sorted);

--- a/src/main/java/org/cryptomator/launcher/SupportedLanguages.java
+++ b/src/main/java/org/cryptomator/launcher/SupportedLanguages.java
@@ -7,6 +7,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.text.Collator;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
@@ -14,10 +16,12 @@ import java.util.Locale;
 public class SupportedLanguages {
 
 	private static final Logger LOG = LoggerFactory.getLogger(SupportedLanguages.class);
-	// these are BCP 47 language codes, not ISO. Note the "-" instead of the "_":
-	public static final List<String> LANGUAGAE_TAGS = List.of("en", "ar", "be", "bn", "bs", "ca", "cs", "da", "de", "el", "es", "fil", "fa", "fr", "gl", "he", //
+	// these are BCP 47 language codes, not ISO. Note the "-" instead of the "_".
+	// "en" is not part of this list - it is always inserted at the top.
+	public static final List<String> LANGUAGE_TAGS = Arrays.asList("ar", "be", "bn", "bs", "ca", "cs", "da", "de", "el", "es", "fil", "fa", "fr", "gl", "he", //
 			"hi", "hr", "hu", "id", "it", "ja", "ko", "lv", "mk", "nb", "nl", "nn", "no", "pa", "pl", "pt", "pt-BR", "ro", "ru", "si", "sk", "sr", "sr-Latn", "sv", "sw", //
 			"ta", "te", "th", "tr", "uk", "vi", "zh", "zh-HK", "zh-TW");
+	public  static final String ENGLISH = "en";
 
 	@Nullable
 	private final String preferredLanguage;
@@ -30,10 +34,15 @@ public class SupportedLanguages {
 	public void applyPreferred() {
 		if (preferredLanguage == null) {
 			LOG.debug("Using system locale");
-			return;
+		} else {
+			var preferredLocale = Locale.forLanguageTag(preferredLanguage);
+			LOG.debug("Applying preferred locale {}", preferredLocale.getDisplayName(Locale.ENGLISH));
+			Locale.setDefault(preferredLocale);
 		}
-		var preferredLocale = Locale.forLanguageTag(preferredLanguage);
-		LOG.debug("Applying preferred locale {}", preferredLocale.getDisplayName(Locale.ENGLISH));
-		Locale.setDefault(preferredLocale);
+		SupportedLanguages.LANGUAGE_TAGS.sort((a, b) -> {
+			var collator = Collator.getInstance(Locale.getDefault());
+			collator.setStrength(Collator.PRIMARY);
+			return collator.compare(Locale.forLanguageTag(a).getDisplayName(), Locale.forLanguageTag(b).getDisplayName());
+		});
 	}
 }

--- a/src/main/java/org/cryptomator/ui/preferences/InterfacePreferencesController.java
+++ b/src/main/java/org/cryptomator/ui/preferences/InterfacePreferencesController.java
@@ -34,6 +34,7 @@ public class InterfacePreferencesController implements FxController {
 	private final ObjectProperty<SelectedPreferencesTab> selectedTabProperty;
 	private final LicenseHolder licenseHolder;
 	private final ResourceBundle resourceBundle;
+	private final SupportedLanguages supportedLanguages;
 	public ChoiceBox<UiTheme> themeChoiceBox;
 	public CheckBox showMinimizeButtonCheckbox;
 	public CheckBox showTrayIconCheckbox;
@@ -43,13 +44,14 @@ public class InterfacePreferencesController implements FxController {
 	public RadioButton nodeOrientationRtl;
 
 	@Inject
-	InterfacePreferencesController(Settings settings, TrayMenuComponent trayMenu, ObjectProperty<SelectedPreferencesTab> selectedTabProperty, LicenseHolder licenseHolder, ResourceBundle resourceBundle) {
+	InterfacePreferencesController(Settings settings, SupportedLanguages supportedLanguages, TrayMenuComponent trayMenu, ObjectProperty<SelectedPreferencesTab> selectedTabProperty, LicenseHolder licenseHolder, ResourceBundle resourceBundle) {
 		this.settings = settings;
 		this.trayMenuInitialized = trayMenu.isInitialized();
 		this.trayMenuSupported = trayMenu.isSupported();
 		this.selectedTabProperty = selectedTabProperty;
 		this.licenseHolder = licenseHolder;
 		this.resourceBundle = resourceBundle;
+		this.supportedLanguages = supportedLanguages;
 	}
 
 	@FXML
@@ -65,10 +67,7 @@ public class InterfacePreferencesController implements FxController {
 
 		showTrayIconCheckbox.selectedProperty().bindBidirectional(settings.showTrayIcon());
 
-		// System default and English at the top of the list
-		preferredLanguageChoiceBox.getItems().add(Settings.DEFAULT_LANGUAGE);
-		preferredLanguageChoiceBox.getItems().add(SupportedLanguages.ENGLISH);
-		preferredLanguageChoiceBox.getItems().addAll(SupportedLanguages.LANGUAGE_TAGS);
+		preferredLanguageChoiceBox.getItems().addAll(supportedLanguages.getLanguageTags());
 		preferredLanguageChoiceBox.valueProperty().bindBidirectional(settings.languageProperty());
 		preferredLanguageChoiceBox.setConverter(new LanguageTagConverter(resourceBundle));
 

--- a/src/main/java/org/cryptomator/ui/preferences/InterfacePreferencesController.java
+++ b/src/main/java/org/cryptomator/ui/preferences/InterfacePreferencesController.java
@@ -1,6 +1,5 @@
 package org.cryptomator.ui.preferences;
 
-import com.google.common.base.Strings;
 import org.cryptomator.common.LicenseHolder;
 import org.cryptomator.common.settings.Settings;
 import org.cryptomator.common.settings.UiTheme;
@@ -66,8 +65,10 @@ public class InterfacePreferencesController implements FxController {
 
 		showTrayIconCheckbox.selectedProperty().bindBidirectional(settings.showTrayIcon());
 
-		preferredLanguageChoiceBox.getItems().add(null);
-		preferredLanguageChoiceBox.getItems().addAll(SupportedLanguages.LANGUAGAE_TAGS);
+		// System default and English at the top of the list
+		preferredLanguageChoiceBox.getItems().add(Settings.DEFAULT_LANGUAGE);
+		preferredLanguageChoiceBox.getItems().add(SupportedLanguages.ENGLISH);
+		preferredLanguageChoiceBox.getItems().addAll(SupportedLanguages.LANGUAGE_TAGS);
 		preferredLanguageChoiceBox.valueProperty().bindBidirectional(settings.languageProperty());
 		preferredLanguageChoiceBox.setConverter(new LanguageTagConverter(resourceBundle));
 
@@ -141,9 +142,7 @@ public class InterfacePreferencesController implements FxController {
 				return resourceBundle.getString("preferences.interface.language.auto");
 			} else {
 				var locale = Locale.forLanguageTag(tag);
-				var lang = locale.getDisplayLanguage(locale);
-				var region = locale.getDisplayCountry(locale);
-				return lang + (Strings.isNullOrEmpty(region) ? "" : " (" + region + ")");
+				return locale.getDisplayName();
 			}
 		}
 

--- a/src/test/java/org/cryptomator/launcher/SupportedLanguagesTest.java
+++ b/src/test/java/org/cryptomator/launcher/SupportedLanguagesTest.java
@@ -25,7 +25,7 @@ public class SupportedLanguagesTest {
 	}
 
 	public static Stream<String> languageTags() {
-		return SupportedLanguages.LANGUAGAE_TAGS.stream() //
+		return SupportedLanguages.LANGUAGE_TAGS.stream() //
 				.filter(tag -> !"en".equals(tag)); // english uses the default bundle
 	}
 }


### PR DESCRIPTION
> List of languages should have system default, English and then all other languages in alphabetic order.
> That is, in alphabetic order with respect to the language the list is localized in (seems to be English always)

Fixes #2813 


![image](https://user-images.githubusercontent.com/7766604/234592374-ee59335e-a84a-4749-b6b0-97118c8d198a.png)


![image](https://user-images.githubusercontent.com/7766604/234592542-9ba05cfb-e63d-4e69-a2dc-a1dfd1134e20.png)

![image](https://user-images.githubusercontent.com/7766604/234592688-2a0a5bcb-070b-44bc-98d7-6c645af092bd.png)
