### PR TITLE
Change error codes URL

### DIFF
--- a/src/main/java/org/cryptomator/ui/error/ErrorController.java
+++ b/src/main/java/org/cryptomator/ui/error/ErrorController.java
@@ -42,7 +42,7 @@ public class ErrorController implements FxController {
 
 	private static final ObjectMapper JSON = new ObjectMapper();
 	private static final Logger LOG = LoggerFactory.getLogger(ErrorController.class);
-	private static final String ERROR_CODES_URL = "https://gist.githubusercontent.com/cryptobot/accba9fb9555e7192271b85606f97230/raw/errorcodes.json";
+	private static final String ERROR_CODES_URL = "https://api.cryptomator.org/desktop/error-codes.json";
 	private static final String SEARCH_URL_FORMAT = "https://github.com/cryptomator/cryptomator/discussions/categories/errors?discussions_q=category:Errors+%s";
 	private static final String REPORT_URL_FORMAT = "https://github.com/cryptomator/cryptomator/discussions/new?category=Errors&title=Error+%s&body=%s";
 	private static final String SEARCH_ERRORCODE_DELIM = " OR ";


### PR DESCRIPTION
When things go wrong, we don't always want to leak user IPs to GitHub, so we now use our proxy instead.