### PR TITLE
Do not show backticks as part of the error detail text

### DIFF
--- a/src/main/java/org/cryptomator/ui/error/ErrorController.java
+++ b/src/main/java/org/cryptomator/ui/error/ErrorController.java
@@ -129,7 +129,7 @@ public class ErrorController implements FxController {
 	@FXML
 	public void copyDetails() {
 		ClipboardContent clipboardContent = new ClipboardContent();
-		clipboardContent.putString(getDetailText());
+		clipboardContent.putString("```\n" + getDetailText() + "\n```");
 		Clipboard.getSystemClipboard().setContent(clipboardContent);
 
 		copiedDetails.set(true);
@@ -259,7 +259,7 @@ public class ErrorController implements FxController {
 	}
 
 	public String getDetailText() {
-		return "```\nError Code " + getErrorCode() + "\n" + getStackTrace() + "\n```";
+		return "Error Code " + getErrorCode() + "\n" + getStackTrace();
 	}
 
 	public BooleanProperty copiedDetailsProperty() {


### PR DESCRIPTION
The backticks are for Markdown rendering when copying the error message to a GitHub issue report. As such, use the backticks only when copying to the clipboard. This makes the error message read a bit cleaner as part of the dialog.