### PR TITLE
Fix for #2989 - Cryptomator using the configured proxy

### DIFF
--- a/src/main/java/org/cryptomator/ui/error/ErrorController.java
+++ b/src/main/java/org/cryptomator/ui/error/ErrorController.java
@@ -157,9 +157,7 @@ public class ErrorController implements FxController {
 								.thenComparing(this::compareIsAnswered)//
 								.thenComparing(this::compareUpvoteCount));
 
-				if (value.isPresent()) {
-					matchingErrorDiscussion.set(value.get());
-				}
+				value.ifPresent(matchingErrorDiscussion::set);
 			}
 		} catch (IOException e) {
 			LOG.error("Failed to load or parse JSON from " + response.uri(), e);

--- a/src/main/java/org/cryptomator/ui/error/ErrorController.java
+++ b/src/main/java/org/cryptomator/ui/error/ErrorController.java
@@ -25,6 +25,7 @@ import javafx.scene.input.ClipboardContent;
 import javafx.stage.Stage;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.ProxySelector;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
@@ -81,7 +82,7 @@ public class ErrorController implements FxController {
 		this.environment = environment;
 
 		isLoadingHttpResponse.set(true);
-		HttpClient httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
+		HttpClient httpClient = HttpClient.newBuilder().proxy(ProxySelector.getDefault()).version(HttpClient.Version.HTTP_1_1).build();
 		HttpRequest httpRequest = HttpRequest.newBuilder()//
 				.uri(URI.create(ERROR_CODES_URL))//
 				.build();

--- a/src/main/java/org/cryptomator/ui/fxapp/UpdateCheckerModule.java
+++ b/src/main/java/org/cryptomator/ui/fxapp/UpdateCheckerModule.java
@@ -81,16 +81,8 @@ public abstract class UpdateCheckerModule {
 		ScheduledService<String> service = new ScheduledService<>() {
 			@Override
 			protected Task<String> createTask() {
-				if (httpClient.isPresent()) {
-					return new UpdateCheckerTask(httpClient.get(), checkForUpdatesRequest);
-				} else {
-					return new Task<>() {
-						@Override
-						protected String call() {
-							throw new NullPointerException("No HttpClient present.");
-						}
-					};
-				}
+				return httpClient.map(client -> new UpdateCheckerTask(client, checkForUpdatesRequest))
+						.orElseThrow(() -> new IllegalArgumentException("No HttpClient present."));
 			}
 		};
 		service.setOnFailed(event -> LOG.error("Failed to execute update service", service.getException()));

--- a/src/main/java/org/cryptomator/ui/fxapp/UpdateCheckerModule.java
+++ b/src/main/java/org/cryptomator/ui/fxapp/UpdateCheckerModule.java
@@ -17,6 +17,7 @@ import javafx.concurrent.ScheduledService;
 import javafx.concurrent.Task;
 import javafx.util.Duration;
 import java.io.UncheckedIOException;
+import java.net.ProxySelector;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -45,6 +46,7 @@ public abstract class UpdateCheckerModule {
 		try {
 			return Optional.of(HttpClient.newBuilder() //
 					.followRedirects(HttpClient.Redirect.NORMAL) // from version 1.6.11 onwards, Cryptomator can follow redirects, in case this URL ever changes
+					.proxy(ProxySelector.getDefault())
 					.build());
 		} catch (UncheckedIOException e) {
 			LOG.error("HttpClient for update check cannot be created.", e);

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/ReceiveKeyController.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/ReceiveKeyController.java
@@ -19,6 +19,7 @@ import javafx.stage.WindowEvent;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.net.ProxySelector;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
@@ -56,7 +57,7 @@ public class ReceiveKeyController implements FxController {
 		this.vaultBaseUri = getVaultBaseUri(vault);
 		this.invalidLicenseScene = invalidLicenseScene;
 		this.window.addEventHandler(WindowEvent.WINDOW_HIDING, this::windowClosed);
-		this.httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).executor(executor).build();
+		this.httpClient = HttpClient.newBuilder().proxy(ProxySelector.getDefault()).version(HttpClient.Version.HTTP_1_1).executor(executor).build();
 	}
 
 	@FXML

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/RegisterDeviceController.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/RegisterDeviceController.java
@@ -31,6 +31,7 @@ import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.ProxySelector;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -76,7 +77,7 @@ public class RegisterDeviceController implements FxController {
 		this.registerFailedScene = registerFailedScene;
 		this.jwt = JWT.decode(this.bearerToken);
 		this.window.addEventHandler(WindowEvent.WINDOW_HIDING, this::windowClosed);
-		this.httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).executor(executor).build();
+		this.httpClient = HttpClient.newBuilder().proxy(ProxySelector.getDefault()).version(HttpClient.Version.HTTP_1_1).executor(executor).build();
 	}
 
 	public void initialize() {


### PR DESCRIPTION
Given issue closes #2989 Cryptomator is not using system proxy to connect to Cryptomator update checker or hub.

During the debug I noticed that it was missing to inject the `ProxySelector.getDefault()` that returns the default proxy of the system. I performed the configurant tests via JVM Args and the `JAVA_TOOL_OPTIONS` environment variable both using the parameters `-Djava.net.useSystemProxies=true -Dhttp.proxyHost=186.248.206.147 -Dhttp.proxyPort=8080`.

Remembering that without the definition of these attributes, the check update works normally

Unfortunately I was only able to test it on MacOS.