### PR TITLE
Disable Update Check

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -97,7 +97,8 @@ jobs:
         run: |
           cp -r dist/linux/debian/ pkgdir
           export RFC2822_TIMESTAMP=`date --rfc-2822`
-          envsubst '${SEMVER_STR} ${VERSION_NUM} ${REVISION_NUM}' < dist/linux/debian/rules > pkgdir/debian/rules
+          export DISABLE_UPDATE_CHECK=${{ inputs.dput }}
+          envsubst '${SEMVER_STR} ${VERSION_NUM} ${REVISION_NUM} ${DISABLE_UPDATE_CHECK}' < dist/linux/debian/rules > pkgdir/debian/rules
           envsubst '${PPA_VERSION} ${RFC2822_TIMESTAMP}' < dist/linux/debian/changelog > pkgdir/debian/changelog
           find . -name "*.jar" >> pkgdir/debian/source/include-binaries
           mv pkgdir cryptomator_${{ inputs.ppaver }}

--- a/dist/linux/debian/rules
+++ b/dist/linux/debian/rules
@@ -59,6 +59,7 @@ override_dh_auto_build:
 		--java-options "-Dcryptomator.integrationsLinux.trayIconsDir=\"/usr/share/icons/hicolor/symbolic/apps\"" \
 		--java-options "-Dcryptomator.buildNumber=\"deb-${REVISION_NUM}\"" \
 		--java-options "-Dcryptomator.appVersion=\"${SEMVER_STR}\"" \
+		--java-options "-Dcryptomator.disableUpdateCheck=\"${DISABLE_UPDATE_CHECK}\"" \
 		--app-version "${VERSION_NUM}.${REVISION_NUM}" \
 		--resource-dir resources \
 		--verbose

