### PR TITLE
Feature: Double click on a vault in the list to unlock it

### DIFF
--- a/src/main/java/org/cryptomator/ui/mainwindow/VaultListController.java
+++ b/src/main/java/org/cryptomator/ui/mainwindow/VaultListController.java
@@ -7,6 +7,7 @@ import org.cryptomator.cryptofs.CryptoFileSystemProvider;
 import org.cryptomator.cryptofs.DirStructure;
 import org.cryptomator.ui.addvaultwizard.AddVaultWizardComponent;
 import org.cryptomator.ui.common.FxController;
+import org.cryptomator.ui.fxapp.FxApplicationWindows;
 import org.cryptomator.ui.removevault.RemoveVaultComponent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,6 +65,7 @@ public class VaultListController implements FxController {
 	private final VaultListManager vaultListManager;
 	private final BooleanProperty draggingVaultOver = new SimpleBooleanProperty();
 	private final ResourceBundle resourceBundle;
+	private final FxApplicationWindows appWindows;
 
 	public ListView<Vault> vaultList;
 	public StackPane root;
@@ -79,7 +81,8 @@ public class VaultListController implements FxController {
 						AddVaultWizardComponent.Builder addVaultWizard, //
 						RemoveVaultComponent.Builder removeVaultDialogue, //
 						VaultListManager vaultListManager, //
-						ResourceBundle resourceBundle) {
+						ResourceBundle resourceBundle, //
+						FxApplicationWindows appWindows) {
 		this.mainWindow = mainWindow;
 		this.vaults = vaults;
 		this.selectedVault = selectedVault;
@@ -88,6 +91,7 @@ public class VaultListController implements FxController {
 		this.removeVaultDialogue = removeVaultDialogue;
 		this.vaultListManager = vaultListManager;
 		this.resourceBundle = resourceBundle;
+		this.appWindows = appWindows;
 
 		this.emptyVaultList = Bindings.isEmpty(vaults);
 
@@ -107,6 +111,18 @@ public class VaultListController implements FxController {
 			}
 		});
 		vaultList.addEventFilter(MouseEvent.MOUSE_RELEASED, this::deselect);
+
+		//toggle selected vault lock status on double click
+		vaultList.addEventFilter(MouseEvent.MOUSE_CLICKED, click -> {
+			if (click.getClickCount() >= 2 && selectedVault.get() != null) {
+				if (selectedVault.get().isLocked()) {
+					appWindows.startUnlockWorkflow(selectedVault.get(), mainWindow);
+				}
+				if (selectedVault.get().isUnlocked()) {
+					appWindows.startLockWorkflow(selectedVault.get(), mainWindow);
+				}
+			}
+		});
 
 		//don't show context menu when no vault selected
 		vaultList.addEventFilter(ContextMenuEvent.CONTEXT_MENU_REQUESTED, request -> {

--- a/src/main/java/org/cryptomator/ui/mainwindow/VaultListController.java
+++ b/src/main/java/org/cryptomator/ui/mainwindow/VaultListController.java
@@ -173,12 +173,12 @@ public class VaultListController implements FxController {
 		}
 	}
 
-	private void toggleVaultLockStatus(Vault selectedVault) {
-		if (selectedVault.isLocked()) {
-			appWindows.startUnlockWorkflow(selectedVault, mainWindow);
+	private void toggleVaultLockStatus(Vault vault) {
+		if (vault.isLocked()) {
+			appWindows.startUnlockWorkflow(vault, mainWindow);
 		}
-		if (selectedVault.isUnlocked()) {
-			appWindows.startLockWorkflow(selectedVault, mainWindow);
+		if (vault.isUnlocked()) {
+			appWindows.startLockWorkflow(vault, mainWindow);
 		}
 	}
 

--- a/src/main/java/org/cryptomator/ui/mainwindow/VaultListController.java
+++ b/src/main/java/org/cryptomator/ui/mainwindow/VaultListController.java
@@ -113,10 +113,12 @@ public class VaultListController implements FxController {
 		});
 		vaultList.addEventFilter(MouseEvent.MOUSE_RELEASED, this::deselect);
 
-		//toggle selected vault lock status on double click
+		//unlock vault on double click
 		vaultList.addEventFilter(MouseEvent.MOUSE_CLICKED, click -> {
 			if (click.getClickCount() >= 2) {
-				Optional.ofNullable(selectedVault.get()).ifPresent(this::toggleVaultLockStatus);
+				Optional.ofNullable(selectedVault.get())
+						.filter(Vault::isLocked)
+						.ifPresent(vault -> appWindows.startUnlockWorkflow(vault, mainWindow));
 			}
 		});
 
@@ -170,15 +172,6 @@ public class VaultListController implements FxController {
 		if (released.getY() > (vaultList.getItems().size() * vaultList.fixedCellSizeProperty().get())) {
 			vaultList.getSelectionModel().clearSelection();
 			released.consume();
-		}
-	}
-
-	private void toggleVaultLockStatus(Vault vault) {
-		if (vault.isLocked()) {
-			appWindows.startUnlockWorkflow(vault, mainWindow);
-		}
-		if (vault.isUnlocked()) {
-			appWindows.startLockWorkflow(vault, mainWindow);
 		}
 	}
 

--- a/src/main/java/org/cryptomator/ui/mainwindow/VaultListController.java
+++ b/src/main/java/org/cryptomator/ui/mainwindow/VaultListController.java
@@ -38,6 +38,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.EnumSet;
+import java.util.Optional;
 import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -114,13 +115,8 @@ public class VaultListController implements FxController {
 
 		//toggle selected vault lock status on double click
 		vaultList.addEventFilter(MouseEvent.MOUSE_CLICKED, click -> {
-			if (click.getClickCount() >= 2 && selectedVault.get() != null) {
-				if (selectedVault.get().isLocked()) {
-					appWindows.startUnlockWorkflow(selectedVault.get(), mainWindow);
-				}
-				if (selectedVault.get().isUnlocked()) {
-					appWindows.startLockWorkflow(selectedVault.get(), mainWindow);
-				}
+			if (click.getClickCount() >= 2) {
+				Optional.ofNullable(selectedVault.get()).ifPresent(this::toggleVaultLockStatus);
 			}
 		});
 
@@ -174,6 +170,15 @@ public class VaultListController implements FxController {
 		if (released.getY() > (vaultList.getItems().size() * vaultList.fixedCellSizeProperty().get())) {
 			vaultList.getSelectionModel().clearSelection();
 			released.consume();
+		}
+	}
+
+	private void toggleVaultLockStatus(Vault selectedVault) {
+		if (selectedVault.isLocked()) {
+			appWindows.startUnlockWorkflow(selectedVault, mainWindow);
+		}
+		if (selectedVault.isUnlocked()) {
+			appWindows.startLockWorkflow(selectedVault, mainWindow);
 		}
 	}
 


### PR DESCRIPTION
Closes #3155 : Toggle vault lock status by double-clicking on it on the vault list of the main window.

![java_rgpEm3sPxq](https://github.com/cryptomator/cryptomator/assets/26577763/9dd4f527-10c0-4f7e-ba66-2d32fbd57e6f)

PS: I tried to do idiomatic and clean code, don't hesitate to ask for changes if needed