### PR TITLE
Add coloured banners for app in Flathub store

### DIFF
--- a/dist/linux/common/org.cryptomator.Cryptomator.metainfo.xml
+++ b/dist/linux/common/org.cryptomator.Cryptomator.metainfo.xml
@@ -54,8 +54,8 @@
 	</screenshots>
 
 	<branding>
-		<color type="primary" scheme_preference="light">#71a0df</color>
-		<color type="primary" scheme_preference="dark">#264268</color>
+		<color type="primary" scheme_preference="light">#EBF5EB</color>
+		<color type="primary" scheme_preference="dark">#2F4858</color>
 	</branding>
 
 	<url type="homepage">https://cryptomator.org/</url>

--- a/dist/linux/common/org.cryptomator.Cryptomator.metainfo.xml
+++ b/dist/linux/common/org.cryptomator.Cryptomator.metainfo.xml
@@ -53,6 +53,11 @@
 		</screenshot>
 	</screenshots>
 
+	<branding>
+		<color type="primary" scheme_preference="light">#264268</color>
+		<color type="primary" scheme_preference="dark">#71a0df</color>
+	</branding>
+
 	<url type="homepage">https://cryptomator.org/</url>
 	<url type="bugtracker">https://github.com/cryptomator/cryptomator/issues/</url>
 	<url type="donation">https://cryptomator.org/donate</url>

--- a/dist/linux/common/org.cryptomator.Cryptomator.metainfo.xml
+++ b/dist/linux/common/org.cryptomator.Cryptomator.metainfo.xml
@@ -54,8 +54,8 @@
 	</screenshots>
 
 	<branding>
-		<color type="primary" scheme_preference="light">#264268</color>
-		<color type="primary" scheme_preference="dark">#71a0df</color>
+		<color type="primary" scheme_preference="light">#71a0df</color>
+		<color type="primary" scheme_preference="dark">#264268</color>
 	</branding>
 
 	<url type="homepage">https://cryptomator.org/</url>


### PR DESCRIPTION
Closes https://github.com/flathub/org.cryptomator.Cryptomator/issues/77.

See https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/quality-guidelines/#brand-colors.

The colours set with this PR can be checked with the [banner preview](https://docs.flathub.org/banner-preview/).

I've taken them from the Cryptomator main web page. They look like this:

<img width="1387" alt="Bildschirmfoto 2024-04-12 um 17 50 57" src="https://github.com/cryptomator/cryptomator/assets/1822238/682884c4-a2d5-4153-9781-410cb5249433">

<img width="1387" alt="Bildschirmfoto 2024-04-12 um 17 52 26" src="https://github.com/cryptomator/cryptomator/assets/1822238/7c48e0db-bf28-4413-88af-3b9bb4f1957a">
