### PR TITLE
Center Unlock Success Dialog on Main Application Window

### DIFF
--- a/src/main/java/org/cryptomator/ui/unlock/UnlockWorkflow.java
+++ b/src/main/java/org/cryptomator/ui/unlock/UnlockWorkflow.java
@@ -20,9 +20,10 @@ import javax.inject.Inject;
 import javafx.application.Platform;
 import javafx.beans.property.ObjectProperty;
 import javafx.concurrent.Task;
+import javafx.geometry.Rectangle2D;
 import javafx.scene.Scene;
+import javafx.stage.Screen;
 import javafx.stage.Stage;
-import javafx.stage.Window;
 import java.io.IOException;
 
 /**
@@ -112,8 +113,16 @@ public class UnlockWorkflow extends Task<Void> {
 			case ASK -> Platform.runLater(() -> {
 				window.setScene(successScene.get());
 				window.show();
-				window.setX(mainWindow.getX() + (mainWindow.getWidth() - window.getWidth()) / 2);
-				window.setY(mainWindow.getY() + (mainWindow.getHeight() - window.getHeight()) / 2);
+				double x = mainWindow.getX() + (mainWindow.getWidth() - window.getWidth()) / 2;
+				double y = mainWindow.getY() + (mainWindow.getHeight() - window.getHeight()) / 2;
+				if(!mainWindow.isShowing()) {
+					Screen screen = Screen.getScreensForRectangle(mainWindow.getX(), mainWindow.getY(), mainWindow.getWidth(), mainWindow.getHeight()).get(0);
+					Rectangle2D bounds = screen.getVisualBounds();
+					x = bounds.getMinX() + (bounds.getWidth() - window.getWidth()) / 2;
+					y = bounds.getMinY() + (bounds.getHeight() - window.getHeight()) / 2;
+				}
+				window.setX(x);
+				window.setY(y);
 			});
 			case REVEAL -> {
 				Platform.runLater(window::close);

--- a/src/main/java/org/cryptomator/ui/unlock/UnlockWorkflow.java
+++ b/src/main/java/org/cryptomator/ui/unlock/UnlockWorkflow.java
@@ -11,6 +11,7 @@ import org.cryptomator.ui.common.FxmlFile;
 import org.cryptomator.ui.common.FxmlScene;
 import org.cryptomator.ui.common.VaultService;
 import org.cryptomator.ui.fxapp.FxApplicationWindows;
+import org.cryptomator.ui.fxapp.PrimaryStage;
 import org.cryptomator.ui.keyloading.KeyLoadingStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,6 +22,7 @@ import javafx.beans.property.ObjectProperty;
 import javafx.concurrent.Task;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
+import javafx.stage.Window;
 import java.io.IOException;
 
 /**
@@ -33,6 +35,7 @@ public class UnlockWorkflow extends Task<Void> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(UnlockWorkflow.class);
 
+	private final Stage mainWindow;
 	private final Stage window;
 	private final Vault vault;
 	private final VaultService vaultService;
@@ -44,7 +47,8 @@ public class UnlockWorkflow extends Task<Void> {
 	private final ObjectProperty<IllegalMountPointException> illegalMountPointException;
 
 	@Inject
-	UnlockWorkflow(@UnlockWindow Stage window, //
+	UnlockWorkflow(@PrimaryStage Stage mainWindow, //
+				   @UnlockWindow Stage window, //
 				   @UnlockWindow Vault vault, //
 				   VaultService vaultService, //
 				   @FxmlScene(FxmlFile.UNLOCK_SUCCESS) Lazy<Scene> successScene, //
@@ -53,6 +57,7 @@ public class UnlockWorkflow extends Task<Void> {
 				   FxApplicationWindows appWindows, //
 				   @UnlockWindow KeyLoadingStrategy keyLoadingStrategy, //
 				   @UnlockWindow ObjectProperty<IllegalMountPointException> illegalMountPointException) {
+		this.mainWindow = mainWindow;
 		this.window = window;
 		this.vault = vault;
 		this.vaultService = vaultService;
@@ -99,6 +104,13 @@ public class UnlockWorkflow extends Task<Void> {
 		appWindows.showErrorWindow(e, window, null);
 	}
 
+	private void centerOnPrimaryStage(Window window){
+		double centerXPosition = mainWindow.getX() + (mainWindow.getWidth() - window.getWidth()) / 2;
+		double centerYPosition = mainWindow.getY() + (mainWindow.getHeight() - window.getHeight()) / 2;
+		window.setX(centerXPosition);
+		window.setY(centerYPosition);
+	}
+
 	@Override
 	protected void succeeded() {
 		LOG.info("Unlock of '{}' succeeded.", vault.getDisplayName());
@@ -107,6 +119,7 @@ public class UnlockWorkflow extends Task<Void> {
 			case ASK -> Platform.runLater(() -> {
 				window.setScene(successScene.get());
 				window.show();
+				centerOnPrimaryStage(window);
 			});
 			case REVEAL -> {
 				Platform.runLater(window::close);

--- a/src/main/java/org/cryptomator/ui/unlock/UnlockWorkflow.java
+++ b/src/main/java/org/cryptomator/ui/unlock/UnlockWorkflow.java
@@ -104,13 +104,6 @@ public class UnlockWorkflow extends Task<Void> {
 		appWindows.showErrorWindow(e, window, null);
 	}
 
-	private void centerOnPrimaryStage(Window window){
-		double centerXPosition = mainWindow.getX() + (mainWindow.getWidth() - window.getWidth()) / 2;
-		double centerYPosition = mainWindow.getY() + (mainWindow.getHeight() - window.getHeight()) / 2;
-		window.setX(centerXPosition);
-		window.setY(centerYPosition);
-	}
-
 	@Override
 	protected void succeeded() {
 		LOG.info("Unlock of '{}' succeeded.", vault.getDisplayName());
@@ -119,7 +112,8 @@ public class UnlockWorkflow extends Task<Void> {
 			case ASK -> Platform.runLater(() -> {
 				window.setScene(successScene.get());
 				window.show();
-				centerOnPrimaryStage(window);
+				window.setX(mainWindow.getX() + (mainWindow.getWidth() - window.getWidth()) / 2);
+				window.setY(mainWindow.getY() + (mainWindow.getHeight() - window.getHeight()) / 2);
 			});
 			case REVEAL -> {
 				Platform.runLater(window::close);


### PR DESCRIPTION
This pull request addresses Issue #3332 by implementing a change that ensures the unlock success dialog is consistently centered relative to the application's main window (PrimaryStage). The enhancement guarantees that if the PrimaryStage is visible, the dialog will be centered on it. However, if the PrimaryStage is hidden, the dialog will be centered on the screen where the PrimaryStage was last located.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit



- **New Features**
	- Improved user interface by centering the unlock window on the primary stage for better visibility and access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->