### PR TITLE
Hub 1.2.x → Hub 1.3.x Legacy Device Migration

### DIFF
--- a/src/main/java/org/cryptomator/ui/keyloading/hub/HubConfig.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/HubConfig.java
@@ -1,5 +1,6 @@
 package org.cryptomator.ui.keyloading.hub;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.jetbrains.annotations.Nullable;
 
@@ -19,10 +20,17 @@ public class HubConfig {
 	public String devicesResourceUrl;
 
 	/**
+	 * A collection of String template processors to construct URIs related to this Hub instance.
+	 */
+	@JsonIgnore
+	public final URIProcessors URIs = new URIProcessors();
+
+	/**
 	 * Get the URI pointing to the <code>/api/</code> base resource.
 	 *
 	 * @return <code>/api/</code> URI
 	 * @apiNote URI is guaranteed to end on <code>/</code>
+	 * @see #URIs
 	 */
 	public URI getApiBaseUrl() {
 		if (apiBaseUrl != null) {
@@ -37,5 +45,18 @@ public class HubConfig {
 
 	public URI getWebappBaseUrl() {
 		return getApiBaseUrl().resolve("../app/");
+	}
+
+	public class URIProcessors {
+
+		/**
+		 * Resolves paths relative to the <code>/api/</code> endpoint of this Hub instance.
+		 */
+		public final StringTemplate.Processor<URI, RuntimeException> API = template -> {
+			var path = template.interpolate();
+			var relPath = path.startsWith("/") ? path.substring(1) : path;
+			return getApiBaseUrl().resolve(relPath);
+		};
+
 	}
 }

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/JWEHelper.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/JWEHelper.java
@@ -1,7 +1,6 @@
 package org.cryptomator.ui.keyloading.hub;
 
 import com.google.common.base.Preconditions;
-import com.google.common.io.BaseEncoding;
 import com.nimbusds.jose.EncryptionMethod;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWEAlgorithm;
@@ -108,7 +107,7 @@ class JWEHelper {
 		var keyBytes = new byte[0];
 		try {
 			if (fields.get(keyField) instanceof String key) {
-				keyBytes = BaseEncoding.base64().decode(key);
+				keyBytes = Base64.getDecoder().decode(key);
 				return rawKeyFactory.apply(keyBytes);
 			} else {
 				throw new IllegalArgumentException("JWE payload doesn't contain field " + keyField);

--- a/src/test/java/org/cryptomator/ui/keyloading/hub/JWEHelperTest.java
+++ b/src/test/java/org/cryptomator/ui/keyloading/hub/JWEHelperTest.java
@@ -5,7 +5,9 @@ import org.cryptomator.cryptolib.api.Masterkey;
 import org.cryptomator.cryptolib.api.MasterkeyLoadingFailedException;
 import org.cryptomator.cryptolib.common.P384KeyPair;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -29,6 +31,35 @@ public class JWEHelperTest {
 	// used for JWE generation in frontend: (jwe.spec.ts):
 	private static final String PRIV_KEY = "ME8CAQAwEAYHKoZIzj0CAQYFK4EEACIEODA2AgEBBDEA6QybmBitf94veD5aCLr7nlkF5EZpaXHCfq1AXm57AKQyGOjTDAF9EQB28fMywTDQ";
 	private static final String PUB_KEY = "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAERxQR+NRN6Wga01370uBBzr2NHDbKIC56tPUEq2HX64RhITGhii8Zzbkb1HnRmdF0aq6uqmUy4jUhuxnKxsv59A6JeK7Unn+mpmm3pQAygjoGc9wrvoH4HWJSQYUlsXDu";
+
+
+	@Nested
+	@DisplayName("DER decoding")
+	public class Decoders {
+
+		private static P384KeyPair keyPair;
+
+		@BeforeAll
+		public static void setup() throws InvalidKeySpecException {
+			keyPair = P384KeyPair.create(new X509EncodedKeySpec(Base64.getDecoder().decode(DEVICE_PUB_KEY)), new PKCS8EncodedKeySpec(Base64.getDecoder().decode(DEVICE_PRIV_KEY)));
+		}
+
+		@Test
+		@DisplayName("decodeECPublicKey")
+		public void testDecodeECPublicKey() {
+			var decodedPublicKey = JWEHelper.decodeECPublicKey(Base64.getDecoder().decode(DEVICE_PUB_KEY));
+
+			Assertions.assertArrayEquals(keyPair.getPublic().getEncoded(), decodedPublicKey.getEncoded());
+		}
+
+		@Test
+		@DisplayName("decodeECPrivateKey")
+		public void testDecodeECPrivateKey() {
+			var decodedPrivateKey = JWEHelper.decodeECPrivateKey(Base64.getDecoder().decode(DEVICE_PRIV_KEY));
+
+			Assertions.assertArrayEquals(keyPair.getPrivate().getEncoded(), decodedPrivateKey.getEncoded());
+		}
+	}
 
 	@Test
 	@DisplayName("decryptUserKey with device key")


### PR DESCRIPTION
This adds a new subroutine during Device Registration, which attempts to migrate existing access tokens by re-encrypting them for the authenticated user.

![Legacy Device Migration](https://github.com/cryptomator/cryptomator/assets/1204330/5aecadde-5412-4a4d-977f-0a05238efc1a)
