### PR TITLE
CI: Use Temurin JVM+JFX Jmods from Gluon instead of Zulu JVM+FX

### DIFF
--- a/.github/workflows/mac-dmg.yml
+++ b/.github/workflows/mac-dmg.yml
@@ -31,7 +31,7 @@ jobs:
           output-suffix: x64
           xcode-path: '/Applications/Xcode_13.2.1.app'
           fuse-lib: macFUSE
-          openjfx-url: https://download2.gluonhq.com/openjfx/20.0.1/openjfx-20.0.1_osx-aarch64_bin-jmods.zip
+          openjfx-url: https://download2.gluonhq.com/openjfx/20.0.1/openjfx-20.0.1_osx-x64_bin-jmods.zip
           openjfx-sha: 4fcd4bc3cd0edeb899108109e42a0c5a2d87d14a195d11199060862eb6d887b5
         - os: [self-hosted, macOS, ARM64]
           architecture: aarch64
@@ -54,7 +54,7 @@ jobs:
         id: download-jmods
         run: |
           curl -L ${{ matrix.openjfx-url }} -o openjfx-jmods.zip
-          echo "${{ matrix.openjfx-sha }} openjfx-jmods.zip" | sha256sum --check
+          echo "${{ matrix.openjfx-sha }} *openjfx-jmods.zip" | shasum -a256 --check
           mkdir -p openjfx-jmods/
           unzip -j openjfx-jmods.zip \*/javafx.base.jmod \*/javafx.controls.jmod \*/javafx.fxml.jmod \*/javafx.graphics.jmod -d openjfx-jmods
       - name: Ensure major jfx version in pom and in jmods is the same

--- a/.github/workflows/mac-dmg.yml
+++ b/.github/workflows/mac-dmg.yml
@@ -31,11 +31,15 @@ jobs:
           output-suffix: x64
           xcode-path: '/Applications/Xcode_13.2.1.app'
           fuse-lib: macFUSE
+          openjfx-url: https://download2.gluonhq.com/openjfx/20.0.1/openjfx-20.0.1_osx-aarch64_bin-jmods.zip
+          openjfx-sha: 4fcd4bc3cd0edeb899108109e42a0c5a2d87d14a195d11199060862eb6d887b5
         - os: [self-hosted, macOS, ARM64]
           architecture: aarch64
           output-suffix: arm64
           xcode-path: '/Applications/Xcode_13.2.1.app'
           fuse-lib: FUSE-T
+          openjfx-url: https://download2.gluonhq.com/openjfx/20.0.1/openjfx-20.0.1_osx-aarch64_bin-jmods.zip
+          openjfx-sha: e7e99e6dc3d091e7e1c6940d8e1acc282f22b82b234a20ae7cbec4b93a6acabe
     steps:
       - uses: actions/checkout@v3
       - name: Setup Java
@@ -49,11 +53,10 @@ jobs:
       - name: Download OpenJFX jmods
         id: download-jmods
         run: |
-          curl -L ${{ env.OPENJFX_JMODS_URL }} -o openjfx-jmods.zip
+          curl -L ${{ matrix.openjfx-url }} -o openjfx-jmods.zip
+          echo "${{ matrix.openjfx-sha }} openjfx-jmods.zip" | sha256sum --check
           mkdir -p openjfx-jmods/
           unzip -j openjfx-jmods.zip \*/javafx.base.jmod \*/javafx.controls.jmod \*/javafx.fxml.jmod \*/javafx.graphics.jmod -d openjfx-jmods
-        env:
-          OPENJFX_JMODS_URL: 'https://download2.gluonhq.com/openjfx/20.0.1/openjfx-20.0.1_osx-${{ matrix.architecture }}_bin-jmods.zip'
       - name: Ensure major jfx version in pom and in jmods is the same
         run: |
           JMOD_VERSION=$(jmod describe openjfx-jmods/javafx.base.jmod | head -1)

--- a/.github/workflows/mac-dmg.yml
+++ b/.github/workflows/mac-dmg.yml
@@ -80,7 +80,7 @@ jobs:
           ${JAVA_HOME}/bin/jlink
           --verbose
           --output runtime
