### PR TITLE
Refactored Hub Unlock

### DIFF
--- a/src/main/java/org/cryptomator/ui/keyloading/hub/HubConfig.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/HubConfig.java
@@ -1,7 +1,6 @@
 package org.cryptomator.ui.keyloading.hub;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.net.URI;
@@ -19,6 +18,12 @@ public class HubConfig {
 	@Deprecated // use apiBaseUrl + "/devices/"
 	public String devicesResourceUrl;
 
+	/**
+	 * Get the URI pointing to the <code>/api/</code> base resource.
+	 *
+	 * @return <code>/api/</code> URI
+	 * @apiNote URI is guaranteed to end on <code>/</code>
+	 */
 	public URI getApiBaseUrl() {
 		if (apiBaseUrl != null) {
 			// make sure to end on "/":

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/ReceiveKeyController.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/ReceiveKeyController.java
@@ -178,7 +178,7 @@ public class ReceiveKeyController implements FxController {
 					var device = JSON.reader().readValue(response.body(), DeviceDto.class);
 					requestVaultMasterkey(device.userPrivateKey);
 				}
-				case 404 -> needsDeviceRegistration(); // TODO: using the setup code, we can theoretically immediately unlock
+				case 404 -> needsDeviceRegistration();
 				default -> throw new IllegalStateException("Unexpected response " + response.statusCode());
 			}
 		} catch (IOException e) {

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/ReceiveKeyController.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/ReceiveKeyController.java
@@ -78,7 +78,11 @@ public class ReceiveKeyController implements FxController {
 
 	@FXML
 	public void initialize() {
-		requestApiConfig(); // FIXME: only called once - need to restart after returning from register device
+		receiveKey();
+	}
+
+	public void receiveKey() {
+		requestApiConfig();
 	}
 
 	/**

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/ReceiveKeyController.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/ReceiveKeyController.java
@@ -62,7 +62,7 @@ public class ReceiveKeyController implements FxController {
 	public ReceiveKeyController(@KeyLoading Vault vault, ExecutorService executor, @KeyLoading Stage window, HubConfig hubConfig, @Named("deviceId") String deviceId, @Named("bearerToken") AtomicReference<String> tokenRef, CompletableFuture<ReceivedKey> result, @FxmlScene(FxmlFile.HUB_REGISTER_DEVICE) Lazy<Scene> registerDeviceScene, @FxmlScene(FxmlFile.HUB_LEGACY_REGISTER_DEVICE) Lazy<Scene> legacyRegisterDeviceScene, @FxmlScene(FxmlFile.HUB_UNAUTHORIZED_DEVICE) Lazy<Scene> unauthorizedScene, @FxmlScene(FxmlFile.HUB_REQUIRE_ACCOUNT_INIT) Lazy<Scene> accountInitializationScene, @FxmlScene(FxmlFile.HUB_INVALID_LICENSE) Lazy<Scene> invalidLicenseScene) {
 		this.window = window;
 		this.hubConfig = hubConfig;
-		this.vaultId = vault.getId();
+		this.vaultId = extractVaultId(vault.getVaultConfigCache().getUnchecked().getKeyId()); // TODO: access vault config's JTI directly (requires changes in cryptofs)
 		this.deviceId = deviceId;
 		this.bearerToken = Objects.requireNonNull(tokenRef.get());
 		this.result = result;
@@ -254,6 +254,12 @@ public class ReceiveKeyController implements FxController {
 		var path = template.interpolate();
 		var relPath = path.startsWith("/") ? path.substring(1) : path;
 		return hubConfig.getApiBaseUrl().resolve(relPath);
+	}
+
+	private static String extractVaultId(URI vaultKeyUri) {
+		assert vaultKeyUri.getScheme().startsWith(SCHEME_PREFIX);
+		var path = vaultKeyUri.getPath();
+		return path.substring(path.lastIndexOf('/') + 1);
 	}
 
 	@JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/RegisterSuccessController.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/RegisterSuccessController.java
@@ -1,24 +1,43 @@
 package org.cryptomator.ui.keyloading.hub;
 
+import dagger.Lazy;
 import org.cryptomator.ui.common.FxController;
+import org.cryptomator.ui.common.FxmlFile;
+import org.cryptomator.ui.common.FxmlScene;
 import org.cryptomator.ui.keyloading.KeyLoading;
 
 import javax.inject.Inject;
 import javafx.fxml.FXML;
+import javafx.scene.Scene;
 import javafx.stage.Stage;
+import javafx.stage.WindowEvent;
+import java.util.concurrent.CompletableFuture;
 
 public class RegisterSuccessController implements FxController {
 
 	private final Stage window;
+	private final CompletableFuture<ReceivedKey> result;
+	private final Lazy<Scene> receiveKeyScene;
+	private final ReceiveKeyController receiveKeyController;
 
 	@Inject
-	public RegisterSuccessController(@KeyLoading Stage window) {
+	public RegisterSuccessController(@KeyLoading Stage window, CompletableFuture<ReceivedKey> result, @FxmlScene(FxmlFile.HUB_RECEIVE_KEY) Lazy<Scene> receiveKeyScene, ReceiveKeyController receiveKeyController) {
 		this.window = window;
+		this.result = result;
+		this.receiveKeyScene = receiveKeyScene;
+		this.receiveKeyController = receiveKeyController;
+		this.window.addEventHandler(WindowEvent.WINDOW_HIDING, this::windowClosed);
 	}
 
 	@FXML
-	public void close() {
-		window.close();
+	public void complete() {
+		window.setScene(receiveKeyScene.get());
+		receiveKeyController.receiveKey();
 	}
+
+	private void windowClosed(WindowEvent windowEvent) {
+		result.cancel(true);
+	}
+
 
 }

--- a/src/main/resources/fxml/hub_register_success.fxml
+++ b/src/main/resources/fxml/hub_register_success.fxml
@@ -41,9 +41,9 @@
 			<Label text="%hub.registerSuccess.description" wrapText="true"/>
 
 			<Region VBox.vgrow="ALWAYS" minHeight="18"/>
-			<ButtonBar buttonMinWidth="120" buttonOrder="+C">
+			<ButtonBar buttonMinWidth="120" buttonOrder="+X">
 				<buttons>
-					<Button text="%generic.button.close" ButtonBar.buttonData="CANCEL_CLOSE" defaultButton="true" onAction="#close"/>
+					<Button text="%generic.button.next" ButtonBar.buttonData="NEXT_FORWARD" defaultButton="true" onAction="#complete"/>
 					<!-- TODO: add request access button -->
 				</buttons>
 			</ButtonBar>

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -162,6 +162,8 @@ hub.register.description=This is the first Hub access from this device. Please a
 hub.register.nameLabel=Device Name
 hub.register.invalidAccountKeyLabel=Invalid Account Key
 hub.register.registerBtn=Authorize
+### Register Device Legacy
+hub.register.occupiedMsg=Name already in use
 ### Registration Success
 hub.registerSuccess.message=Device registered
 hub.registerSuccess.description=To access the vault, your device needs to be authorized by the vault owner.


### PR DESCRIPTION
This fixes #3247 by changing the order of `GET /api/devices/{deviceId}` and `GET /api/vaults/{vaultId}/access-token`. By first retrieving the device data, we can identify non-registered devices before attempting vault unlock. This also fixes a TODO to immediately unlock after device registration.

Furthermore this PR changes how we distinguish legacy (pre Hub 1.3.0) vs current vault unlock. Instead of relying on HTTP status code 404 returned from `GET /api/vaults/{vaultId}/access-token`, we will look at the `apiLevel` returned from `GET /api/config`.

This is the first step to adjust the workflow as depicted in the following diagram, however it does not yet contain the Legacy Device Migration (separate PR will follow):

![Refactored Hub Unlock Workflow](https://github.com/cryptomator/cryptomator/assets/1204330/34129637-eefd-4317-b5d2-4b61d8a6230c)

- [x] Tested Unlock on Hub 1.3.x
- [x] Tested Device Registration with consecutive Unlock on Hub 1.3.x
- [x] Tested Unlock on Hub 1.2.x
- [x] Tested Device Registration with consecutive Unlock on Hub 1.2.x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Implemented a new key loading workflow for enhanced security.
	- Added the ability to configure API base URLs for key retrieval.

- **Refactor**
	- Streamlined the key retrieval process with new methods and updated parameters.
	- Improved the registration success flow by handling window events more effectively.

- **Style**
	- Updated button order in the user interface for better usability.

- **Chores**
	- Removed unused legacy access token request method.
	- Cleaned up imports and unused fields to optimize the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->