--- a/src/main/java/org/cryptomator/common/Environment.java
+++ b/src/main/java/org/cryptomator/common/Environment.java
@@ -32,6 +32,7 @@ public class Environment {
 	private static final String BUILD_NUMBER_PROP_NAME = "cryptomator.buildNumber";
 	private static final String PLUGIN_DIR_PROP_NAME = "cryptomator.pluginDir";
 	private static final String TRAY_ICON_PROP_NAME = "cryptomator.showTrayIcon";
+	private static final String DISABLE_UPDATE_CHECK_PROP_NAME = "cryptomator.disableUpdateCheck";
 
 	private Environment() {}
 
@@ -53,6 +54,7 @@ public class Environment {
 		logCryptomatorSystemProperty(BUILD_NUMBER_PROP_NAME);
 		logCryptomatorSystemProperty(PLUGIN_DIR_PROP_NAME);
 		logCryptomatorSystemProperty(TRAY_ICON_PROP_NAME);
+		logCryptomatorSystemProperty(DISABLE_UPDATE_CHECK_PROP_NAME);
 	}
 
 	public static Environment getInstance() {
@@ -122,6 +124,10 @@ public class Environment {
 
 	public boolean showTrayIcon() {
 		return Boolean.getBoolean(TRAY_ICON_PROP_NAME);
+	}
+
+	public boolean disableUpdateCheck() {
+		return Boolean.getBoolean(DISABLE_UPDATE_CHECK_PROP_NAME);
 	}
 
 	private Optional<Path> getPath(String propertyName) {

--- a/src/main/java/org/cryptomator/ui/fxapp/FxApplication.java
+++ b/src/main/java/org/cryptomator/ui/fxapp/FxApplication.java
@@ -1,6 +1,7 @@
 package org.cryptomator.ui.fxapp;
 
 import dagger.Lazy;
+import org.cryptomator.common.Environment;
 import org.cryptomator.common.settings.Settings;
 import org.cryptomator.ui.traymenu.TrayMenuComponent;
 import org.slf4j.Logger;
@@ -17,6 +18,7 @@ public class FxApplication {
 	private static final Logger LOG = LoggerFactory.getLogger(FxApplication.class);
 
 	private final long startupTime;
+	private final Environment environment;
 	private final Settings settings;
 	private final AppLaunchEventHandler launchEventHandler;
 	private final Lazy<TrayMenuComponent> trayMenu;
@@ -26,8 +28,9 @@ public class FxApplication {
 	private final AutoUnlocker autoUnlocker;
 
 	@Inject
-	FxApplication(@Named("startupTime") long startupTime, Settings settings, AppLaunchEventHandler launchEventHandler, Lazy<TrayMenuComponent> trayMenu, FxApplicationWindows appWindows, FxApplicationStyle applicationStyle, FxApplicationTerminator applicationTerminator, AutoUnlocker autoUnlocker) {
+	FxApplication(@Named("startupTime") long startupTime, Environment environment, Settings settings, AppLaunchEventHandler launchEventHandler, Lazy<TrayMenuComponent> trayMenu, FxApplicationWindows appWindows, FxApplicationStyle applicationStyle, FxApplicationTerminator applicationTerminator, AutoUnlocker autoUnlocker) {
 		this.startupTime = startupTime;
+		this.environment = environment;
 		this.settings = settings;
 		this.launchEventHandler = launchEventHandler;
 		this.trayMenu = trayMenu;
@@ -68,7 +71,9 @@ public class FxApplication {
 			return null;
 		});
 
-		appWindows.checkAndShowUpdateReminderWindow();
+		if (!environment.disableUpdateCheck()) {
+			appWindows.checkAndShowUpdateReminderWindow();
+		}
 
 		launchEventHandler.startHandlingLaunchEvents();
 		autoUnlocker.tryUnlockForTimespan(2, TimeUnit.MINUTES);

--- a/src/main/java/org/cryptomator/ui/preferences/PreferencesController.java
+++ b/src/main/java/org/cryptomator/ui/preferences/PreferencesController.java
@@ -1,5 +1,6 @@
 package org.cryptomator.ui.preferences;
 
+import org.cryptomator.common.Environment;
 import org.cryptomator.ui.common.FxController;
 import org.cryptomator.ui.fxapp.UpdateChecker;
 import org.slf4j.Logger;
@@ -19,6 +20,7 @@ public class PreferencesController implements FxController {
 
 	private static final Logger LOG = LoggerFactory.getLogger(PreferencesController.class);
 
+	private final Environment env;
 	private final Stage window;
 	private final ObjectProperty<SelectedPreferencesTab> selectedTabProperty;
 	private final BooleanBinding updateAvailable;
@@ -31,7 +33,8 @@ public class PreferencesController implements FxController {
 	public Tab aboutTab;
 
 	@Inject
-	public PreferencesController(@PreferencesWindow Stage window, ObjectProperty<SelectedPreferencesTab> selectedTabProperty, UpdateChecker updateChecker) {
+	public PreferencesController(Environment env, @PreferencesWindow Stage window, ObjectProperty<SelectedPreferencesTab> selectedTabProperty, UpdateChecker updateChecker) {
+		this.env = env;
 		this.window = window;
 		this.selectedTabProperty = selectedTabProperty;
 		this.updateAvailable = updateChecker.latestVersionProperty().isNotNull();
@@ -42,6 +45,9 @@ public class PreferencesController implements FxController {
 		window.setOnShowing(this::windowWillAppear);
 		selectedTabProperty.addListener(observable -> this.selectChosenTab());
 		tabPane.getSelectionModel().selectedItemProperty().addListener(observable -> this.selectedTabChanged());
+		if (env.disableUpdateCheck()) {
+			tabPane.getTabs().remove(updatesTab);
+		}
 	}
 
 	private void selectChosenTab() {


### PR DESCRIPTION
This adds a new system property `cryptomator.disableUpdateCheck` which (when set) will

* disable version checks
* disable the update reminder (#2998)
* removes the updates tab from the preferences window

Furthermore, it sets this property for PPA builds, as updates will be handled externally via `apt`.

fixes #3117