### PR TITLE
Feature: Load LocationPresets in background and show indicator in UI

### DIFF
--- a/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
+++ b/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
@@ -150,10 +150,13 @@ public class CreateNewVaultLocationController implements FxController {
 
 	private void loadLocationPresets() {
 		Platform.runLater(() -> loadingPresetLocations.set(true));
-		LocationPresetsProvider.loadAll(LocationPresetsProvider.class) //
-				.flatMap(LocationPresetsProvider::getLocations) //we do not use sorted(), because it evaluates the stream elements, blocking until all elements are gathered
-				.forEach(this::createRadioButtonFor);
-		Platform.runLater(() -> loadingPresetLocations.set(false));
+		try{
+			LocationPresetsProvider.loadAll(LocationPresetsProvider.class) //
+					.flatMap(LocationPresetsProvider::getLocations) //we do not use sorted(), because it evaluates the stream elements, blocking until all elements are gathered
+					.forEach(this::createRadioButtonFor);
+		} finally {
+			Platform.runLater(() -> loadingPresetLocations.set(false));
+		}
 	}
 
 	private void createRadioButtonFor(LocationPreset preset) {

--- a/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
+++ b/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
@@ -165,13 +165,13 @@ public class CreateNewVaultLocationController implements FxController {
 		});
 	}
 
