### PR TITLE
Reset position when out of display bounds

### DIFF
--- a/src/main/java/org/cryptomator/common/settings/Settings.java
+++ b/src/main/java/org/cryptomator/common/settings/Settings.java
@@ -65,7 +65,6 @@ public class Settings {
 	public final IntegerProperty windowYPosition;
 	public final IntegerProperty windowWidth;
 	public final IntegerProperty windowHeight;
-	public final StringProperty displayConfiguration;
 	public final StringProperty language;
 	public final StringProperty mountService;
 	public final StringProperty lastUpdateCheck;
@@ -103,7 +102,6 @@ public class Settings {
 		this.windowYPosition = new SimpleIntegerProperty(this, "windowYPosition", json.windowYPosition);
 		this.windowWidth = new SimpleIntegerProperty(this, "windowWidth", json.windowWidth);
 		this.windowHeight = new SimpleIntegerProperty(this, "windowHeight", json.windowHeight);
-		this.displayConfiguration = new SimpleStringProperty(this, "displayConfiguration", json.displayConfiguration);
 		this.language = new SimpleStringProperty(this, "language", json.language);
 		this.mountService = new SimpleStringProperty(this, "mountService", json.mountService);
 		this.lastUpdateCheck = new SimpleStringProperty(this, "lastUpdateCheck", json.lastUpdateCheck);
@@ -131,7 +129,6 @@ public class Settings {
 		windowYPosition.addListener(this::somethingChanged);
 		windowWidth.addListener(this::somethingChanged);
 		windowHeight.addListener(this::somethingChanged);
-		displayConfiguration.addListener(this::somethingChanged);
 		language.addListener(this::somethingChanged);
 		mountService.addListener(this::somethingChanged);
 		lastUpdateCheck.addListener(this::somethingChanged);
@@ -186,7 +183,6 @@ public class Settings {
 		json.windowYPosition = windowYPosition.get();
 		json.windowWidth = windowWidth.get();
 		json.windowHeight = windowHeight.get();
-		json.displayConfiguration = displayConfiguration.get();
 		json.language = language.get();
 		json.mountService = mountService.get();
 		json.lastUpdateCheck = lastUpdateCheck.get();

--- a/src/main/java/org/cryptomator/common/settings/SettingsJson.java
+++ b/src/main/java/org/cryptomator/common/settings/SettingsJson.java
@@ -31,9 +31,6 @@ class SettingsJson {
 	@JsonProperty("theme")
 	UiTheme theme = Settings.DEFAULT_THEME;
 
-	@JsonProperty("displayConfiguration")
-	String displayConfiguration;
-
 	@JsonProperty("keychainProvider")
 	String keychainProvider = Settings.DEFAULT_KEYCHAIN_PROVIDER;
 

--- a/src/main/java/org/cryptomator/ui/mainwindow/ResizeController.java
+++ b/src/main/java/org/cryptomator/ui/mainwindow/ResizeController.java
@@ -6,7 +6,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
@@ -54,40 +53,18 @@ public class ResizeController implements FxController {
 	public void initialize() {
 		LOG.trace("init ResizeController");
 
-		if (neverTouched()) {
-			settings.displayConfiguration.set(getMonitorSizes());
-			return;
-		} else {
-			if (didDisplayConfigurationChange() || !isWithinDisplayBounds()) {
-				// If the position is illegal, then the window appears on the main screen in the middle of the window.
-				Rectangle2D primaryScreenBounds = Screen.getPrimary().getBounds();
-				window.setX((primaryScreenBounds.getWidth() - window.getMinWidth()) / 2);
-				window.setY((primaryScreenBounds.getHeight() - window.getMinHeight()) / 2);
-				window.setWidth(window.getMinWidth());
-				window.setHeight(window.getMinHeight());
-			} else {
-				window.setHeight(settings.windowHeight.get() > window.getMinHeight() ? settings.windowHeight.get() : window.getMinHeight());
-				window.setWidth(settings.windowWidth.get() > window.getMinWidth() ? settings.windowWidth.get() : window.getMinWidth());
-				window.setX(settings.windowXPosition.get());
-				window.setY(settings.windowYPosition.get());
-			}
+		if (!neverTouched()) {
+			window.setHeight(settings.windowHeight.get() > window.getMinHeight() ? settings.windowHeight.get() : window.getMinHeight());
+			window.setWidth(settings.windowWidth.get() > window.getMinWidth() ? settings.windowWidth.get() : window.getMinWidth());
+			window.setX(settings.windowXPosition.get());
+			window.setY(settings.windowYPosition.get());
 		}
 
 		window.setOnShowing(this::checkDisplayBounds);
-
-		savePositionalSettings();
 	}
 
 	private boolean neverTouched() {
 		return (settings.windowHeight.get() == 0) && (settings.windowWidth.get() == 0) && (settings.windowXPosition.get() == 0) && (settings.windowYPosition.get() == 0);
-	}
-
-	private boolean didDisplayConfigurationChange() {
-		String currentDisplayConfiguration = getMonitorSizes();
-		String settingsDisplayConfiguration = settings.displayConfiguration.get();
-		boolean configurationHasChanged = !settingsDisplayConfiguration.equals(currentDisplayConfiguration);
-		if (configurationHasChanged) settings.displayConfiguration.set(currentDisplayConfiguration);
-		return configurationHasChanged;
 	}
 
 	private boolean isWithinDisplayBounds() {
@@ -129,17 +106,6 @@ public class ResizeController implements FxController {
 			window.setHeight(window.getMinHeight());
 			savePositionalSettings();
 		}
-	}
-
-	private String getMonitorSizes() {
-		ObservableList<Screen> screens = Screen.getScreens();
-		StringBuilder sb = new StringBuilder();
-		for (int i = 0; i < screens.size(); i++) {
-			Rectangle2D screenBounds = screens.get(i).getBounds();
-			if (!sb.isEmpty()) sb.append(" ");
-			sb.append("displayId: " + i + ", " + screenBounds.getWidth() + "x" + screenBounds.getHeight() + ";");
-		}
-		return sb.toString();
 	}
 
 	private void startResize(MouseEvent evt) {

--- a/src/main/java/org/cryptomator/ui/mainwindow/ResizeController.java
+++ b/src/main/java/org/cryptomator/ui/mainwindow/ResizeController.java
@@ -15,6 +15,7 @@ import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Region;
 import javafx.stage.Screen;
 import javafx.stage.Stage;
+import javafx.stage.WindowEvent;
 
 @MainWindow
 public class ResizeController implements FxController {
@@ -71,6 +72,9 @@ public class ResizeController implements FxController {
 				window.setY(settings.windowYPosition.get());
 			}
 		}
+
+		window.setOnShowing(this::checkDisplayBounds);
+
 		savePositionalSettings();
 	}
 
@@ -113,6 +117,18 @@ public class ResizeController implements FxController {
 
 		// Within bounds if the visible area matches the window area
 		return visibleArea == windowArea;
+	}
+
+	private void checkDisplayBounds(WindowEvent evt) {
+		if (!isWithinDisplayBounds()) {
+			// If the position is illegal, then the window appears on the main screen in the middle of the window.
+			Rectangle2D primaryScreenBounds = Screen.getPrimary().getBounds();
+			window.setX((primaryScreenBounds.getWidth() - window.getMinWidth()) / 2);
+			window.setY((primaryScreenBounds.getHeight() - window.getMinHeight()) / 2);
+			window.setWidth(window.getMinWidth());
+			window.setHeight(window.getMinHeight());
+			savePositionalSettings();
+		}
 	}
 
 	private String getMonitorSizes() {
@@ -212,5 +228,4 @@ public class ResizeController implements FxController {
 	public boolean isShowResizingArrows() {
 		return showResizingArrows.get();
 	}
-
 }

--- a/src/main/java/org/cryptomator/ui/mainwindow/ResizeController.java
+++ b/src/main/java/org/cryptomator/ui/mainwindow/ResizeController.java
@@ -97,6 +97,17 @@ public class ResizeController implements FxController {
 	}
 
 	private void checkDisplayBounds(WindowEvent evt) {
+
+		// Minimizing a window in Windows and closing it could result in an out of bounds position at (x, y) = (-32000, -32000)
+		// See https://devblogs.microsoft.com/oldnewthing/20041028-00/?p=37453
+		// If the position is (-32000, -32000), restore to the last saved position
+		if (window.getX() == -32000 && window.getY() == -32000) {
+			window.setX(settings.windowXPosition.get());
+			window.setY(settings.windowYPosition.get());
+			window.setWidth(settings.windowWidth.get());
+			window.setHeight(settings.windowHeight.get());
+		}
+
 		if (!isWithinDisplayBounds()) {
 			// If the position is illegal, then the window appears on the main screen in the middle of the window.
 			Rectangle2D primaryScreenBounds = Screen.getPrimary().getBounds();


### PR DESCRIPTION
If the main window is stuck at a display that is no longer attached then the user cannot use the Cryptomator main window, even after restarting. This PR ensures that the position of the window is reset to the primary display after restarting Cryptomator. This happens only if the position stored in `settings.json` is out of display bounds. This PR is related to #3003 and prevents the need for workarounds.

The method `isOutOfDisplayBounds()` checks for each edge of the main window if it is out of bounds. If one of them is out of bounds then the window is reset to the center of the primary display. Or in other words, if a single pixel is out of bounds then the window gets reset.