### PR TITLE
Fixed "Locked Vault Options after unlocking vault #3249"

### DIFF
--- a/src/main/java/org/cryptomator/ui/fxapp/FxApplicationWindows.java
+++ b/src/main/java/org/cryptomator/ui/fxapp/FxApplicationWindows.java
@@ -135,17 +135,15 @@ public class FxApplicationWindows {
 	}
 
 	public CompletionStage<Void> startUnlockWorkflow(Vault vault, @Nullable Stage owner) {
-
-		//Check whether Vault options are open and close the window before unlocking it
-		for (Window theWindow : visibleWindows) {
-			Stage thestage = theWindow instanceof Stage ? ((Stage) theWindow) : null;
-			if (thestage != null && thestage.getTitle().equals(vault.getDisplayName())) {
-				thestage.close();
-				break;
-			}
-		}
-
 		return CompletableFuture.supplyAsync(() -> {
+					//Check whether Vault options are open and close the window before unlocking it
+					for (Window theWindow : visibleWindows) {
+						Stage thestage = theWindow instanceof Stage ? ((Stage) theWindow) : null;
+						if (thestage != null && thestage.getTitle().equals(vault.getDisplayName())) {
+							thestage.close();
+							break;
+						}
+					}
 					Preconditions.checkState(vault.stateProperty().transition(VaultState.Value.LOCKED, VaultState.Value.PROCESSING), "Vault not locked.");
 					LOG.debug("Start unlock workflow for {}", vault.getDisplayName());
 					return unlockWorkflowFactory.create(vault, owner).unlockWorkflow();

--- a/src/main/java/org/cryptomator/ui/fxapp/FxApplicationWindows.java
+++ b/src/main/java/org/cryptomator/ui/fxapp/FxApplicationWindows.java
@@ -135,6 +135,19 @@ public class FxApplicationWindows {
 	}
 
 	public CompletionStage<Void> startUnlockWorkflow(Vault vault, @Nullable Stage owner) {
+
+		//Check whether Vault options are open and close the window before unlocking it
+		if (!visibleWindows.isEmpty()) {
+			for (Window theWindow : visibleWindows) {
+				Stage thestage = theWindow instanceof Stage ? ((Stage) theWindow) : null;
+				if (thestage == null) continue;
+				if (thestage.getTitle().equals(vault.getDisplayName())) {
+					thestage.close();
+					break;
+				}
+			}
+		}
+
 		return CompletableFuture.supplyAsync(() -> {
 					Preconditions.checkState(vault.stateProperty().transition(VaultState.Value.LOCKED, VaultState.Value.PROCESSING), "Vault not locked.");
 					LOG.debug("Start unlock workflow for {}", vault.getDisplayName());

--- a/src/main/java/org/cryptomator/ui/fxapp/FxApplicationWindows.java
+++ b/src/main/java/org/cryptomator/ui/fxapp/FxApplicationWindows.java
@@ -136,14 +136,6 @@ public class FxApplicationWindows {
 
 	public CompletionStage<Void> startUnlockWorkflow(Vault vault, @Nullable Stage owner) {
 		return CompletableFuture.supplyAsync(() -> {
-					//Check whether Vault options are open and close the window before unlocking it
-					for (Window theWindow : visibleWindows) {
-						Stage thestage = theWindow instanceof Stage ? ((Stage) theWindow) : null;
-						if (thestage != null && thestage.getTitle().equals(vault.getDisplayName())) {
-							thestage.close();
-							break;
-						}
-					}
 					Preconditions.checkState(vault.stateProperty().transition(VaultState.Value.LOCKED, VaultState.Value.PROCESSING), "Vault not locked.");
 					LOG.debug("Start unlock workflow for {}", vault.getDisplayName());
 					return unlockWorkflowFactory.create(vault, owner).unlockWorkflow();

--- a/src/main/java/org/cryptomator/ui/fxapp/FxApplicationWindows.java
+++ b/src/main/java/org/cryptomator/ui/fxapp/FxApplicationWindows.java
@@ -137,14 +137,11 @@ public class FxApplicationWindows {
 	public CompletionStage<Void> startUnlockWorkflow(Vault vault, @Nullable Stage owner) {
 
 		//Check whether Vault options are open and close the window before unlocking it
-		if (!visibleWindows.isEmpty()) {
-			for (Window theWindow : visibleWindows) {
-				Stage thestage = theWindow instanceof Stage ? ((Stage) theWindow) : null;
-				if (thestage == null) continue;
-				if (thestage.getTitle().equals(vault.getDisplayName())) {
-					thestage.close();
-					break;
-				}
+		for (Window theWindow : visibleWindows) {
+			Stage thestage = theWindow instanceof Stage ? ((Stage) theWindow) : null;
+			if (thestage != null && thestage.getTitle().equals(vault.getDisplayName())) {
+				thestage.close();
+				break;
 			}
 		}
 

--- a/src/main/java/org/cryptomator/ui/vaultoptions/VaultOptionsController.java
+++ b/src/main/java/org/cryptomator/ui/vaultoptions/VaultOptionsController.java
@@ -1,6 +1,7 @@
 package org.cryptomator.ui.vaultoptions;
 
 import org.cryptomator.common.vaults.Vault;
+import org.cryptomator.common.vaults.VaultState;
 import org.cryptomator.ui.common.FxController;
 import org.cryptomator.ui.keyloading.hub.HubKeyLoadingStrategy;
 import org.cryptomator.ui.keyloading.masterkeyfile.MasterkeyFileLoadingStrategy;
@@ -48,6 +49,11 @@ public class VaultOptionsController implements FxController {
 		if(!(vaultScheme.equals(HubKeyLoadingStrategy.SCHEME_HUB_HTTP) || vaultScheme.equals(HubKeyLoadingStrategy.SCHEME_HUB_HTTPS))){
 			tabPane.getTabs().remove(hubTab);
 		}
+
+		// Fixes: https://github.com/cryptomator/cryptomator/pull/3267
+		vault.stateProperty().addListener(observable -> {
+			tabPane.setDisable(vault.getState().equals(VaultState.Value.UNLOCKED));
+		});
 	}
 
 	private void selectChosenTab() {

--- a/src/main/java/org/cryptomator/ui/vaultoptions/VaultOptionsController.java
+++ b/src/main/java/org/cryptomator/ui/vaultoptions/VaultOptionsController.java
@@ -50,7 +50,6 @@ public class VaultOptionsController implements FxController {
 			tabPane.getTabs().remove(hubTab);
 		}
 
-		// Fixes: https://github.com/cryptomator/cryptomator/pull/3267
 		vault.stateProperty().addListener(observable -> {
 			tabPane.setDisable(vault.getState().equals(VaultState.Value.UNLOCKED));
 		});


### PR DESCRIPTION
I fixed the issue: "Locked Vault Options after unlocking vault #3249". It searches for the visible windows and closes the stage with the same name as the vault.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Ensured that any open Vault options window is closed before starting the unlock process to prevent potential conflicts.
	- Modified `Preconditions` check to transition from `LOCKED` to `PROCESSING.

- **Refactor**
	- Introduced a new import for `VaultState`.
	- Added a listener to `vault.stateProperty()` to disable `tabPane` based on the vault state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->