-          --module-path "${JAVA_HOME}/jmods"
+          --module-path "${JAVA_HOME}/jmods:openjfx-jmods"
           --add-modules java.base,java.desktop,java.instrument,java.logging,java.naming,java.net.http,java.scripting,java.sql,java.xml,javafx.base,javafx.graphics,javafx.controls,javafx.fxml,jdk.unsupported,jdk.crypto.ec,jdk.accessibility,jdk.management.jfr
           --strip-native-commands
           --no-header-files

--- a/.github/workflows/mac-dmg.yml
+++ b/.github/workflows/mac-dmg.yml
@@ -41,21 +41,32 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
-          java-package: 'jdk+fx'
+          java-package: 'jdk'
           architecture: ${{ matrix.architecture }}
           cache: 'maven'
-      - name: Ensure major jfx version in pom equals in jdk
-        if: ${{ !contains(matrix.os, 'self-hosted') }}
-        shell: pwsh
+      - name: Download OpenJFX jmods
+        id: download-jmods
         run: |
-          $jfxPomVersion = (&mvn help:evaluate "-Dexpression=javafx.version" -q -DforceStdout) -split "\."
-          $jfxJdkVersion = ((Get-Content -path "${env:JAVA_HOME}/lib/javafx.properties" | Where-Object {$_ -like 'javafx.version=*' }) -replace '.*=','') -split "\."
-          if ($jfxPomVersion[0] -ne $jfxJdkVersion[0]) {
-            Write-Error "Major part of JavaFX version in pom($($jfxPomVersion[0])) does not match the version in JDK($($jfxJdkVersion[0])) "
+          curl -L ${{ env.OPENJFX_JMODS_URL }} -o openjfx-jmods.zip
+          mkdir -p openjfx-jmods/
+          unzip -j openjfx-jmods.zip \*/javafx.base.jmod \*/javafx.controls.jmod \*/javafx.fxml.jmod \*/javafx.graphics.jmod -d openjfx-jmods
+        env:
+          OPENJFX_JMODS_URL: 'https://download2.gluonhq.com/openjfx/20.0.1/openjfx-20.0.1_osx-${{ matrix.architecture }}_bin-jmods.zip'
+      - name: Ensure major jfx version in pom and in jmods is the same
+        run: |
+          JMOD_VERSION=$(jmod describe openjfx-jmods/javafx.base.jmod | head -1)
+          JMOD_VERSION=${JMOD_VERSION#*@}
+          JMOD_VERSION=${JMOD_VERSION%%.*}
+          POM_JFX_VERSION=$(mvn help:evaluate "-Dexpression=javafx.version" -q -DforceStdout)
+          POM_JFX_VERSION=${POM_JFX_VERSION#*@}
+          POM_JFX_VERSION=${POM_JFX_VERSION%%.*}
+
+          if [ $POM_JFX_VERSION -ne $JMOD_VERSION ]; then
+            >&2 echo "Major JavaFX version in pom.xml (${POM_JFX_VERSION}) != jmod version (${JMOD_VERSION_AMD64})"
             exit 1
-          }
+          fi
       - name: Set version
         run : mvn versions:set -DnewVersion=${{ needs.get-version.outputs.semVerStr }}
       - name: Run maven

--- a/dist/mac/dmg/build.sh
+++ b/dist/mac/dmg/build.sh
@@ -47,10 +47,10 @@ if [ -n "${CODESIGN_IDENTITY}" ]; then
 fi
 
 # download and check jmods
-curl -L ${{ env.OPENJFX_JMODS }} -o openjfx.zip
+curl -L ${OPENJFX_JMODS} -o openjfx-jmods.zip
 mkdir -p openjfx-jmods/
 unzip -j openjfx-jmods.zip \*/javafx.base.jmod \*/javafx.controls.jmod \*/javafx.fxml.jmod \*/javafx.graphics.jmod -d openjfx-jmods/
-JMOD_VERSION=$(jmod describe jmods/amd64/javafx.base.jmod | head -1)
+JMOD_VERSION=$(jmod describe openjfx-jmods/javafx.base.jmod | head -1)
 JMOD_VERSION=${JMOD_VERSION#*@}
 JMOD_VERSION=${JMOD_VERSION%%.*}
 POM_JFX_VERSION=$(mvn help:evaluate "-Dexpression=javafx.version" -q -DforceStdout)

--- a/dist/mac/dmg/build.sh
+++ b/dist/mac/dmg/build.sh
@@ -29,6 +29,14 @@ REVISION_NO=`git rev-list --count HEAD`
 VERSION_NO=`mvn -f../../../pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout | sed -rn 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p'`
 FUSE_LIB="FUSE-T"
 
+ARCH="undefined"
+if [ "$(machine)" = "arm64e" ]; then
+    ARCH="aarch64"
+else
+    ARCH="x64"
+fi
+OPENJFX_JMODS="https://download2.gluonhq.com/openjfx/20.0.1/openjfx-20.0.1_linux-${ARCH}_bin-jmods.zip"
+
 # check preconditions
 if [ -z "${JAVA_HOME}" ]; then echo "JAVA_HOME not set. Run using JAVA_HOME=/path/to/jdk ./build.sh"; exit 1; fi
 command -v mvn >/dev/null 2>&1 || { echo >&2 "mvn not found. Fix by 'brew install maven'."; exit 1; }
@@ -38,6 +46,22 @@ if [ -n "${CODESIGN_IDENTITY}" ]; then
     if [[ ! `security find-identity -v -p codesigning | grep -w "${CODESIGN_IDENTITY}"` ]]; then echo "Given codesign identity is invalid."; exit 1; fi
 fi
 
+# download and check jmods
+curl -L ${{ env.OPENJFX_JMODS }} -o openjfx.zip
+mkdir -p openjfx-jmods/
+unzip -j openjfx-jmods.zip \*/javafx.base.jmod \*/javafx.controls.jmod \*/javafx.fxml.jmod \*/javafx.graphics.jmod -d openjfx-jmods/
+JMOD_VERSION=$(jmod describe jmods/amd64/javafx.base.jmod | head -1)
+JMOD_VERSION=${JMOD_VERSION#*@}
+JMOD_VERSION=${JMOD_VERSION%%.*}
+POM_JFX_VERSION=$(mvn help:evaluate "-Dexpression=javafx.version" -q -DforceStdout)
+POM_JFX_VERSION=${POM_JFX_VERSION#*@}
+POM_JFX_VERSION=${POM_JFX_VERSION%%.*}
+
+if [ $POM_JFX_VERSION -ne $JMOD_VERSION ]; then
+>&2 echo "Major JavaFX version in pom.xml (${POM_JFX_VERSION}) != jmod version (${JMOD_VERSION})"
+exit 1
+fi
+
 # compile
 mvn -B -f../../../pom.xml clean package -DskipTests -Pmac
 cp ../../../target/${MAIN_JAR_GLOB} ../../../target/mods
@@ -45,8 +69,8 @@ cp ../../../target/${MAIN_JAR_GLOB} ../../../target/mods
 # add runtime
 ${JAVA_HOME}/bin/jlink \
     --output runtime \
-    --module-path "${JAVA_HOME}/jmods" \
-    --add-modules java.base,java.desktop,java.instrument,java.logging,java.naming,java.net.http,java.scripting,java.sql,java.xml,jdk.unsupported,jdk.crypto.ec,jdk.accessibility,jdk.management.jfr \
+    --module-path "${JAVA_HOME}/jmods:openjfx-jmods" \
+    --add-modules java.base,java.desktop,java.instrument,java.logging,java.naming,java.net.http,java.scripting,java.sql,java.xml,javafx.base,javafx.graphics,javafx.controls,javafx.fxml,jdk.unsupported,jdk.crypto.ec,jdk.security.auth,jdk.accessibility,jdk.management.jfr \
     --strip-native-commands \
     --no-header-files \
     --no-man-pages \


### PR DESCRIPTION
Fixes #3030.

This PR replaces in the CI script the Zulu JVM+FX by Temurin JVM and downloads in a seperate step JFX jmods from Gluon. Additionally, the local build script is adjusted to work out-of-the-box again by also adding a step downloading the jmods.