### PR TITLE
Enhance user agent string when downloading error code database

### DIFF
--- a/src/main/java/org/cryptomator/ui/error/ErrorController.java
+++ b/src/main/java/org/cryptomator/ui/error/ErrorController.java
@@ -2,6 +2,7 @@ package org.cryptomator.ui.error;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.SystemUtils;
 import org.cryptomator.common.Environment;
 import org.cryptomator.common.ErrorCode;
 import org.cryptomator.common.Nullable;
@@ -42,7 +43,7 @@ public class ErrorController implements FxController {
 
 	private static final ObjectMapper JSON = new ObjectMapper();
 	private static final Logger LOG = LoggerFactory.getLogger(ErrorController.class);
-	private static final String USER_AGENT_VERSION_FORMAT = "Cryptomator/%s (Build %s)";
+	private static final String USER_AGENT_VERSION_FORMAT = "Cryptomator/%s (Build %s) %s %s (%s)";
 	private static final String ERROR_CODES_URL_FORMAT = "https://api.cryptomator.org/desktop/error-codes.json?error-code=%s";
 	private static final String SEARCH_URL_FORMAT = "https://github.com/cryptomator/cryptomator/discussions/categories/errors?discussions_q=category:Errors+%s";
 	private static final String REPORT_URL_FORMAT = "https://github.com/cryptomator/cryptomator/discussions/new?category=Errors&title=Error+%s&body=%s";
@@ -143,11 +144,17 @@ public class ErrorController implements FxController {
 
 	@FXML
 	public void lookUpSolution() {
+		String userAgent = USER_AGENT_VERSION_FORMAT.formatted( //
+				environment.getAppVersion(), //
+				environment.getBuildNumber().orElse("undefined"), //
+				SystemUtils.OS_NAME, //
+				SystemUtils.OS_VERSION, //
+				SystemUtils.OS_ARCH); //
 		isLoadingHttpResponse.set(true);
 		askedForLookupDatabasePermission.set(true);
 		HttpClient httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
 		HttpRequest httpRequest = HttpRequest.newBuilder()//
-				.header("User-Agent", USER_AGENT_VERSION_FORMAT.formatted(environment.getAppVersion(),environment.getBuildNumber().orElse("undefined")))
+				.header("User-Agent", userAgent)
 				.uri(URI.create(ERROR_CODES_URL_FORMAT.formatted(URLEncoder.encode(errorCode.toString(),StandardCharsets.UTF_8))))//
 				.build();
 		httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofInputStream())//

--- a/src/main/java/org/cryptomator/ui/error/ErrorController.java
+++ b/src/main/java/org/cryptomator/ui/error/ErrorController.java
@@ -43,7 +43,7 @@ public class ErrorController implements FxController {
 
 	private static final ObjectMapper JSON = new ObjectMapper();
 	private static final Logger LOG = LoggerFactory.getLogger(ErrorController.class);
-	private static final String USER_AGENT_VERSION_FORMAT = "Cryptomator/%s (Build %s) %s %s (%s)";
+	private static final String USER_AGENT_FORMAT = "Cryptomator/%s (Build %s) (%s %s %s)";
 	private static final String ERROR_CODES_URL_FORMAT = "https://api.cryptomator.org/desktop/error-codes.json?error-code=%s";
 	private static final String SEARCH_URL_FORMAT = "https://github.com/cryptomator/cryptomator/discussions/categories/errors?discussions_q=category:Errors+%s";
 	private static final String REPORT_URL_FORMAT = "https://github.com/cryptomator/cryptomator/discussions/new?category=Errors&title=Error+%s&body=%s";
@@ -144,7 +144,7 @@ public class ErrorController implements FxController {
 
 	@FXML
 	public void lookUpSolution() {
-		String userAgent = USER_AGENT_VERSION_FORMAT.formatted( //
+		String userAgent = USER_AGENT_FORMAT.formatted( //
 				environment.getAppVersion(), //
 				environment.getBuildNumber().orElse("undefined"), //
 				SystemUtils.OS_NAME, //

--- a/src/main/java/org/cryptomator/ui/error/ErrorController.java
+++ b/src/main/java/org/cryptomator/ui/error/ErrorController.java
@@ -146,7 +146,7 @@ public class ErrorController implements FxController {
 		askedForLookupDatabasePermission.set(true);
 		HttpClient httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
 		HttpRequest httpRequest = HttpRequest.newBuilder()//
-				.uri(URI.create(ERROR_CODES_URL.formatted(errorCode.toString())))//
+				.uri(URI.create(ERROR_CODES_URL.formatted(URLEncoder.encode(errorCode.toString(),StandardCharsets.UTF_8))))//
 				.build();
 		httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofInputStream())//
 				.thenAcceptAsync(this::loadHttpResponse, executorService)//

--- a/src/main/java/org/cryptomator/ui/error/ErrorController.java
+++ b/src/main/java/org/cryptomator/ui/error/ErrorController.java
@@ -6,7 +6,6 @@ import org.cryptomator.common.Environment;
 import org.cryptomator.common.ErrorCode;
 import org.cryptomator.common.Nullable;
 import org.cryptomator.ui.common.FxController;
-import org.cryptomator.ui.fxapp.UpdateChecker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,7 +68,6 @@ public class ErrorController implements FxController {
 	private final Stage window;
 	private final Environment environment;
 	private final ExecutorService executorService;
-	private final UpdateChecker updateChecker;
 
 	private final BooleanProperty copiedDetails = new SimpleBooleanProperty();
 	private final ObjectProperty<ErrorDiscussion> matchingErrorDiscussion = new SimpleObjectProperty<>();
@@ -78,7 +76,7 @@ public class ErrorController implements FxController {
 	private final BooleanProperty askedForLookupDatabasePermission = new SimpleBooleanProperty();
 
 	@Inject
-	ErrorController(Application application, @Named("stackTrace") String stackTrace, ErrorCode errorCode, @Nullable Scene previousScene, Stage window, Environment environment, ExecutorService executorService, UpdateChecker updateChecker) {
+	ErrorController(Application application, @Named("stackTrace") String stackTrace, ErrorCode errorCode, @Nullable Scene previousScene, Stage window, Environment environment, ExecutorService executorService) {
 		this.application = application;
 		this.stackTrace = stackTrace;
 		this.errorCode = errorCode;
@@ -86,7 +84,6 @@ public class ErrorController implements FxController {
 		this.window = window;
 		this.environment = environment;
 		this.executorService = executorService;
-		this.updateChecker = updateChecker;
 	}
 
 	@FXML
@@ -150,7 +147,7 @@ public class ErrorController implements FxController {
 		askedForLookupDatabasePermission.set(true);
 		HttpClient httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
 		HttpRequest httpRequest = HttpRequest.newBuilder()//
-				.header("User-Agent", USER_AGENT_VERSION_FORMAT.formatted(updateChecker.getCurrentVersion()))
+				.header("User-Agent", USER_AGENT_VERSION_FORMAT.formatted(environment.getAppVersion()))
 				.uri(URI.create(ERROR_CODES_URL_FORMAT.formatted(URLEncoder.encode(errorCode.toString(),StandardCharsets.UTF_8))))//
 				.build();
 		httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofInputStream())//

--- a/src/main/java/org/cryptomator/ui/error/ErrorController.java
+++ b/src/main/java/org/cryptomator/ui/error/ErrorController.java
@@ -2,7 +2,6 @@ package org.cryptomator.ui.error;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.lang3.SystemUtils;
 import org.cryptomator.common.Environment;
 import org.cryptomator.common.ErrorCode;
 import org.cryptomator.common.Nullable;
@@ -147,9 +146,9 @@ public class ErrorController implements FxController {
 		String userAgent = USER_AGENT_FORMAT.formatted( //
 				environment.getAppVersion(), //
 				environment.getBuildNumber().orElse("undefined"), //
-				SystemUtils.OS_NAME, //
-				SystemUtils.OS_VERSION, //
-				SystemUtils.OS_ARCH); //
+				System.getProperty("os.name"), //
+				System.getProperty("os.version"), //
+				System.getProperty("os.arch"));
 		isLoadingHttpResponse.set(true);
 		askedForLookupDatabasePermission.set(true);
 		HttpClient httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();

--- a/src/main/java/org/cryptomator/ui/error/ErrorController.java
+++ b/src/main/java/org/cryptomator/ui/error/ErrorController.java
@@ -42,7 +42,7 @@ public class ErrorController implements FxController {
 
 	private static final ObjectMapper JSON = new ObjectMapper();
 	private static final Logger LOG = LoggerFactory.getLogger(ErrorController.class);
-	private static final String ERROR_CODES_URL = "https://api.cryptomator.org/desktop/error-codes.json";
+	private static final String ERROR_CODES_URL = "https://api.cryptomator.org/desktop/error-codes.json?error-code=%s";
 	private static final String SEARCH_URL_FORMAT = "https://github.com/cryptomator/cryptomator/discussions/categories/errors?discussions_q=category:Errors+%s";
 	private static final String REPORT_URL_FORMAT = "https://github.com/cryptomator/cryptomator/discussions/new?category=Errors&title=Error+%s&body=%s";
 	private static final String SEARCH_ERRORCODE_DELIM = " OR ";
@@ -146,7 +146,7 @@ public class ErrorController implements FxController {
 		askedForLookupDatabasePermission.set(true);
 		HttpClient httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
 		HttpRequest httpRequest = HttpRequest.newBuilder()//
-				.uri(URI.create(ERROR_CODES_URL))//
+				.uri(URI.create(ERROR_CODES_URL.formatted(errorCode.toString())))//
 				.build();
 		httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofInputStream())//
 				.thenAcceptAsync(this::loadHttpResponse, executorService)//

--- a/src/main/java/org/cryptomator/ui/error/ErrorController.java
+++ b/src/main/java/org/cryptomator/ui/error/ErrorController.java
@@ -42,7 +42,7 @@ public class ErrorController implements FxController {
 
 	private static final ObjectMapper JSON = new ObjectMapper();
 	private static final Logger LOG = LoggerFactory.getLogger(ErrorController.class);
-	private static final String USER_AGENT_VERSION_FORMAT = "Cryptomator/%s";
+	private static final String USER_AGENT_VERSION_FORMAT = "Cryptomator/%s (Build %s)";
 	private static final String ERROR_CODES_URL_FORMAT = "https://api.cryptomator.org/desktop/error-codes.json?error-code=%s";
 	private static final String SEARCH_URL_FORMAT = "https://github.com/cryptomator/cryptomator/discussions/categories/errors?discussions_q=category:Errors+%s";
 	private static final String REPORT_URL_FORMAT = "https://github.com/cryptomator/cryptomator/discussions/new?category=Errors&title=Error+%s&body=%s";
@@ -147,7 +147,7 @@ public class ErrorController implements FxController {
 		askedForLookupDatabasePermission.set(true);
 		HttpClient httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
 		HttpRequest httpRequest = HttpRequest.newBuilder()//
-				.header("User-Agent", USER_AGENT_VERSION_FORMAT.formatted(environment.getAppVersion()))
+				.header("User-Agent", USER_AGENT_VERSION_FORMAT.formatted(environment.getAppVersion(),environment.getBuildNumber().orElse("undefined")))
 				.uri(URI.create(ERROR_CODES_URL_FORMAT.formatted(URLEncoder.encode(errorCode.toString(),StandardCharsets.UTF_8))))//
 				.build();
 		httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofInputStream())//


### PR DESCRIPTION
As an addition to Issue [#3060](https://github.com/cryptomator/cryptomator/pull/3060), this pull request extends the HTTP request to api.cryptomator.org/desktop/error-codes.json by adding the 'error-code' parameter with the current error code as follows:
`api.cryptomator.org/desktop/error-codes.json?error-code=####%3A####%3A####`

Furthermore, we've added a 'User-Agent' header to the HTTP request, including the product version, build flavor, os, os version and cpu architecture.