### PR TITLE
Change format of errordb gist

### DIFF
--- a/.github/workflows/error-db.yml
+++ b/.github/workflows/error-db.yml
@@ -46,9 +46,10 @@ jobs:
           gistURL: https://gist.github.com/cryptobot/accba9fb9555e7192271b85606f97230
       - name: Merge Error Code Data
         run: |
-          jq -c '.' ${{ steps.get-gist.outputs.file }} > original.json
+          jq -c 'map({key:.id} + {value:.}) | from_entries' ${{ steps.get-gist.outputs.file }} > original.json
           echo $DISCUSSION | jq -c '.repository.discussion | .comments = .comments.totalCount | {(.id|tostring) : .}' > new.json
           jq -s '.[0] * .[1]' original.json new.json > merged.json
+          jq -c 'to_entries | map(.value)' merged.json > final.json
         env:
           DISCUSSION: ${{ steps.query-data.outputs.result }}
       - name: Patch Gist
@@ -57,4 +58,4 @@ jobs:
           token: ${{ secrets.CRYPTOBOT_GIST_TOKEN }}
           gist_id: accba9fb9555e7192271b85606f97230
           gist_file_name: errorcodes.json
-          file_path: merged.json
+          file_path: final.json


### PR DESCRIPTION
This PR changes the format of the error db from being a map of objects to an array of objects. Merging updates is still done via a dictionary, inside the workflow we convert from array to map, process the updates and convert the map back to an array.

This change is required to enhance the error screen.

## Requirements:
* [ ] Update [gist](https://gist.github.com/cryptobot/accba9fb9555e7192271b85606f97230) to new format once


## Example
Before merge:
```json
{
  "D_kwDOAPryk84AP3vK": {
    "id": "D_kwDOAPryk84AP3vK",
    "upvoteCount": 1,
    "title": "Error J6ML:BENT:Q9PV",
    ...
  },
  "D_kwDOAPryk84AOCHV": {
    "id": "D_kwDOAPryk84AOCHV",
    "upvoteCount": 1,
    "title": "Error RK30:3502:5PNR",
    ...
  }
}
```

After merge:
```json
[
  {
    "id": "D_kwDOAPryk84AP3vK",
    "upvoteCount": 1,
    "title": "Error J6ML:BENT:Q9PV",
    ...
  },
  {
    "id": "D_kwDOAPryk84AOCHV",
    "upvoteCount": 1,
    "title": "Error RK30:3502:5PNR",
    ...
  }
]
```