### PR TITLE
Bump README's build dependency JDK version from 19 to 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ For more information on the security details visit [cryptomator.org](https://doc
 
 ### Dependencies
 
-* JDK 19 (e.g. temurin)
+* JDK 21 (e.g. temurin, zulu)
 * Maven 3
 
 ### Run Maven


### PR DESCRIPTION
This addresses #3277 . It is a one-line change in the README so that new devs won't trip over the same stone again.

I also noticed in commit 4043e3f71f9f2dd908814a54700ae0e52582e163 where the JDK bump happens, Zulu becomes the preferred flavor in GH actions env. Thus I have appended `zulu` to the JDK flavor example list as well.

## Testing done
- cryptomator develop branch, as of now, compiles fine with Zulu JDK 21 arm64:

```bash
brew tap mdogan/zulu
brew install zulu-jdk21
export JAVA_HOME="$(/usr/libexec/java_home -v 21)"
```

```bash
$ mvn -version     
Apache Maven 3.9.6 (bc0240f3c744dd6b6ec2920b3cd08dcc295161ae)
Maven home: /opt/homebrew/Cellar/maven/3.9.6/libexec
Java version: 21.0.1, vendor: Azul Systems, Inc., runtime: /Library/Java/JavaVirtualMachines/zulu-21.jdk/Contents/Home
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "14.2.1", arch: "aarch64", family: "mac"
```

```bash
$ mvn clean install
...
[INFO] --- install:3.1.1:install (default-install) @ cryptomator ---
[INFO] Installing /Users/u/fun/cryptomator/pom.xml to /Users/u/.m2/repository/org/cryptomator/cryptomator/1.12.0-SNAPSHOT/cryptomator-1.12.0-SNAPSHOT.pom
[INFO] Installing /Users/u/fun/cryptomator/target/cryptomator-1.12.0-SNAPSHOT.jar to /Users/u/.m2/repository/org/cryptomator/cryptomator/1.12.0-SNAPSHOT/cryptomator-1.12.0-SNAPSHOT.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  8.920 s
```

Pls kindly review. :)