### PR TITLE
Hello 2024 🎉

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -103,7 +103,7 @@ jobs:
           --dest appdir
           --name Cryptomator
           --vendor "Skymatic GmbH"
-          --copyright "(C) 2016 - 2023 Skymatic GmbH"
+          --copyright "(C) 2016 - 2024 Skymatic GmbH"
           --app-version "${{  needs.get-version.outputs.semVerNum }}.${{  needs.get-version.outputs.revNum }}"
           --java-options "--enable-preview"
           --java-options "--enable-native-access=org.cryptomator.jfuse.linux.amd64,org.cryptomator.jfuse.linux.aarch64,org.purejava.appindicator"

--- a/.github/workflows/mac-dmg.yml
+++ b/.github/workflows/mac-dmg.yml
@@ -109,7 +109,7 @@ jobs:
           --dest appdir
           --name Cryptomator
           --vendor "Skymatic GmbH"
-          --copyright "(C) 2016 - 2023 Skymatic GmbH"
+          --copyright "(C) 2016 - 2024 Skymatic GmbH"
           --app-version "${{ needs.get-version.outputs.semVerNum }}"
           --java-options "--enable-preview"
           --java-options "--enable-native-access=org.cryptomator.jfuse.mac"

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -106,7 +106,7 @@ jobs:
           --dest appdir
           --name Cryptomator
           --vendor "Skymatic GmbH"
-          --copyright "(C) 2016 - 2023 Skymatic GmbH"
+          --copyright "(C) 2016 - 2024 Skymatic GmbH"
           --app-version "${{ needs.get-version.outputs.semVerNum }}.${{ needs.get-version.outputs.revNum }}"
           --java-options "--enable-preview"
           --java-options "--enable-native-access=org.cryptomator.jfuse.win"
@@ -214,7 +214,7 @@ jobs:
           --dest installer
           --name Cryptomator
           --vendor "Skymatic GmbH"
-          --copyright "(C) 2016 - 2023 Skymatic GmbH"
+          --copyright "(C) 2016 - 2024 Skymatic GmbH"
           --app-version "${{ needs.get-version.outputs.semVerNum }}.${{ needs.get-version.outputs.revNum}}"
           --win-menu
           --win-dir-chooser
@@ -309,7 +309,7 @@ jobs:
           -out dist/win/bundle/
           -dBundleVersion="${{ needs.get-version.outputs.semVerNum }}.${{ needs.get-version.outputs.revNum }}"
           -dBundleVendor="Skymatic GmbH"
-          -dBundleCopyright="(C) 2016 - 2023 Skymatic GmbH"
+          -dBundleCopyright="(C) 2016 - 2024 Skymatic GmbH"
           -dAboutUrl="https://cryptomator.org"
           -dHelpUrl="https://cryptomator.org/contact"
           -dUpdateUrl="https://cryptomator.org/downloads/"

--- a/dist/linux/appimage/build.sh
+++ b/dist/linux/appimage/build.sh
@@ -77,7 +77,7 @@ ${JAVA_HOME}/bin/jpackage \
     --vendor "Skymatic GmbH" \
     --java-options "--enable-preview" \
     --java-options "--enable-native-access=org.cryptomator.jfuse.linux.amd64,org.cryptomator.jfuse.linux.aarch64,org.purejava.appindicator" \
-    --copyright "(C) 2016 - 2023 Skymatic GmbH" \
+    --copyright "(C) 2016 - 2024 Skymatic GmbH" \
     --java-options "-Xss5m" \
     --java-options "-Xmx256m" \
     --app-version "${VERSION}.${REVISION_NO}" \

--- a/dist/linux/debian/copyright
+++ b/dist/linux/debian/copyright
@@ -4,11 +4,11 @@ Upstream-Contact: Cryptomator <info@cryptomator.org>
 Source: https://cryptomator.org
 
 Files: *
-Copyright: 2016-2023 Skymatic GmbH
+Copyright: 2016-2024 Skymatic GmbH
 License: GPL-3+
 
 Files: debian/org.cryptomator.Cryptomator.appdata.xml
-Copyright: 2016-2023 Skymatic GmbH
+Copyright: 2016-2024 Skymatic GmbH
 License: FSFAP
 
 License: GPL-3+

