### PR TITLE
Improve AppImage build script

### DIFF
--- a/dist/linux/appimage/build.sh
+++ b/dist/linux/appimage/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 cd $(dirname $0)
 REVISION_NO=`git rev-list --count HEAD`
@@ -10,6 +11,7 @@ command -v curl >/dev/null 2>&1 || { echo >&2 "curl not found."; exit 1; }
 
 VERSION=$(mvn -f ../../../pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
 SEMVER_STR=${VERSION}
+MACHINE_TYPE=$(uname -m)
 
 mvn -f ../../../pom.xml versions:set -DnewVersion=${SEMVER_STR}
 
@@ -83,17 +85,17 @@ ln -s usr/share/applications/org.cryptomator.Cryptomator.desktop Cryptomator.App
 ln -s bin/cryptomator.sh Cryptomator.AppDir/AppRun
 
 # load AppImageTool
-curl -L https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage -o /tmp/appimagetool.AppImage
+curl -L https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-${MACHINE_TYPE}.AppImage -o /tmp/appimagetool.AppImage
 chmod +x /tmp/appimagetool.AppImage
 
 # create AppImage
 /tmp/appimagetool.AppImage \
     Cryptomator.AppDir \
-    cryptomator-${SEMVER_STR}-x86_64.AppImage  \
-    -u 'gh-releases-zsync|cryptomator|cryptomator|latest|cryptomator-*-x86_64.AppImage.zsync'
+    cryptomator-${SEMVER_STR}-${MACHINE_TYPE}.AppImage  \
+    -u 'gh-releases-zsync|cryptomator|cryptomator|latest|cryptomator-*-${MACHINE_TYPE}.AppImage.zsync'
 
 echo ""
-echo "Done. AppImage successfully created: cryptomator-${SEMVER_STR}-x86_64.AppImage"
+echo "Done. AppImage successfully created: cryptomator-${SEMVER_STR}-${MACHINE_TYPE}.AppImage"
 echo ""
 echo >&2 "To clean up, run: rm -rf Cryptomator.AppDir appdir jni runtime squashfs-root; rm launcher-gtk2.properties /tmp/appimagetool.AppImage"
 echo ""


### PR DESCRIPTION
These are the changes:
- follow up of https://github.com/cryptomator/cryptomator/issues/3102: Build for aarch64 too; the script determines the architecture and builds, considering the architecture
- added `set -e` at the top, that causes the script to stop on an error instead of continuing; this makes it easier to find errors, once the script is running, and it now only shows _success_ at the end, when the AppImage truly was built