### PR TITLE
Propagate deleted discussions to the error database

### DIFF
--- a/.github/workflows/error-db.yml
+++ b/.github/workflows/error-db.yml
@@ -12,6 +12,7 @@ jobs:
     if: github.event.discussion.category.name == 'Errors'
     steps:
       - name: Query Discussion Data
+        if: github.event_name == 'discussion_comment' || github.event_name == 'discussion' && github.event.action != 'deleted'
         id: query-data
         uses: actions/github-script@v6
         with:
@@ -47,8 +48,13 @@ jobs:
       - name: Merge Error Code Data
         run: |
           jq -c '.' ${{ steps.get-gist.outputs.file }} > original.json
-          echo $DISCUSSION | jq -c '.repository.discussion | .comments = .comments.totalCount | {(.id|tostring) : .}' > new.json
-          jq -s '.[0] * .[1]' original.json new.json > merged.json
+          if [ ! -z "$DISCUSSION" ]
+          then
+            echo $DISCUSSION | jq -c '.repository.discussion | .comments = .comments.totalCount | {(.id|tostring) : .}' > new.json
+            jq -s '.[0] * .[1]' original.json new.json > merged.json
+          else
+            cat original.json | jq 'del(.[] | select(.url=="https://github.com/cryptomator/cryptomator/discussions/${{ github.event.discussion.number }}"))' > merged.json
+          fi
         env:
           DISCUSSION: ${{ steps.query-data.outputs.result }}
       - name: Patch Gist


### PR DESCRIPTION
When we delete a discussion, it is not currently propagated against the error database, which means that Cryptomator thinks there is a solution to a problem, but when it is opened in GitHub it shows a 404.

https://github.com/cryptomator/cryptomator/commit/109f5d1faa1057884445ed16f0b9c16d54dfe845 was not enough to fix this, because the query against the discussion repo simply fails because the entry does not exists anymore.

This PR implements the deletion of the discussion to be propagated against the error database.