### PR TITLE
Feature: Implement Indicator for Cryptomator Up-to-date Status in Preferences Updates

### DIFF
--- a/src/main/java/org/cryptomator/ui/fxapp/UpdateChecker.java
+++ b/src/main/java/org/cryptomator/ui/fxapp/UpdateChecker.java
@@ -8,6 +8,8 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javafx.beans.binding.BooleanBinding;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.concurrent.ScheduledService;
@@ -25,14 +27,20 @@ public class UpdateChecker {
 	private final Environment env;
 	private final Settings settings;
 	private final StringProperty latestVersionProperty;
+	private final BooleanProperty upToDate;
 	private final Comparator<String> semVerComparator;
 	private final ScheduledService<String> updateCheckerService;
 
 	@Inject
-	UpdateChecker(Settings settings, Environment env, @Named("latestVersion") StringProperty latestVersionProperty, @Named("SemVer") Comparator<String> semVerComparator, ScheduledService<String> updateCheckerService) {
+	UpdateChecker(Settings settings, Environment env, //
+				  @Named("latestVersion") StringProperty latestVersionProperty, //
+				  @Named("upToDate") BooleanProperty upToDate, //
+				  @Named("SemVer") Comparator<String> semVerComparator, //
+				  ScheduledService<String> updateCheckerService) {
 		this.env = env;
 		this.settings = settings;
 		this.latestVersionProperty = latestVersionProperty;
+		this.upToDate = upToDate;
 		this.semVerComparator = semVerComparator;
 		this.updateCheckerService = updateCheckerService;
 	}
@@ -68,8 +76,10 @@ public class UpdateChecker {
 		if (semVerComparator.compare(getCurrentVersion(), latestVersion) < 0) {
 			// update is available
 			latestVersionProperty.set(latestVersion);
+			upToDate.set(false);
 		} else {
 			latestVersionProperty.set(null);
+			upToDate.set(true);
 		}
 	}
 
@@ -91,4 +101,7 @@ public class UpdateChecker {
 		return env.getAppVersion();
 	}
 
+	public ReadOnlyBooleanProperty upToDateProperty() {
+		return upToDate;
+	}
 }

--- a/src/main/java/org/cryptomator/ui/fxapp/UpdateChecker.java
+++ b/src/main/java/org/cryptomator/ui/fxapp/UpdateChecker.java
@@ -11,6 +11,7 @@ import javafx.beans.binding.BooleanBinding;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.ReadOnlyStringProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.StringProperty;
 import javafx.concurrent.ScheduledService;
 import javafx.concurrent.Worker;
@@ -34,15 +35,14 @@ public class UpdateChecker {
 	@Inject
 	UpdateChecker(Settings settings, Environment env, //
 				  @Named("latestVersion") StringProperty latestVersionProperty, //
-				  @Named("upToDate") BooleanProperty upToDate, //
 				  @Named("SemVer") Comparator<String> semVerComparator, //
 				  ScheduledService<String> updateCheckerService) {
 		this.env = env;
 		this.settings = settings;
 		this.latestVersionProperty = latestVersionProperty;
-		this.upToDate = upToDate;
 		this.semVerComparator = semVerComparator;
 		this.updateCheckerService = updateCheckerService;
+		this.upToDate = new SimpleBooleanProperty();
 	}
 
 	public void automaticallyCheckForUpdatesIfEnabled() {

--- a/src/main/java/org/cryptomator/ui/fxapp/UpdateCheckerModule.java
+++ b/src/main/java/org/cryptomator/ui/fxapp/UpdateCheckerModule.java
@@ -11,8 +11,6 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Named;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.ObjectBinding;
-import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.concurrent.ScheduledService;
@@ -39,13 +37,6 @@ public abstract class UpdateCheckerModule {
 	@FxApplicationScoped
 	static StringProperty provideLatestVersion() {
 		return new SimpleStringProperty();
-	}
-
-	@Provides
-	@Named("upToDate")
-	@FxApplicationScoped
-	static BooleanProperty provideUpToDate() {
-		return new SimpleBooleanProperty();
 	}
 
 	@Provides

--- a/src/main/java/org/cryptomator/ui/fxapp/UpdateCheckerModule.java
+++ b/src/main/java/org/cryptomator/ui/fxapp/UpdateCheckerModule.java
@@ -11,6 +11,8 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Named;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.ObjectBinding;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.concurrent.ScheduledService;
@@ -37,6 +39,13 @@ public abstract class UpdateCheckerModule {
 	@FxApplicationScoped
 	static StringProperty provideLatestVersion() {
 		return new SimpleStringProperty();
+	}
+
+	@Provides
+	@Named("upToDate")
+	@FxApplicationScoped
+	static BooleanProperty provideUpToDate() {
+		return new SimpleBooleanProperty();
 	}
 
 	@Provides

--- a/src/main/java/org/cryptomator/ui/preferences/UpdatesPreferencesController.java
+++ b/src/main/java/org/cryptomator/ui/preferences/UpdatesPreferencesController.java
@@ -9,6 +9,7 @@ import javafx.application.Application;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.binding.ObjectBinding;
+import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.fxml.FXML;
 import javafx.scene.control.CheckBox;
@@ -26,7 +27,8 @@ public class UpdatesPreferencesController implements FxController {
 	private final ReadOnlyStringProperty latestVersion;
 	private final String currentVersion;
 	private final BooleanBinding updateAvailable;
-
+	private final ReadOnlyBooleanProperty upToDate;
+	
 	/* FXML */
 	public CheckBox checkForUpdatesCheckbox;
 
@@ -39,6 +41,7 @@ public class UpdatesPreferencesController implements FxController {
 		this.latestVersion = updateChecker.latestVersionProperty();
 		this.updateAvailable = latestVersion.isNotNull();
 		this.currentVersion = updateChecker.getCurrentVersion();
+		this.upToDate = updateChecker.upToDateProperty();
 	}
 
 	public void initialize() {
@@ -84,4 +87,8 @@ public class UpdatesPreferencesController implements FxController {
 	public boolean isUpdateAvailable() {
 		return updateAvailable.get();
 	}
+
+	public ReadOnlyBooleanProperty upToDateProperty(){ return upToDate;}
+
+	public Boolean getUpToDate(){ return upToDate.get();}
 }

--- a/src/main/java/org/cryptomator/ui/preferences/UpdatesPreferencesController.java
+++ b/src/main/java/org/cryptomator/ui/preferences/UpdatesPreferencesController.java
@@ -90,5 +90,5 @@ public class UpdatesPreferencesController implements FxController {
 
 	public ReadOnlyBooleanProperty upToDateProperty(){ return upToDate;}
 
-	public Boolean getUpToDate(){ return upToDate.get();}
+	public boolean getUpToDate(){ return upToDate.get();}
 }

--- a/src/main/resources/fxml/preferences_updates.fxml
+++ b/src/main/resources/fxml/preferences_updates.fxml
@@ -6,6 +6,7 @@
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.Hyperlink?>
+<?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.VBox?>
 <?import org.cryptomator.ui.controls.FontAwesome5Spinner?>
 <VBox xmlns:fx="http://javafx.com/fxml"
@@ -29,7 +30,7 @@
 					<FontAwesome5Spinner fx:id="spinner" glyphSize="12"/>
 				</graphic>
 			</Button>
-
+			<Label text="%preferences.updates.upToDate" managed="${controller.upToDate}" visible="${controller.upToDate}"/>
 			<Hyperlink text="${linkLabel.value}" onAction="#visitDownloadsPage" textAlignment="CENTER" wrapText="true" styleClass="hyperlink-underline" visible="${controller.updateAvailable}"/>
 		</VBox>
 	</children>

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -321,6 +321,7 @@ preferences.updates.currentVersion=Current Version: %s
 preferences.updates.autoUpdateCheck=Check for updates automatically
 preferences.updates.checkNowBtn=Check Now
 preferences.updates.updateAvailable=Update to version %s available.
+preferences.updates.upToDate=Cryptomator is up-to-date.
 ## Contribution
 preferences.contribute=Support Us
 preferences.contribute.registeredFor=Supporter certificate registered for %s


### PR DESCRIPTION
This pull request introduces a software status indicator within the Preferences->Updates window. It provides visual feedback on the up-to-date status of Cryptomator following an update check.

If Cryptomator is current, the text 'Cryptomator is up-to-date' will appear below the 'Check Now' button.

<img width="718" alt="Bildschirmfoto 2024-01-31 um 11 43 54" src="https://github.com/cryptomator/cryptomator/assets/29817198/88626112-8cf2-476e-af69-4b3e8da574ab">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the update checking mechanism to include a new `upToDate` status indicator.
	- Introduced a visual indicator in the updates preferences to reflect the up-to-date status of the application.
- **Improvements**
	- Added a new string resource for displaying the up-to-date status message in the application's preferences screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->