### PR TITLE
Update Reminder

### DIFF
--- a/src/main/java/org/cryptomator/common/settings/Settings.java
+++ b/src/main/java/org/cryptomator/common/settings/Settings.java
@@ -26,6 +26,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.geometry.NodeOrientation;
 import java.util.function.Consumer;
+import java.time.LocalDate;
 
 public class Settings {
 
@@ -44,6 +45,7 @@ public class Settings {
 	static final String DEFAULT_KEYCHAIN_PROVIDER = SystemUtils.IS_OS_WINDOWS ? "org.cryptomator.windows.keychain.WindowsProtectedKeychainAccess" : SystemUtils.IS_OS_MAC ? "org.cryptomator.macos.keychain.MacSystemKeychainAccess" : "org.cryptomator.linux.keychain.SecretServiceKeychainAccess";
 	static final String DEFAULT_USER_INTERFACE_ORIENTATION = NodeOrientation.LEFT_TO_RIGHT.name();
 	static final boolean DEFAULT_SHOW_MINIMIZE_BUTTON = false;
+	static final String DEFAULT_LAST_UPDATE_CHECK = "2000-01-01";
 
 	public final ObservableList<VaultSettings> directories;
 	public final BooleanProperty askedForUpdateCheck;
@@ -67,6 +69,7 @@ public class Settings {
 	public final StringProperty displayConfiguration;
 	public final StringProperty language;
 	public final StringProperty mountService;
+	public final StringProperty lastUpdateCheck;
 
 	private Consumer<Settings> saveCmd;
 
@@ -104,6 +107,7 @@ public class Settings {
 		this.displayConfiguration = new SimpleStringProperty(this, "displayConfiguration", json.displayConfiguration);
 		this.language = new SimpleStringProperty(this, "language", json.language);
 		this.mountService = new SimpleStringProperty(this, "mountService", json.mountService);
+		this.lastUpdateCheck = new SimpleStringProperty(this,"lastUpdateCheck",json.lastUpdateCheck);
 
 		this.directories.addAll(json.directories.stream().map(VaultSettings::new).toList());
 
@@ -131,6 +135,7 @@ public class Settings {
 		displayConfiguration.addListener(this::somethingChanged);
 		language.addListener(this::somethingChanged);
 		mountService.addListener(this::somethingChanged);
+		lastUpdateCheck.addListener(this::somethingChanged);
 	}
 
 	@SuppressWarnings("deprecation")
@@ -185,6 +190,7 @@ public class Settings {
 		json.displayConfiguration = displayConfiguration.get();
 		json.language = language.get();
 		json.mountService = mountService.get();
+		json.lastUpdateCheck = lastUpdateCheck.get();
 		return json;
 	}
 

--- a/src/main/java/org/cryptomator/common/settings/Settings.java
+++ b/src/main/java/org/cryptomator/common/settings/Settings.java
@@ -26,7 +26,6 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.geometry.NodeOrientation;
 import java.util.function.Consumer;
-import java.time.LocalDate;
 
 public class Settings {
 
@@ -107,7 +106,7 @@ public class Settings {
 		this.displayConfiguration = new SimpleStringProperty(this, "displayConfiguration", json.displayConfiguration);
 		this.language = new SimpleStringProperty(this, "language", json.language);
 		this.mountService = new SimpleStringProperty(this, "mountService", json.mountService);
-		this.lastUpdateCheck = new SimpleStringProperty(this,"lastUpdateCheck",json.lastUpdateCheck);
+		this.lastUpdateCheck = new SimpleStringProperty(this, "lastUpdateCheck", json.lastUpdateCheck);
 
 		this.directories.addAll(json.directories.stream().map(VaultSettings::new).toList());
 

--- a/src/main/java/org/cryptomator/common/settings/SettingsJson.java
+++ b/src/main/java/org/cryptomator/common/settings/SettingsJson.java
@@ -83,4 +83,7 @@ class SettingsJson {
 	@JsonProperty(value = "preferredVolumeImpl", access = JsonProperty.Access.WRITE_ONLY) // WRITE_ONLY means value is "written" into the java object during deserialization. Upvote this: https://github.com/FasterXML/jackson-annotations/issues/233
 	String preferredVolumeImpl;
 
+	@JsonProperty("lastUpdateCheck")
+	String lastUpdateCheck = Settings.DEFAULT_LAST_UPDATE_CHECK;
+
 }

--- a/src/main/java/org/cryptomator/ui/common/FxmlFile.java
+++ b/src/main/java/org/cryptomator/ui/common/FxmlFile.java
@@ -41,6 +41,7 @@ public enum FxmlFile {
 	RECOVERYKEY_RESET_PASSWORD_SUCCESS("/fxml/recoverykey_reset_password_success.fxml"), //
 	RECOVERYKEY_SUCCESS("/fxml/recoverykey_success.fxml"), //
 	REMOVE_VAULT("/fxml/remove_vault.fxml"), //
+	UPDATE_REMINDER("/fxml/update_reminder.fxml"), //
 	UNLOCK_ENTER_PASSWORD("/fxml/unlock_enter_password.fxml"),
 	UNLOCK_INVALID_MOUNT_POINT("/fxml/unlock_invalid_mount_point.fxml"), //
 	UNLOCK_SELECT_MASTERKEYFILE("/fxml/unlock_select_masterkeyfile.fxml"), //

--- a/src/main/java/org/cryptomator/ui/fxapp/FxApplication.java
+++ b/src/main/java/org/cryptomator/ui/fxapp/FxApplication.java
@@ -9,7 +9,6 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javafx.application.Platform;
-import java.time.LocalDate;
 import java.util.concurrent.TimeUnit;
 
 @FxApplicationScoped
@@ -69,9 +68,7 @@ public class FxApplication {
 			return null;
 		});
 
-		if (LocalDate.parse(settings.lastUpdateCheck.get()).isBefore(LocalDate.now().minusDays(14)) && !settings.checkForUpdates.getValue()) {
-			appWindows.showUpdateReminderWindow();
-		}
+		appWindows.checkAndShowUpdateReminderWindow();
 
 		launchEventHandler.startHandlingLaunchEvents();
 		autoUnlocker.tryUnlockForTimespan(2, TimeUnit.MINUTES);

--- a/src/main/java/org/cryptomator/ui/fxapp/FxApplication.java
+++ b/src/main/java/org/cryptomator/ui/fxapp/FxApplication.java
@@ -67,6 +67,9 @@ public class FxApplication {
 			LOG.error("Failed to show main window", error);
 			return null;
 		});
+		if(!settings.checkForUpdates.getValue()){
+			appWindows.showUpdateReminderWindow();
+		}
 
 		launchEventHandler.startHandlingLaunchEvents();
 		autoUnlocker.tryUnlockForTimespan(2, TimeUnit.MINUTES);

--- a/src/main/java/org/cryptomator/ui/fxapp/FxApplication.java
+++ b/src/main/java/org/cryptomator/ui/fxapp/FxApplication.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javafx.application.Platform;
+import java.time.LocalDate;
 import java.util.concurrent.TimeUnit;
 
 @FxApplicationScoped
@@ -67,7 +68,8 @@ public class FxApplication {
 			LOG.error("Failed to show main window", error);
 			return null;
 		});
-		if(!settings.checkForUpdates.getValue()){
+
+		if(LocalDate.parse(settings.lastUpdateCheck.get()).isBefore(LocalDate.now().minusDays(14)) && !settings.checkForUpdates.getValue()){
 			appWindows.showUpdateReminderWindow();
 		}
 

--- a/src/main/java/org/cryptomator/ui/fxapp/FxApplication.java
+++ b/src/main/java/org/cryptomator/ui/fxapp/FxApplication.java
@@ -69,7 +69,7 @@ public class FxApplication {
 			return null;
 		});
 
-		if(LocalDate.parse(settings.lastUpdateCheck.get()).isBefore(LocalDate.now().minusDays(14)) && !settings.checkForUpdates.getValue()){
+		if (LocalDate.parse(settings.lastUpdateCheck.get()).isBefore(LocalDate.now().minusDays(14)) && !settings.checkForUpdates.getValue()) {
 			appWindows.showUpdateReminderWindow();
 		}
 

--- a/src/main/java/org/cryptomator/ui/fxapp/FxApplicationModule.java
+++ b/src/main/java/org/cryptomator/ui/fxapp/FxApplicationModule.java
@@ -55,10 +55,4 @@ abstract class FxApplicationModule {
 		return builder.build();
 	}
 
-	@Provides
-	@FxApplicationScoped
-	static UpdateReminderComponent provideUpdateReminderComponent(UpdateReminderComponent.Factory factory) {
-		return factory.create();
-	}
-
 }

--- a/src/main/java/org/cryptomator/ui/fxapp/FxApplicationModule.java
+++ b/src/main/java/org/cryptomator/ui/fxapp/FxApplicationModule.java
@@ -57,8 +57,8 @@ abstract class FxApplicationModule {
 
 	@Provides
 	@FxApplicationScoped
-	static UpdateReminderComponent provideUpdateReminderComponent(UpdateReminderComponent.Builder builder) {
-		return builder.build();
+	static UpdateReminderComponent provideUpdateReminderComponent(UpdateReminderComponent.Factory factory) {
+		return factory.create();
 	}
 
 }

--- a/src/main/java/org/cryptomator/ui/fxapp/FxApplicationModule.java
+++ b/src/main/java/org/cryptomator/ui/fxapp/FxApplicationModule.java
@@ -15,12 +15,13 @@ import org.cryptomator.ui.quit.QuitComponent;
 
 import org.cryptomator.ui.traymenu.TrayMenuComponent;
 import org.cryptomator.ui.unlock.UnlockComponent;
+import org.cryptomator.ui.updatereminder.UpdateReminderComponent;
 
 import javafx.scene.image.Image;
 import java.io.IOException;
 import java.io.InputStream;
 
-@Module(includes = {UpdateCheckerModule.class}, subcomponents = {TrayMenuComponent.class, MainWindowComponent.class, PreferencesComponent.class, UnlockComponent.class, LockComponent.class, QuitComponent.class, ErrorComponent.class})
+@Module(includes = {UpdateCheckerModule.class}, subcomponents = {TrayMenuComponent.class, MainWindowComponent.class, PreferencesComponent.class, UnlockComponent.class, LockComponent.class, QuitComponent.class, ErrorComponent.class, UpdateReminderComponent.class})
 abstract class FxApplicationModule {
 
 	private static Image createImageFromResource(String resourceName) throws IOException {
@@ -52,4 +53,11 @@ abstract class FxApplicationModule {
 	static QuitComponent provideQuitComponent(QuitComponent.Builder builder) {
 		return builder.build();
 	}
+
+	@Provides
+	@FxApplicationScoped
+	static UpdateReminderComponent provideUpdateReminderComponent(UpdateReminderComponent.Builder builder) {
+		return builder.build();
+	}
+
 }

--- a/src/main/java/org/cryptomator/ui/fxapp/FxApplicationModule.java
+++ b/src/main/java/org/cryptomator/ui/fxapp/FxApplicationModule.java
@@ -12,7 +12,6 @@ import org.cryptomator.ui.lock.LockComponent;
 import org.cryptomator.ui.mainwindow.MainWindowComponent;
 import org.cryptomator.ui.preferences.PreferencesComponent;
 import org.cryptomator.ui.quit.QuitComponent;
-
 import org.cryptomator.ui.traymenu.TrayMenuComponent;
 import org.cryptomator.ui.unlock.UnlockComponent;
 import org.cryptomator.ui.updatereminder.UpdateReminderComponent;

--- a/src/main/java/org/cryptomator/ui/fxapp/FxApplicationWindows.java
+++ b/src/main/java/org/cryptomator/ui/fxapp/FxApplicationWindows.java
@@ -13,6 +13,7 @@ import org.cryptomator.ui.preferences.SelectedPreferencesTab;
 import org.cryptomator.ui.quit.QuitComponent;
 import org.cryptomator.ui.unlock.UnlockComponent;
 import org.cryptomator.ui.unlock.UnlockWorkflow;
+import org.cryptomator.ui.updatereminder.UpdateReminderComponent;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,19 +44,30 @@ public class FxApplicationWindows {
 	private final Lazy<PreferencesComponent> preferencesWindow;
 	private final QuitComponent.Builder quitWindowBuilder;
 	private final UnlockComponent.Factory unlockWorkflowFactory;
+	private final UpdateReminderComponent.Builder updateReminderWindowBuilder;
 	private final LockComponent.Factory lockWorkflowFactory;
 	private final ErrorComponent.Factory errorWindowFactory;
 	private final ExecutorService executor;
 	private final FilteredList<Window> visibleWindows;
 
 	@Inject
-	public FxApplicationWindows(@PrimaryStage Stage primaryStage, Optional<TrayIntegrationProvider> trayIntegration, Lazy<MainWindowComponent> mainWindow, Lazy<PreferencesComponent> preferencesWindow, QuitComponent.Builder quitWindowBuilder, UnlockComponent.Factory unlockWorkflowFactory, LockComponent.Factory lockWorkflowFactory, ErrorComponent.Factory errorWindowFactory, ExecutorService executor) {
+	public FxApplicationWindows(@PrimaryStage Stage primaryStage,
+								Optional<TrayIntegrationProvider> trayIntegration, //
+								Lazy<MainWindowComponent> mainWindow, //
+								Lazy<PreferencesComponent> preferencesWindow, //
+								QuitComponent.Builder quitWindowBuilder, //
+								UnlockComponent.Factory unlockWorkflowFactory, //
+								UpdateReminderComponent.Builder updateReminderWindowBuilder, //
+								LockComponent.Factory lockWorkflowFactory, //
+								ErrorComponent.Factory errorWindowFactory, //
+								ExecutorService executor) {
 		this.primaryStage = primaryStage;
 		this.trayIntegration = trayIntegration;
 		this.mainWindow = mainWindow;
 		this.preferencesWindow = preferencesWindow;
 		this.quitWindowBuilder = quitWindowBuilder;
 		this.unlockWorkflowFactory = unlockWorkflowFactory;
+		this.updateReminderWindowBuilder = updateReminderWindowBuilder;
 		this.lockWorkflowFactory = lockWorkflowFactory;
 		this.errorWindowFactory = errorWindowFactory;
 		this.executor = executor;
@@ -107,6 +119,10 @@ public class FxApplicationWindows {
 
 	public void showQuitWindow(QuitResponse response, boolean forced) {
 			CompletableFuture.runAsync(() -> quitWindowBuilder.build().showQuitWindow(response,forced), Platform::runLater);
+	}
+
+	public void showUpdateReminderWindow() {
+		CompletableFuture.runAsync(() -> updateReminderWindowBuilder.build().showUpdateReminderWindow(), Platform::runLater);
 	}
 
 	public CompletionStage<Void> startUnlockWorkflow(Vault vault, @Nullable Stage owner) {

--- a/src/main/java/org/cryptomator/ui/fxapp/FxApplicationWindows.java
+++ b/src/main/java/org/cryptomator/ui/fxapp/FxApplicationWindows.java
@@ -46,7 +46,7 @@ public class FxApplicationWindows {
 	private final Lazy<PreferencesComponent> preferencesWindow;
 	private final QuitComponent.Builder quitWindowBuilder;
 	private final UnlockComponent.Factory unlockWorkflowFactory;
-	private final UpdateReminderComponent.Builder updateReminderWindowBuilder;
+	private final UpdateReminderComponent.Factory updateReminderWindowBuilder;
 	private final LockComponent.Factory lockWorkflowFactory;
 	private final ErrorComponent.Factory errorWindowFactory;
 	private final ExecutorService executor;
@@ -60,7 +60,7 @@ public class FxApplicationWindows {
 								Lazy<PreferencesComponent> preferencesWindow, //
 								QuitComponent.Builder quitWindowBuilder, //
 								UnlockComponent.Factory unlockWorkflowFactory, //
-								UpdateReminderComponent.Builder updateReminderWindowBuilder, //
+								UpdateReminderComponent.Factory updateReminderWindowBuilder, //
 								LockComponent.Factory lockWorkflowFactory, //
 								ErrorComponent.Factory errorWindowFactory, //
 								VaultOptionsComponent.Factory vaultOptionsWindow, //
@@ -131,7 +131,7 @@ public class FxApplicationWindows {
 	}
 
 	public void showUpdateReminderWindow() {
-		CompletableFuture.runAsync(() -> updateReminderWindowBuilder.build().showUpdateReminderWindow(), Platform::runLater);
+		CompletableFuture.runAsync(() -> updateReminderWindowBuilder.create().showUpdateReminderWindow(), Platform::runLater);
 	}
 
 	public CompletionStage<Void> startUnlockWorkflow(Vault vault, @Nullable Stage owner) {

--- a/src/main/java/org/cryptomator/ui/fxapp/FxApplicationWindows.java
+++ b/src/main/java/org/cryptomator/ui/fxapp/FxApplicationWindows.java
@@ -130,8 +130,8 @@ public class FxApplicationWindows {
 			CompletableFuture.runAsync(() -> quitWindowBuilder.build().showQuitWindow(response,forced), Platform::runLater);
 	}
 
-	public void showUpdateReminderWindow() {
-		CompletableFuture.runAsync(() -> updateReminderWindowBuilder.create().showUpdateReminderWindow(), Platform::runLater);
+	public void checkAndShowUpdateReminderWindow() {
+		CompletableFuture.runAsync(() -> updateReminderWindowBuilder.create().checkAndShowUpdateReminderWindow(), Platform::runLater);
 	}
 
 	public CompletionStage<Void> startUnlockWorkflow(Vault vault, @Nullable Stage owner) {

--- a/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderComponent.java
+++ b/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderComponent.java
@@ -1,8 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2017 Skymatic UG (haftungsbeschränkt).
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the accompanying LICENSE file.
- *******************************************************************************/
 package org.cryptomator.ui.updatereminder;
 
 import dagger.Lazy;

--- a/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderComponent.java
+++ b/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderComponent.java
@@ -25,8 +25,8 @@ public interface UpdateReminderComponent {
 		stage.show();
 	}
 
-	@Subcomponent.Builder
-	interface Builder {
-		UpdateReminderComponent build();
+	@Subcomponent.Factory
+	interface Factory {
+		UpdateReminderComponent create();
 	}
 }

--- a/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderComponent.java
+++ b/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderComponent.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Skymatic UG (haftungsbeschränkt).
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the accompanying LICENSE file.
+ *******************************************************************************/
+package org.cryptomator.ui.updatereminder;
+
+import dagger.Lazy;
+import dagger.Subcomponent;
+import org.cryptomator.ui.common.FxmlFile;
+import org.cryptomator.ui.common.FxmlScene;
+
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+
+@UpdateReminderScoped
+@Subcomponent(modules = {UpdateReminderModule.class})
+public interface UpdateReminderComponent {
+
+	@UpdateReminderWindow
+	Stage window();
+
+	@FxmlScene(FxmlFile.UPDATE_REMINDER)
+	Lazy<Scene> updateReminderScene();
+
+	default void showUpdateReminderWindow() {
+		Stage stage = window();
+		stage.setScene(updateReminderScene().get());
+		stage.sizeToScene();
+		stage.show();
+	}
+
+	@Subcomponent.Builder
+	interface Builder {
+		UpdateReminderComponent build();
+	}
+}

--- a/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderComponent.java
+++ b/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderComponent.java
@@ -2,11 +2,13 @@ package org.cryptomator.ui.updatereminder;
 
 import dagger.Lazy;
 import dagger.Subcomponent;
+import org.cryptomator.common.settings.Settings;
 import org.cryptomator.ui.common.FxmlFile;
 import org.cryptomator.ui.common.FxmlScene;
 
 import javafx.scene.Scene;
 import javafx.stage.Stage;
+import java.time.LocalDate;
 
 @UpdateReminderScoped
 @Subcomponent(modules = {UpdateReminderModule.class})
@@ -18,11 +20,15 @@ public interface UpdateReminderComponent {
 	@FxmlScene(FxmlFile.UPDATE_REMINDER)
 	Lazy<Scene> updateReminderScene();
 
-	default void showUpdateReminderWindow() {
-		Stage stage = window();
-		stage.setScene(updateReminderScene().get());
-		stage.sizeToScene();
-		stage.show();
+	Settings settings();
+
+	default void checkAndShowUpdateReminderWindow() {
+		if (LocalDate.parse(settings().lastUpdateCheck.get()).isBefore(LocalDate.now().minusDays(14)) && !settings().checkForUpdates.getValue()) {
+			Stage stage = window();
+			stage.setScene(updateReminderScene().get());
+			stage.sizeToScene();
+			stage.show();
+		}
 	}
 
 	@Subcomponent.Factory

--- a/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderController.java
+++ b/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderController.java
@@ -7,7 +7,6 @@ import org.cryptomator.ui.fxapp.UpdateChecker;
 import javax.inject.Inject;
 import javafx.fxml.FXML;
 import javafx.stage.Stage;
-
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
@@ -31,12 +30,14 @@ public class UpdateReminderController implements FxController {
 		settings.lastUpdateCheck.set(LocalDate.now().format(DateTimeFormatter.ISO_DATE));
 		window.close();
 	}
+
 	@FXML
 	public void once() {
 		settings.lastUpdateCheck.set(LocalDate.now().format(DateTimeFormatter.ISO_DATE));
 		updateChecker.checkForUpdatesNow();
 		window.close();
 	}
+
 	@FXML
 	public void automatically() {
 		settings.lastUpdateCheck.set(LocalDate.now().format(DateTimeFormatter.ISO_DATE));

--- a/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderController.java
+++ b/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderController.java
@@ -1,0 +1,42 @@
+package org.cryptomator.ui.updatereminder;
+
+import org.cryptomator.common.settings.Settings;
+import org.cryptomator.ui.common.FxController;
+import org.cryptomator.ui.fxapp.UpdateChecker;
+
+import javax.inject.Inject;
+import javafx.fxml.FXML;
+import javafx.stage.Stage;
+
+@UpdateReminderScoped
+public class UpdateReminderController implements FxController {
+
+	private final Stage window;
+	private final Settings settings;
+	private final UpdateChecker updateChecker;
+
+
+	@Inject
+	UpdateReminderController(@UpdateReminderWindow Stage window, Settings settings, UpdateChecker updateChecker) {
+		this.window = window;
+		this.settings = settings;
+		this.updateChecker = updateChecker;
+	}
+
+	@FXML
+	public void cancel() {
+		window.close();
+	}
+	@FXML
+	public void once() {
+		updateChecker.checkForUpdatesNow();
+		window.close();
+	}
+	@FXML
+	public void automatically() {
+		settings.checkForUpdates.set(true);
+		updateChecker.checkForUpdatesNow();
+		window.close();
+	}
+
+}

--- a/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderController.java
+++ b/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderController.java
@@ -8,6 +8,9 @@ import javax.inject.Inject;
 import javafx.fxml.FXML;
 import javafx.stage.Stage;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
 @UpdateReminderScoped
 public class UpdateReminderController implements FxController {
 
@@ -25,17 +28,20 @@ public class UpdateReminderController implements FxController {
 
 	@FXML
 	public void cancel() {
+		settings.lastUpdateCheck.set(LocalDate.now().format(DateTimeFormatter.ISO_DATE));
 		window.close();
 	}
 	@FXML
 	public void once() {
+		settings.lastUpdateCheck.set(LocalDate.now().format(DateTimeFormatter.ISO_DATE));
 		updateChecker.checkForUpdatesNow();
 		window.close();
 	}
 	@FXML
 	public void automatically() {
-		settings.checkForUpdates.set(true);
+		settings.lastUpdateCheck.set(LocalDate.now().format(DateTimeFormatter.ISO_DATE));
 		updateChecker.checkForUpdatesNow();
+		settings.checkForUpdates.set(true);
 		window.close();
 	}
 

--- a/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderModule.java
+++ b/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderModule.java
@@ -34,8 +34,8 @@ abstract class UpdateReminderModule {
 	@UpdateReminderScoped
 	static Stage provideStage(StageFactory factory, ResourceBundle resourceBundle) {
 		Stage stage = factory.create();
-		stage.setTitle(resourceBundle.getString("updateReminder.title"));
-		stage.setMinWidth(450);
+		stage.setTitle(resourceBundle.getString("updateReminder.windowTitle"));
+		stage.setMinWidth(550);
 		stage.setMinHeight(100);
 		stage.initModality(Modality.APPLICATION_MODAL);
 		return stage;

--- a/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderModule.java
+++ b/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderModule.java
@@ -34,7 +34,7 @@ abstract class UpdateReminderModule {
 	@UpdateReminderScoped
 	static Stage provideStage(StageFactory factory, ResourceBundle resourceBundle) {
 		Stage stage = factory.create();
-		stage.setTitle(resourceBundle.getString("updateReminder.windowTitle"));
+		stage.setTitle(resourceBundle.getString("updateReminder.title"));
 		stage.setMinWidth(550);
 		stage.setMinHeight(100);
 		stage.initModality(Modality.APPLICATION_MODAL);

--- a/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderModule.java
+++ b/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderModule.java
@@ -1,0 +1,59 @@
+package org.cryptomator.ui.updatereminder;
+
+import dagger.Binds;
+import dagger.Module;
+import dagger.Provides;
+import dagger.multibindings.IntoMap;
+import org.cryptomator.ui.common.DefaultSceneFactory;
+import org.cryptomator.ui.common.FxController;
+import org.cryptomator.ui.common.FxControllerKey;
+import org.cryptomator.ui.common.FxmlFile;
+import org.cryptomator.ui.common.FxmlLoaderFactory;
+import org.cryptomator.ui.common.FxmlScene;
+import org.cryptomator.ui.common.StageFactory;
+
+import javax.inject.Provider;
+import javafx.scene.Scene;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+import java.util.Map;
+import java.util.ResourceBundle;
+
+@Module
+abstract class UpdateReminderModule {
+
+	@Provides
+	@UpdateReminderWindow
+	@UpdateReminderScoped
+	static FxmlLoaderFactory provideFxmlLoaderFactory(Map<Class<? extends FxController>, Provider<FxController>> factories, DefaultSceneFactory sceneFactory, ResourceBundle resourceBundle) {
+		return new FxmlLoaderFactory(factories, sceneFactory, resourceBundle);
+	}
+
+	@Provides
+	@UpdateReminderWindow
+	@UpdateReminderScoped
+	static Stage provideStage(StageFactory factory, ResourceBundle resourceBundle) {
+		Stage stage = factory.create();
+		stage.setTitle(resourceBundle.getString("updateReminder.title"));
+		stage.setMinWidth(450);
+		stage.setMinHeight(100);
+		stage.initModality(Modality.APPLICATION_MODAL);
+		return stage;
+	}
+
+	@Provides
+	@FxmlScene(FxmlFile.UPDATE_REMINDER)
+	@UpdateReminderScoped
+	static Scene provideUpdateReminderScene(@UpdateReminderWindow FxmlLoaderFactory fxmlLoaders) {
+		return fxmlLoaders.createScene(FxmlFile.UPDATE_REMINDER);
+	}
+
+
+	// ------------------
+
+	@Binds
+	@IntoMap
+	@FxControllerKey(UpdateReminderController.class)
+	abstract FxController bindUpdateReminderController(UpdateReminderController controller);
+
+}

--- a/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderModule.java
+++ b/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderModule.java
@@ -35,7 +35,7 @@ abstract class UpdateReminderModule {
 	static Stage provideStage(StageFactory factory, ResourceBundle resourceBundle) {
 		Stage stage = factory.create();
 		stage.setTitle(resourceBundle.getString("updateReminder.title"));
-		stage.setMinWidth(550);
+		stage.setMinWidth(500);
 		stage.setMinHeight(100);
 		stage.initModality(Modality.APPLICATION_MODAL);
 		return stage;

--- a/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderScoped.java
+++ b/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderScoped.java
@@ -1,0 +1,13 @@
+package org.cryptomator.ui.updatereminder;
+
+import javax.inject.Scope;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Scope
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@interface UpdateReminderScoped {
+
+}

--- a/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderWindow.java
+++ b/src/main/java/org/cryptomator/ui/updatereminder/UpdateReminderWindow.java
@@ -1,0 +1,14 @@
+package org.cryptomator.ui.updatereminder;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Qualifier
+@Documented
+@Retention(RUNTIME)
+@interface UpdateReminderWindow {
+
+}

--- a/src/main/resources/fxml/update_reminder.fxml
+++ b/src/main/resources/fxml/update_reminder.fxml
@@ -14,8 +14,8 @@
 <HBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
 	  fx:controller="org.cryptomator.ui.updatereminder.UpdateReminderController"
-	  minWidth="550"
-	  maxWidth="550"
+	  minWidth="500"
+	  prefWidth="500"
 	  minHeight="145"
 	  spacing="12"
 	  alignment="TOP_LEFT">
@@ -23,35 +23,32 @@
 		<Insets topRightBottomLeft="12"/>
 	</padding>
 	<children>
-		<VBox>
-			<HBox>
-				<Group>
-					<StackPane>
-						<padding>
-							<Insets topRightBottomLeft="6"/>
-						</padding>
-						<Circle styleClass="glyph-icon-primary" radius="24"/>
-						<FontAwesome5IconView styleClass="glyph-icon-white" glyph="QUESTION" glyphSize="24"/>
-					</StackPane>
-				</Group>
+		<Group>
+			<StackPane>
+				<padding>
+					<Insets topRightBottomLeft="6"/>
+				</padding>
+				<Circle styleClass="glyph-icon-primary" radius="24"/>
+				<FontAwesome5IconView styleClass="glyph-icon-white" glyph="QUESTION" glyphSize="24"/>
+			</StackPane>
+		</Group>
 
-				<VBox HBox.hgrow="ALWAYS">
-					<Label styleClass="label-large" text="%updateReminder.message" wrapText="true">
-						<padding>
-							<Insets bottom="6" top="6"/>
-						</padding>
-					</Label>
-					<Label text="%updateReminder.description" wrapText="true"/>
-					<Region VBox.vgrow="ALWAYS" minHeight="18"/>
-				</VBox>
-			</HBox>
-			<ButtonBar buttonMinWidth="120" buttonOrder="CY">
+		<VBox HBox.hgrow="ALWAYS">
+			<Label styleClass="label-large" text="%updateReminder.message" wrapText="true">
+				<padding>
+					<Insets bottom="6" top="6"/>
+				</padding>
+			</Label>
+			<Label text="%updateReminder.description" wrapText="true"/>
+			<Region VBox.vgrow="ALWAYS" minHeight="18"/>
+			<ButtonBar buttonMinWidth="120" buttonOrder="+CY" >
 				<buttons>
 					<Button text="%updateReminder.notNow" ButtonBar.buttonData="CANCEL_CLOSE" cancelButton="true" onAction="#cancel"/>
 					<Button text="%updateReminder.yesOnce" ButtonBar.buttonData="YES" onAction="#once"/>
 					<Button text="%updateReminder.yesAutomatically" ButtonBar.buttonData="YES" defaultButton="true" onAction="#automatically"/>
 				</buttons>
 			</ButtonBar>
+
 		</VBox>
 	</children>
 </HBox>

--- a/src/main/resources/fxml/update_reminder.fxml
+++ b/src/main/resources/fxml/update_reminder.fxml
@@ -28,7 +28,7 @@
 						<Insets topRightBottomLeft="6"/>
 					</padding>
 					<Circle styleClass="glyph-icon-primary" radius="24"/>
-					<FontAwesome5IconView styleClass="glyph-icon-white" glyph="EXCLAMATION" glyphSize="24"/>
+					<FontAwesome5IconView styleClass="glyph-icon-white" glyph="QUESTION" glyphSize="24"/>
 				</StackPane>
 			</Group>
 

--- a/src/main/resources/fxml/update_reminder.fxml
+++ b/src/main/resources/fxml/update_reminder.fxml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.layout.*?>
+<?import javafx.scene.control.ButtonBar?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.Group?>
+<?import javafx.scene.shape.Circle?>
+<?import org.cryptomator.ui.controls.FontAwesome5IconView?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.Button?>
+<HBox xmlns:fx="http://javafx.com/fxml"
+	  xmlns="http://javafx.com/javafx"
+	  fx:controller="org.cryptomator.ui.updatereminder.UpdateReminderController"
+	  minWidth="450"
+	  maxWidth="450"
+	  minHeight="145"
+	  spacing="12"
+	  alignment="TOP_LEFT">
+	<padding>
+		<Insets topRightBottomLeft="12"/>
+	</padding>
+	<children>
+		<VBox>
+			<HBox>
+			<Group>
+				<StackPane>
+					<padding>
+						<Insets topRightBottomLeft="6"/>
+					</padding>
+					<Circle styleClass="glyph-icon-primary" radius="24"/>
+					<FontAwesome5IconView styleClass="glyph-icon-white" glyph="EXCLAMATION" glyphSize="24"/>
+				</StackPane>
+			</Group>
+
+		<VBox HBox.hgrow="ALWAYS">
+			<Label styleClass="label-large" text="%updateReminder.title" wrapText="true">
+				<padding>
+					<Insets bottom="6" top="6"/>
+				</padding>
+			</Label>
+			<Label text="%updateReminder.message" wrapText="true"/>
+			<Region VBox.vgrow="ALWAYS" minHeight="18"/>
+		</VBox>
+		</HBox>
+		<ButtonBar buttonMinWidth="120" buttonOrder="CY">
+			<buttons>
+				<Button text="%updateReminder.notNow" ButtonBar.buttonData="CANCEL_CLOSE" cancelButton="true" onAction="#cancel"/>
+				<Button text="%updateReminder.yesOnce" ButtonBar.buttonData="YES" onAction="#once"/>
+				<Button text="%updateReminder.yesAutomatically" ButtonBar.buttonData="YES" defaultButton="true" onAction="#automatically" />
+			</buttons>
+		</ButtonBar>
+		</VBox>
+	</children>
+</HBox>

--- a/src/main/resources/fxml/update_reminder.fxml
+++ b/src/main/resources/fxml/update_reminder.fxml
@@ -11,8 +11,8 @@
 <HBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
 	  fx:controller="org.cryptomator.ui.updatereminder.UpdateReminderController"
-	  minWidth="450"
-	  maxWidth="450"
+	  minWidth="550"
+	  maxWidth="550"
 	  minHeight="145"
 	  spacing="12"
 	  alignment="TOP_LEFT">

--- a/src/main/resources/fxml/update_reminder.fxml
+++ b/src/main/resources/fxml/update_reminder.fxml
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.layout.*?>
-<?import javafx.scene.control.ButtonBar?>
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.Group?>
-<?import javafx.scene.shape.Circle?>
 <?import org.cryptomator.ui.controls.FontAwesome5IconView?>
-<?import javafx.scene.control.Label?>
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
+<?import javafx.scene.control.ButtonBar?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.Group?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.shape.Circle?>
 <HBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
 	  fx:controller="org.cryptomator.ui.updatereminder.UpdateReminderController"
@@ -22,33 +25,33 @@
 	<children>
 		<VBox>
 			<HBox>
-			<Group>
-				<StackPane>
-					<padding>
-						<Insets topRightBottomLeft="6"/>
-					</padding>
-					<Circle styleClass="glyph-icon-primary" radius="24"/>
-					<FontAwesome5IconView styleClass="glyph-icon-white" glyph="QUESTION" glyphSize="24"/>
-				</StackPane>
-			</Group>
+				<Group>
+					<StackPane>
+						<padding>
+							<Insets topRightBottomLeft="6"/>
+						</padding>
+						<Circle styleClass="glyph-icon-primary" radius="24"/>
+						<FontAwesome5IconView styleClass="glyph-icon-white" glyph="QUESTION" glyphSize="24"/>
+					</StackPane>
+				</Group>
 
-		<VBox HBox.hgrow="ALWAYS">
-			<Label styleClass="label-large" text="%updateReminder.title" wrapText="true">
-				<padding>
-					<Insets bottom="6" top="6"/>
-				</padding>
-			</Label>
-			<Label text="%updateReminder.message" wrapText="true"/>
-			<Region VBox.vgrow="ALWAYS" minHeight="18"/>
-		</VBox>
-		</HBox>
-		<ButtonBar buttonMinWidth="120" buttonOrder="CY">
-			<buttons>
-				<Button text="%updateReminder.notNow" ButtonBar.buttonData="CANCEL_CLOSE" cancelButton="true" onAction="#cancel"/>
-				<Button text="%updateReminder.yesOnce" ButtonBar.buttonData="YES" onAction="#once"/>
-				<Button text="%updateReminder.yesAutomatically" ButtonBar.buttonData="YES" defaultButton="true" onAction="#automatically" />
-			</buttons>
-		</ButtonBar>
+				<VBox HBox.hgrow="ALWAYS">
+					<Label styleClass="label-large" text="%updateReminder.title" wrapText="true">
+						<padding>
+							<Insets bottom="6" top="6"/>
+						</padding>
+					</Label>
+					<Label text="%updateReminder.message" wrapText="true"/>
+					<Region VBox.vgrow="ALWAYS" minHeight="18"/>
+				</VBox>
+			</HBox>
+			<ButtonBar buttonMinWidth="120" buttonOrder="CY">
+				<buttons>
+					<Button text="%updateReminder.notNow" ButtonBar.buttonData="CANCEL_CLOSE" cancelButton="true" onAction="#cancel"/>
+					<Button text="%updateReminder.yesOnce" ButtonBar.buttonData="YES" onAction="#once"/>
+					<Button text="%updateReminder.yesAutomatically" ButtonBar.buttonData="YES" defaultButton="true" onAction="#automatically"/>
+				</buttons>
+			</ButtonBar>
 		</VBox>
 	</children>
 </HBox>

--- a/src/main/resources/fxml/update_reminder.fxml
+++ b/src/main/resources/fxml/update_reminder.fxml
@@ -36,12 +36,12 @@
 				</Group>
 
 				<VBox HBox.hgrow="ALWAYS">
-					<Label styleClass="label-large" text="%updateReminder.title" wrapText="true">
+					<Label styleClass="label-large" text="%updateReminder.message" wrapText="true">
 						<padding>
 							<Insets bottom="6" top="6"/>
 						</padding>
 					</Label>
-					<Label text="%updateReminder.message" wrapText="true"/>
+					<Label text="%updateReminder.description" wrapText="true"/>
 					<Region VBox.vgrow="ALWAYS" minHeight="18"/>
 				</VBox>
 			</HBox>

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -493,3 +493,9 @@ quit.lockAndQuitBtn=Lock and Quit
 quit.forced.message=Some vaults could not be locked
 quit.forced.description=Locking vaults was blocked by pending operations or open files. You can force lock remaining vaults, however interrupting I/O may result in the loss of unsaved data.
 quit.forced.forceAndQuitBtn=Force and Quit
+# Update Reminder
+updateReminder.title=Check for Updates?
+updateReminder.message=Would you like Cryptomator to check whether an update is available?
+updateReminder.notNow=Not now
+updateReminder.yesOnce=Yes, once
+updateReminder.yesAutomatically=Yes, automatically

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -497,6 +497,6 @@ quit.forced.forceAndQuitBtn=Force and Quit
 updateReminder.windowTitle=Update Check Reminder
 updateReminder.title=Check for Updates?
 updateReminder.message=Cryptomator can automatically check for updates. This is useful to get notified about new features and security updates. You can change this later in the preferences.
-updateReminder.notNow=Not now
+updateReminder.notNow=Ask Me Later
 updateReminder.yesOnce=Check Now Once
 updateReminder.yesAutomatically=Enable Update Checker

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -499,10 +499,11 @@ quit.lockAndQuitBtn=Lock and Quit
 quit.forced.message=Some vaults could not be locked
 quit.forced.description=Locking vaults was blocked by pending operations or open files. You can force lock remaining vaults, however interrupting I/O may result in the loss of unsaved data.
 quit.forced.forceAndQuitBtn=Force and Quit
+
 # Update Reminder
-updateReminder.windowTitle=Update Check Reminder
-updateReminder.title=Check for Updates?
-updateReminder.message=Cryptomator can automatically check for updates. This is useful to get notified about new features and security updates. You can change this later in the preferences.
-updateReminder.notNow=Ask Me Later
-updateReminder.yesOnce=Check Now Once
-updateReminder.yesAutomatically=Enable Update Checker
+updateReminder.title=Update Check
+updateReminder.message=Check for Updates?
+updateReminder.description=Stay updated with new features, bug fixes, and security improvements. We recommend to automatically check for updates.
+updateReminder.notNow=Not Now
+updateReminder.yesOnce=Yes, Once
+updateReminder.yesAutomatically=Yes, Automatically

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -494,8 +494,9 @@ quit.forced.message=Some vaults could not be locked
 quit.forced.description=Locking vaults was blocked by pending operations or open files. You can force lock remaining vaults, however interrupting I/O may result in the loss of unsaved data.
 quit.forced.forceAndQuitBtn=Force and Quit
 # Update Reminder
+updateReminder.windowTitle=Update Check Reminder
 updateReminder.title=Check for Updates?
-updateReminder.message=Would you like Cryptomator to check whether an update is available?
+updateReminder.message=Cryptomator can automatically check for updates. This is useful to get notified about new features and security updates. You can change this later in the preferences.
 updateReminder.notNow=Not now
-updateReminder.yesOnce=Yes, once
-updateReminder.yesAutomatically=Yes, automatically
+updateReminder.yesOnce=Check Now Once
+updateReminder.yesAutomatically=Enable Update Checker


### PR DESCRIPTION
This pull request addresses issue #2984. 

When the "Check for updates automatically" option is disabled in the Preferences, a dialog will be displayed upon application startup.

The "Not now" button sets the new setting value "lastUpdateCheck" to the current date. This ensures that the dialog will not be displayed again for 14 days.

The "Yes, Once" button also sets the current date in the setting value "lastUpdateCheck" and performs an update check.

The "Yes, Automatically" button sets the current date in the setting value "lastUpdateCheck" and also performs an update check. Additionally, this button sets the "checkForUpdates" value to true in the settings, which triggers an update check at every application startup.

Please refer to the attached screenshot for the added dialog.

Screenshot:
![Bildschirmfoto 2023-07-20 um 11 35 38](https://github.com/cryptomator/cryptomator/assets/29817198/8d012113-f159-4a8f-8032-d4762fddbfc6)