--- a/dist/linux/debian/rules
+++ b/dist/linux/debian/rules
@@ -45,7 +45,7 @@ override_dh_auto_build:
 		--vendor "Skymatic GmbH" \
 		--java-options "--enable-preview" \
 		--java-options "--enable-native-access=org.cryptomator.jfuse.linux.amd64,org.cryptomator.jfuse.linux.aarch64,org.purejava.appindicator" \
-		--copyright "(C) 2016 - 2023 Skymatic GmbH" \
+		--copyright "(C) 2016 - 2024 Skymatic GmbH" \
 		--java-options "-Xss5m" \
 		--java-options "-Xmx256m" \
 		--java-options "-Dfile.encoding=\"utf-8\"" \

--- a/dist/mac/dmg/build.sh
+++ b/dist/mac/dmg/build.sh
@@ -21,7 +21,7 @@ rm -rf runtime dmg *.app *.dmg
 # set variables
 APP_NAME="Cryptomator"
 VENDOR="Skymatic GmbH"
-COPYRIGHT_YEARS="2016 - 2023"
+COPYRIGHT_YEARS="2016 - 2024"
 PACKAGE_IDENTIFIER="org.cryptomator"
 MAIN_JAR_GLOB="cryptomator-*.jar"
 MODULE_AND_MAIN_CLASS="org.cryptomator.desktop/org.cryptomator.launcher.Cryptomator"

--- a/dist/mac/dmg/resources/licenseTemplate.ftl
+++ b/dist/mac/dmg/resources/licenseTemplate.ftl
@@ -17,7 +17,7 @@
 \f1\b0 \
 \
 
-\f0\b \'a9 2016 \'96 2023 Skymatic GmbH
+\f0\b \'a9 2016 \'96 2024 Skymatic GmbH
 \f1\b0 \
 \
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.\

--- a/dist/win/bundle/resources/licenseTemplate.ftl
+++ b/dist/win/bundle/resources/licenseTemplate.ftl
@@ -10,7 +10,7 @@
 \vieww12000\viewh15840\viewkind0
 \pard\tx283\tx567\tx850\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\b\fs16\lang7 Cryptomator is distributed under the GPLv3 License, found below. Please see the bottom of this document for any other license applicable to code used within Cryptomator.\b0\par
 \par
-\b\'a9 2016 \'96 2023 Skymatic GmbH \b0\par
+\b\'a9 2016 \'96 2024 Skymatic GmbH \b0\par
 \par
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.\par
 \par

--- a/dist/win/resources/licenseTemplate.ftl
+++ b/dist/win/resources/licenseTemplate.ftl
@@ -10,7 +10,7 @@
 \vieww12000\viewh15840\viewkind0
 \pard\tx283\tx567\tx850\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\b\fs16\lang7 Cryptomator is distributed under the GPLv3 License, found below. Please see the bottom of this document for any other license applicable to code used within Cryptomator.\b0\par
 \par
-\b\'a9 2016 \'96 2023 Skymatic GmbH \b0\par
+\b\'a9 2016 \'96 2024 Skymatic GmbH \b0\par
 \par
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.\par
 \par

--- a/src/main/resources/fxml/preferences_about.fxml
+++ b/src/main/resources/fxml/preferences_about.fxml
@@ -22,7 +22,7 @@
 			</ImageView>
 			<VBox spacing="3" HBox.hgrow="ALWAYS" alignment="CENTER_LEFT">
 				<FormattedLabel styleClass="label-extra-large" format="Cryptomator %s" arg1="${controller.fullApplicationVersion}"/>
-				<Label text="© 2016 – 2023 Skymatic GmbH"/>
+				<Label text="© 2016 – 2024 Skymatic GmbH"/>
 			</VBox>
 		</HBox>
 


### PR DESCRIPTION
Just noticed all copyrights were for 2023 so I updated this commit with 2024 

https://github.com/cryptomator/cryptomator/commit/9182c415ebfa2af576e45557a37ff7f596c93cab

I could not see any reason why this should not be done but if there is, I apologize in advance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated copyright year to "2016 - 2024" in the application workflows and about section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->