-	private int compareLocationPresets(Node n1, Node n2) {
-		if (customLocationRadioBtn.getId().equals(n1.getId())) {
+	private int compareLocationPresets(Node left, Node right) {
+		if (customLocationRadioBtn.getId().equals(left.getId())) {
 			return 1;
-		} else if (customLocationRadioBtn.getId().equals(n2.getId())) {
+		} else if (customLocationRadioBtn.getId().equals(right.getId())) {
 			return -1;
 		} else {
-			return ((RadioButton) n1).getText().compareToIgnoreCase(((RadioButton) n2).getText());
+			return ((RadioButton) left).getText().compareToIgnoreCase(((RadioButton) right).getText());
 		}
 	}
 

--- a/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
+++ b/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
@@ -148,6 +148,8 @@ public class CreateNewVaultLocationController implements FxController {
 	}
 
 	private void createRadioButtonFor(LocationPreset preset) {
+		assert !radioButtonVBox.getChildren().isEmpty();
+
 		Platform.runLater(() -> {
 			var btn = new RadioButton(preset.name());
 			btn.setUserData(preset.path());
@@ -155,9 +157,7 @@ public class CreateNewVaultLocationController implements FxController {
 			//in place sorting
 			var vboxElements = radioButtonVBox.getChildren();
 			boolean added = false;
-			int listIndex = 0; //first item of vbox is the list header
-			while (listIndex < vboxElements.size()) {
-				listIndex++;
+			for (int listIndex = 0; listIndex < vboxElements.size(); listIndex++) {
 				if (vboxElements.get(listIndex) instanceof RadioButton rb) {
 					//another radio button
 					if (rb.getText().compareTo(preset.name()) > 0) {
@@ -165,13 +165,11 @@ public class CreateNewVaultLocationController implements FxController {
 						added = true;
 						break;
 					}
-				} else {
-					//end of all radiobuttons
-					break;
 				}
 			}
+
 			if (!added) {
-				vboxElements.add(listIndex, btn);
+				vboxElements.add(vboxElements.size() - 1, btn); //last element is always the custom location btn
 			}
 
 			locationPresetsToggler.getToggles().add(btn);

--- a/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
+++ b/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
@@ -131,7 +131,16 @@ public class CreateNewVaultLocationController implements FxController {
 
 	@FXML
 	public void initialize() {
-		backgroundExecutor.submit(this::loadLocationPresets);
+		var task = backgroundExecutor.submit(this::loadLocationPresets);
+		var onHiddenAction = window.getOnHidden();
+		if(onHiddenAction != null) {
+			window.setOnHidden(evt -> {
+				task.cancel(true);
+				onHiddenAction.handle(evt);
+			});
+		} else {
+			window.setOnHidden(_ -> task.cancel(true));
+		}
 		locationPresetsToggler.selectedToggleProperty().addListener(this::togglePredefinedLocation);
 		usePresetPath.bind(locationPresetsToggler.selectedToggleProperty().isNotEqualTo(customRadioButton));
 	}

--- a/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
+++ b/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
@@ -21,6 +21,7 @@ import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.StringProperty;
 import javafx.beans.value.ObservableValue;
 import javafx.fxml.FXML;
+
 import javafx.scene.Scene;
 import javafx.scene.control.Label;
 import javafx.scene.control.RadioButton;
@@ -29,6 +30,7 @@ import javafx.scene.control.ToggleGroup;
 import javafx.scene.layout.VBox;
 import javafx.stage.DirectoryChooser;
 import javafx.stage.Stage;
+import javafx.stage.WindowEvent;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;

--- a/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
+++ b/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
@@ -132,15 +132,7 @@ public class CreateNewVaultLocationController implements FxController {
 	@FXML
 	public void initialize() {
 		var task = backgroundExecutor.submit(this::loadLocationPresets);
-		var onHiddenAction = window.getOnHidden();
-		if(onHiddenAction != null) {
-			window.setOnHidden(evt -> {
-				task.cancel(true);
-				onHiddenAction.handle(evt);
-			});
-		} else {
-			window.setOnHidden(_ -> task.cancel(true));
-		}
+		window.addEventHandler(WindowEvent.WINDOW_HIDING, _ -> task.cancel(true));
 		locationPresetsToggler.selectedToggleProperty().addListener(this::togglePredefinedLocation);
 		usePresetPath.bind(locationPresetsToggler.selectedToggleProperty().isNotEqualTo(customRadioButton));
 	}

--- a/src/main/resources/fxml/addvault_new_location.fxml
+++ b/src/main/resources/fxml/addvault_new_location.fxml
@@ -11,6 +11,7 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.VBox?>
+<?import org.cryptomator.ui.controls.FontAwesome5Spinner?>
 <VBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
 	  fx:controller="org.cryptomator.ui.addvaultwizard.CreateNewVaultLocationController"
@@ -40,6 +41,11 @@
 					</graphic>
 				</Button>
 			</HBox>
+			<Label wrapText="true" text="Checking local filesystem for default cloud storage directories..." visible="${controller.loadingPresetLocations}" managed="${controller.loadingPresetLocations}">
+				<graphic>
+					<FontAwesome5Spinner />
+				</graphic>
+			</Label>
 		</VBox>
 
 		<Region prefHeight="12" VBox.vgrow="NEVER"/>

--- a/src/main/resources/fxml/addvault_new_location.fxml
+++ b/src/main/resources/fxml/addvault_new_location.fxml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import org.cryptomator.ui.controls.FontAwesome5IconView?>
+<?import org.cryptomator.ui.controls.FontAwesome5Spinner?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.ButtonBar?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.RadioButton?>
+<?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.control.ToggleGroup?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.VBox?>
-<?import org.cryptomator.ui.controls.FontAwesome5Spinner?>
-<?import javafx.scene.layout.StackPane?>
 <VBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
 	  fx:controller="org.cryptomator.ui.addvaultwizard.CreateNewVaultLocationController"
@@ -31,24 +31,26 @@
 	<children>
 		<Region VBox.vgrow="ALWAYS"/>
 
-		<VBox fx:id="radioButtonVBox" spacing="6">
-			<Label wrapText="true" text="%addvaultwizard.new.locationInstruction"/>
-			<!-- PLACEHOLDER, more radio buttons are added programmatically via controller -->
-			<HBox spacing="12" alignment="CENTER_LEFT">
-				<RadioButton fx:id="customRadioButton" toggleGroup="${locationPresetsToggler}" text="%addvaultwizard.new.directoryPickerLabel"/>
-				<Button contentDisplay="LEFT" text="%addvaultwizard.new.directoryPickerButton" onAction="#chooseCustomVaultPath" disable="${controller.usePresetPath}">
-					<graphic>
-						<FontAwesome5IconView glyph="FOLDER_OPEN"/>
-					</graphic>
-				</Button>
-			</HBox>
-			<Region prefHeight="2"/>
-			<Label wrapText="true" text="%addvaultwizard.new.locationLoading" visible="${controller.loadingPresetLocations}" managed="${controller.loadingPresetLocations}" graphicTextGap="8">
-				<graphic>
-					<FontAwesome5Spinner />
-				</graphic>
-			</Label>
-		</VBox>
+		<Label wrapText="true" text="%addvaultwizard.new.locationInstruction"/>
+		<ScrollPane hbarPolicy="NEVER">
+			<VBox fx:id="radioButtonVBox" spacing="6">
+				<!-- PLACEHOLDER, more radio buttons are added programmatically via controller -->
+				<HBox spacing="12" alignment="CENTER_LEFT">
+					<RadioButton fx:id="customRadioButton" toggleGroup="${locationPresetsToggler}" text="%addvaultwizard.new.directoryPickerLabel"/>
+					<Button contentDisplay="LEFT" text="%addvaultwizard.new.directoryPickerButton" onAction="#chooseCustomVaultPath" disable="${controller.usePresetPath}">
+						<graphic>
+							<FontAwesome5IconView glyph="FOLDER_OPEN"/>
+						</graphic>
+					</Button>
+				</HBox>
+			</VBox>
+		</ScrollPane>
+		<Region prefHeight="2"/>
+		<Label wrapText="true" text="%addvaultwizard.new.locationLoading" visible="${controller.loadingPresetLocations}" managed="${controller.loadingPresetLocations}" graphicTextGap="8">
+			<graphic>
+				<FontAwesome5Spinner/>
+			</graphic>
+		</Label>
 
 		<Region prefHeight="12" VBox.vgrow="NEVER"/>
 

--- a/src/main/resources/fxml/addvault_new_location.fxml
+++ b/src/main/resources/fxml/addvault_new_location.fxml
@@ -12,6 +12,7 @@
 <?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.VBox?>
 <?import org.cryptomator.ui.controls.FontAwesome5Spinner?>
+<?import javafx.scene.layout.StackPane?>
 <VBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
 	  fx:controller="org.cryptomator.ui.addvaultwizard.CreateNewVaultLocationController"
@@ -41,7 +42,8 @@
 					</graphic>
 				</Button>
 			</HBox>
-			<Label wrapText="true" text="Checking local filesystem for default cloud storage directories..." visible="${controller.loadingPresetLocations}" managed="${controller.loadingPresetLocations}">
+			<Region prefHeight="2"/>
+			<Label wrapText="true" text="%addvaultwizard.new.locationLoading" visible="${controller.loadingPresetLocations}" managed="${controller.loadingPresetLocations}" graphicTextGap="8">
 				<graphic>
 					<FontAwesome5Spinner />
 				</graphic>

--- a/src/main/resources/fxml/addvault_new_location.fxml
+++ b/src/main/resources/fxml/addvault_new_location.fxml
@@ -35,7 +35,7 @@
 		<ScrollPane hbarPolicy="NEVER">
 			<VBox fx:id="radioButtonVBox" spacing="6">
 				<!-- PLACEHOLDER, more radio buttons are added programmatically via controller -->
-				<HBox spacing="12" alignment="CENTER_LEFT">
+				<HBox fx:id="customLocationRadioBtn" spacing="12" alignment="CENTER_LEFT">
 					<RadioButton fx:id="customRadioButton" toggleGroup="${locationPresetsToggler}" text="%addvaultwizard.new.directoryPickerLabel"/>
 					<Button contentDisplay="LEFT" text="%addvaultwizard.new.directoryPickerButton" onAction="#chooseCustomVaultPath" disable="${controller.usePresetPath}">
 						<graphic>

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -48,6 +48,7 @@ addvaultwizard.new.nameInstruction=Choose a name for the vault
 addvaultwizard.new.namePrompt=Vault Name
 ### Location
 addvaultwizard.new.locationInstruction=Where should Cryptomator store the encrypted files of your vault?
+addvaultwizard.new.locationLoading=Checking local filesystem for default cloud storage directories…
 addvaultwizard.new.locationLabel=Storage location
 addvaultwizard.new.locationPrompt=…
 addvaultwizard.new.directoryPickerLabel=Custom location


### PR DESCRIPTION
Fixes #3233.

This PR moves the loading of LocationsPresets into a background task and making it a non-blocking operation. Even if a LocationPresetsProvider takes a long time, the "NewVaultLocation" screen is displayed. Additionally, a loading indicator is shown:
![grafik](https://github.com/cryptomator/cryptomator/assets/9036915/4d23b83c-c9ce-446c-96af-50051ae86801)

If the window is closed, the loading task is canceled. Additionally, the locations presets are put in a scrollpane, in case their number exceed the window.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced the vault creation wizard to include a loading indicator for better feedback during the search for default cloud storage directories.
- **Refactor**
	- Simplified the vault location selection interface for improved user experience.
- **Documentation**
	- Updated user interface text to reflect new loading behavior during vault setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->