### PR TITLE
Feature: Split device registration into "normal" and "legacy" flow

### DIFF
--- a/src/main/java/org/cryptomator/ui/common/FxmlFile.java
+++ b/src/main/java/org/cryptomator/ui/common/FxmlFile.java
@@ -21,6 +21,7 @@ public enum FxmlFile {
 	HUB_INVALID_LICENSE("/fxml/hub_invalid_license.fxml"), //
 	HUB_RECEIVE_KEY("/fxml/hub_receive_key.fxml"), //
 	HUB_LEGACY_REGISTER_DEVICE("/fxml/hub_legacy_register_device.fxml"), //
+	HUB_LEGACY_REGISTER_SUCCESS("/fxml/hub_legacy_register_success.fxml"), //
 	HUB_REGISTER_SUCCESS("/fxml/hub_register_success.fxml"), //
 	HUB_REGISTER_DEVICE_ALREADY_EXISTS("/fxml/hub_register_device_already_exists.fxml"), //
 	HUB_REGISTER_FAILED("/fxml/hub_register_failed.fxml"), //

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/HubKeyLoadingModule.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/HubKeyLoadingModule.java
@@ -119,6 +119,12 @@ public abstract class HubKeyLoadingModule {
 		return fxmlLoaders.createScene(FxmlFile.HUB_LEGACY_REGISTER_DEVICE);
 	}
 
+	@Provides
+	@FxmlScene(FxmlFile.HUB_LEGACY_REGISTER_SUCCESS)
+	@KeyLoadingScoped
+	static Scene provideHubLegacyRegisterSuccessScene(@KeyLoading FxmlLoaderFactory fxmlLoaders) {
+		return fxmlLoaders.createScene(FxmlFile.HUB_LEGACY_REGISTER_SUCCESS);
+	}
 
 	@Provides
 	@FxmlScene(FxmlFile.HUB_REGISTER_SUCCESS)
@@ -191,6 +197,11 @@ public abstract class HubKeyLoadingModule {
 	@IntoMap
 	@FxControllerKey(LegacyRegisterDeviceController.class)
 	abstract FxController bindLegacyRegisterDeviceController(LegacyRegisterDeviceController controller);
+
+	@Binds
+	@IntoMap
+	@FxControllerKey(LegacyRegisterSuccessController.class)
+	abstract FxController bindLegacyRegisterSuccessController(LegacyRegisterSuccessController controller);
 
 	@Binds
 	@IntoMap

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/LegacyRegisterDeviceController.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/LegacyRegisterDeviceController.java
@@ -64,7 +64,7 @@ public class LegacyRegisterDeviceController implements FxController {
 	public Button registerBtn;
 
 	@Inject
-	public LegacyRegisterDeviceController(@KeyLoading Stage window, ExecutorService executor, HubConfig hubConfig, @Named("deviceId") String deviceId, DeviceKey deviceKey, CompletableFuture<ReceivedKey> result, @Named("bearerToken") AtomicReference<String> bearerToken, @FxmlScene(FxmlFile.HUB_REGISTER_SUCCESS) Lazy<Scene> registerSuccessScene, @FxmlScene(FxmlFile.HUB_REGISTER_FAILED) Lazy<Scene> registerFailedScene) {
+	public LegacyRegisterDeviceController(@KeyLoading Stage window, ExecutorService executor, HubConfig hubConfig, @Named("deviceId") String deviceId, DeviceKey deviceKey, CompletableFuture<ReceivedKey> result, @Named("bearerToken") AtomicReference<String> bearerToken, @FxmlScene(FxmlFile.HUB_LEGACY_REGISTER_SUCCESS) Lazy<Scene> registerSuccessScene, @FxmlScene(FxmlFile.HUB_REGISTER_FAILED) Lazy<Scene> registerFailedScene) {
 		this.window = window;
 		this.hubConfig = hubConfig;
 		this.deviceId = deviceId;

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/LegacyRegisterSuccessController.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/LegacyRegisterSuccessController.java
@@ -1,0 +1,24 @@
+package org.cryptomator.ui.keyloading.hub;
+
+import org.cryptomator.ui.common.FxController;
+import org.cryptomator.ui.keyloading.KeyLoading;
+import org.cryptomator.ui.keyloading.KeyLoadingScoped;
+
+import javax.inject.Inject;
+import javafx.fxml.FXML;
+import javafx.stage.Stage;
+
+@KeyLoadingScoped
+public class LegacyRegisterSuccessController implements FxController {
+	private final Stage window;
+
+	@Inject
+	public LegacyRegisterSuccessController(@KeyLoading Stage window) {
+		this.window = window;
+	}
+
+	@FXML
+	public void close() {
+		window.close();
+	}
+}

--- a/src/main/resources/fxml/hub_legacy_register_device.fxml
+++ b/src/main/resources/fxml/hub_legacy_register_device.fxml
@@ -41,7 +41,7 @@
 					<Insets bottom="6" top="6"/>
 				</padding>
 			</Label>
-			<Label text="%hub.register.description" wrapText="true"/>
+			<Label text="%hub.register.legacy.description" wrapText="true"/>
 			<HBox spacing="6" alignment="CENTER_LEFT">
 				<padding>
 					<Insets top="12"/>
@@ -50,7 +50,7 @@
 				<TextField fx:id="deviceNameField" HBox.hgrow="ALWAYS"/>
 			</HBox>
 			<HBox alignment="TOP_RIGHT">
-				<Label text="%hub.register.occupiedMsg" textAlignment="RIGHT" alignment="CENTER_RIGHT" visible="${controller.deviceNameAlreadyExists}" graphicTextGap="6">
+				<Label text="%hub.register.legacy.occupiedMsg" textAlignment="RIGHT" alignment="CENTER_RIGHT" visible="${controller.deviceNameAlreadyExists}" graphicTextGap="6">
 					<padding>
 						<Insets top="6"/>
 					</padding>

--- a/src/main/resources/fxml/hub_legacy_register_success.fxml
+++ b/src/main/resources/fxml/hub_legacy_register_success.fxml
@@ -44,7 +44,6 @@
 			<ButtonBar buttonMinWidth="120" buttonOrder="+C">
 				<buttons>
 					<Button text="%generic.button.close" ButtonBar.buttonData="CANCEL_CLOSE" defaultButton="true" onAction="#close"/>
-					<!-- TODO: add request access button -->
 				</buttons>
 			</ButtonBar>
 		</VBox>

--- a/src/main/resources/fxml/hub_legacy_register_success.fxml
+++ b/src/main/resources/fxml/hub_legacy_register_success.fxml
@@ -13,7 +13,7 @@
 <?import javafx.scene.shape.Circle?>
 <HBox xmlns:fx="http://javafx.com/fxml"
 	  xmlns="http://javafx.com/javafx"
-	  fx:controller="org.cryptomator.ui.keyloading.hub.RegisterSuccessController"
+	  fx:controller="org.cryptomator.ui.keyloading.hub.LegacyRegisterSuccessController"
 	  minWidth="400"
 	  maxWidth="400"
 	  minHeight="145"
@@ -38,12 +38,12 @@
 					<Insets bottom="6" top="6"/>
 				</padding>
 			</Label>
-			<Label text="%hub.registerSuccess.description" wrapText="true"/>
+			<Label text="%hub.registerSuccess.legacy.description" wrapText="true"/>
 
 			<Region VBox.vgrow="ALWAYS" minHeight="18"/>
-			<ButtonBar buttonMinWidth="120" buttonOrder="+X">
+			<ButtonBar buttonMinWidth="120" buttonOrder="+C">
 				<buttons>
-					<Button text="%hub.registerSuccess.unlockBtn" ButtonBar.buttonData="NEXT_FORWARD" defaultButton="true" onAction="#complete"/>
+					<Button text="%generic.button.close" ButtonBar.buttonData="CANCEL_CLOSE" defaultButton="true" onAction="#close"/>
 					<!-- TODO: add request access button -->
 				</buttons>
 			</ButtonBar>

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -158,15 +158,18 @@ hub.receive.message=Processing response…
 hub.receive.description=Cryptomator is receiving and processing the response from Hub. Please wait.
 ### Register Device
 hub.register.message=New Device
-hub.register.description=This is the first Hub access from this device. Please authorize it using your Account Key.
+hub.register.description=This is the first Hub access from this device. Please register it using your Account Key.
 hub.register.nameLabel=Device Name
 hub.register.invalidAccountKeyLabel=Invalid Account Key
-hub.register.registerBtn=Authorize
+hub.register.registerBtn=Register
 ### Register Device Legacy
-hub.register.occupiedMsg=Name already in use
+hub.register.legacy.occupiedMsg=Name already in use
+hub.register.legacy.description=This is the first Hub access from this device. Please register it.
 ### Registration Success
 hub.registerSuccess.message=Device registered
-hub.registerSuccess.description=To access the vault, your device needs to be authorized by the vault owner.
+hub.registerSuccess.description=Your device is successfully registered. You can now continue to unlock the vault.
+hub.registerSuccess.unlockBtn=Unlock
+hub.registerSuccess.legacy.description=To access the vault, your device needs to be additionally authorized by the vault owner.
 ### Registration Failed
 hub.registerFailed.message=Device registration failed
 hub.registerFailed.description.generic=An error was thrown in the registration process. For more details, look into the application log.


### PR DESCRIPTION
Fixes #3246 

This PR splits the device registration cleaner into the legacy flow and the "normal"/1.3.x flow by providing two different registerSuccess scenes. Additionally, the wording is adjusted for a better understanding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a legacy registration success screen for improved user experience.
  - Added new user interface elements and messages for successful legacy device registration.

- **Enhancements**
  - Updated button labels and descriptions for device registration to enhance clarity and consistency.

- **Documentation**
  - Adjusted text properties of UI labels for better localization support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->