### PR TITLE
Feature: Update to jfx22

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -29,12 +29,12 @@ jobs:
         include:
           - os: ubuntu-latest
             appimage-suffix: x86_64
-            openjfx-url: 'https://download2.gluonhq.com/openjfx/21.0.1/openjfx-21.0.1_linux-x64_bin-jmods.zip'
-            openjfx-sha: '7baed11ca56d5fee85995fa6612d4299f1e8b7337287228f7f12fd50407c56f8'
+            openjfx-url: 'https://download2.gluonhq.com/openjfx/22.0.1/openjfx-22.0.1_linux-x64_bin-jmods.zip'
+            openjfx-sha: 'fbb22f35951c2e049cc2554dd03c2c56b4f5adc4b2ae9248872f46175ac103d8'
           - os: [self-hosted, Linux, ARM64]
             appimage-suffix: aarch64
-            openjfx-url: 'https://download2.gluonhq.com/openjfx/21.0.1/openjfx-21.0.1_linux-aarch64_bin-jmods.zip'
-            openjfx-sha: '871e7b9d7af16aef2e55c1b7830d0e0b2503b13dd8641374ba7e55ecb81d2ef9'
+            openjfx-url: 'https://download2.gluonhq.com/openjfx/22.0.1/openjfx-22.0.1_linux-aarch64_bin-jmods.zip'
+            openjfx-sha: '1982ad168a5e8d7cf4a9458a7d088b4f0552d0ac3f24f23fb88f8bc7e8d69a13'
     steps:
       - uses: actions/checkout@v4
       - name: Setup Java

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -20,10 +20,10 @@ env:
   JAVA_VERSION: '22.0.1+8'
   COFFEELIBS_JDK: 22
   COFFEELIBS_JDK_VERSION: '22.0.1+8-0ppa1'
-  OPENJFX_JMODS_AMD64: 'https://download2.gluonhq.com/openjfx/21.0.1/openjfx-21.0.1_linux-x64_bin-jmods.zip'
-  OPENJFX_JMODS_AMD64_HASH: '7baed11ca56d5fee85995fa6612d4299f1e8b7337287228f7f12fd50407c56f8'
-  OPENJFX_JMODS_AARCH64: 'https://download2.gluonhq.com/openjfx/21.0.1/openjfx-21.0.1_linux-aarch64_bin-jmods.zip'
-  OPENJFX_JMODS_AARCH64_HASH: '871e7b9d7af16aef2e55c1b7830d0e0b2503b13dd8641374ba7e55ecb81d2ef9'
+  OPENJFX_JMODS_AMD64: 'https://download2.gluonhq.com/openjfx/22.0.1/openjfx-22.0.1_linux-x64_bin-jmods.zip'
+  OPENJFX_JMODS_AMD64_HASH: 'fbb22f35951c2e049cc2554dd03c2c56b4f5adc4b2ae9248872f46175ac103d8'
+  OPENJFX_JMODS_AARCH64: 'https://download2.gluonhq.com/openjfx/22.0.1/openjfx-22.0.1_linux-aarch64_bin-jmods.zip'
+  OPENJFX_JMODS_AARCH64_HASH: '1982ad168a5e8d7cf4a9458a7d088b4f0552d0ac3f24f23fb88f8bc7e8d69a13'
 
 jobs:
   build:

--- a/.github/workflows/mac-dmg.yml
+++ b/.github/workflows/mac-dmg.yml
@@ -37,15 +37,15 @@ jobs:
           output-suffix: x64
           xcode-path: '/Applications/Xcode_13.2.1.app'
           fuse-lib: macFUSE
-          openjfx-url: 'https://download2.gluonhq.com/openjfx/21.0.1/openjfx-21.0.1_osx-x64_bin-jmods.zip'
-          openjfx-sha: 'bd6abab20da73d5a968dcf2fd915d81b5fb919340e3bb84979ee9a888a829939'
+          openjfx-url: 'https://download2.gluonhq.com/openjfx/22.0.1/openjfx-22.0.1_osx-x64_bin-jmods.zip'
+          openjfx-sha: 'e07a11c112abbdebe7c058b44c151e1e475de748671d896aef3d73f32453c248'
         - os: [self-hosted, macOS, ARM64]
           architecture: aarch64
           output-suffix: arm64
           xcode-path: '/Applications/Xcode_13.2.1.app'
           fuse-lib: FUSE-T
-          openjfx-url: 'https://download2.gluonhq.com/openjfx/21.0.1/openjfx-21.0.1_osx-aarch64_bin-jmods.zip'
-          openjfx-sha: '7afaa1c57a6cc3c384d636e597b9a5364693e2db4aaec0a6e63d2fa964400b58'
+          openjfx-url: 'https://download2.gluonhq.com/openjfx/22.0.1/openjfx-22.0.1_osx-aarch64_bin-jmods.zip'
+          openjfx-sha: '572fce94b9b09d316b960a49e3c2b5d35231ed0463e3b1c4020b8de89783b51d'
     steps:
       - uses: actions/checkout@v4
       - name: Setup Java

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -17,8 +17,8 @@ on:
 env:
   JAVA_DIST: 'zulu'
   JAVA_VERSION: '22.0.1+8'
-  OPENJFX_JMODS_AMD64: 'https://download2.gluonhq.com/openjfx/21.0.1/openjfx-21.0.1_windows-x64_bin-jmods.zip'
-  OPENJFX_JMODS_AMD64_HASH: 'daf8acae631c016c24cfe23f88469400274d3441dd890615a42dfb501f3eb94a'
+  OPENJFX_JMODS_AMD64: 'https://download2.gluonhq.com/openjfx/22.0.1/openjfx-22.0.1_windows-x64_bin-jmods.zip'
+  OPENJFX_JMODS_AMD64_HASH: 'de82e53179032a49bec005deb4438e8f261d08c4b58864a5c17e1d87286b09dd'
   WINFSP_MSI: 'https://github.com/winfsp/winfsp/releases/download/v2.0/winfsp-2.0.23075.msi'
   WINFSP_UNINSTALLER: 'https://github.com/cryptomator/winfsp-uninstaller/releases/latest/download/winfsp-uninstaller.exe'
 

--- a/dist/linux/appimage/build.sh
+++ b/dist/linux/appimage/build.sh
@@ -23,12 +23,12 @@ mvn -B -f ../../../pom.xml clean package -Plinux -DskipTests
 cp ../../../LICENSE.txt ../../../target
 cp ../../../target/cryptomator-*.jar ../../../target/mods
 
-JAVAFX_VERSION=21.0.1
+JAVAFX_VERSION=22.0.1
 JAVAFX_ARCH="x64"
-JAVAFX_JMODS_SHA256='7baed11ca56d5fee85995fa6612d4299f1e8b7337287228f7f12fd50407c56f8'
+JAVAFX_JMODS_SHA256='fbb22f35951c2e049cc2554dd03c2c56b4f5adc4b2ae9248872f46175ac103d8'
 if [ "${CPU_ARCH}" = "aarch64" ]; then
     JAVAFX_ARCH="aarch64"
-    JAVAFX_JMODS_SHA256='871e7b9d7af16aef2e55c1b7830d0e0b2503b13dd8641374ba7e55ecb81d2ef9'
+    JAVAFX_JMODS_SHA256='1982ad168a5e8d7cf4a9458a7d088b4f0552d0ac3f24f23fb88f8bc7e8d69a13'
 fi
 
 # download javaFX jmods

--- a/dist/linux/appimage/build.sh
+++ b/dist/linux/appimage/build.sh
@@ -12,9 +12,9 @@ command -v unzip >/dev/null 2>&1 || { echo >&2 "unzip not found."; exit 1; }
 
 VERSION=$(mvn -f ../../../pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
 SEMVER_STR=${VERSION}
-MACHINE_TYPE=$(uname -m)
+CPU_ARCH=$(uname -p)
 
-if [[ ! "${MACHINE_TYPE}" =~ x86_64|aarch64 ]]; then echo "Platform ${MACHINE_TYPE} not supported"; exit 1; fi
+if [[ ! "${CPU_ARCH}" =~ x86_64|aarch64 ]]; then echo "Platform ${CPU_ARCH} not supported"; exit 1; fi
 
 mvn -f ../../../pom.xml versions:set -DnewVersion=${SEMVER_STR}
 
@@ -23,20 +23,20 @@ mvn -B -f ../../../pom.xml clean package -Plinux -DskipTests
 cp ../../../LICENSE.txt ../../../target
 cp ../../../target/cryptomator-*.jar ../../../target/mods
 
-
-# download javaFX jmods
-OPENJFX_URL='https://download2.gluonhq.com/openjfx/21.0.1/openjfx-21.0.1_linux-x64_bin-jmods.zip'
-OPENJFX_SHA='7baed11ca56d5fee85995fa6612d4299f1e8b7337287228f7f12fd50407c56f8'
-OPENJFX_URL_aarch64='https://download2.gluonhq.com/openjfx/21.0.1/openjfx-21.0.1_linux-aarch64_bin-jmods.zip'
-OPENJFX_SHA_aarch64='871e7b9d7af16aef2e55c1b7830d0e0b2503b13dd8641374ba7e55ecb81d2ef9'
-
-if [[ "${MACHINE_TYPE}" = "aarch64" ]]; then
-	OPENJFX_URL="${OPENJFX_URL_aarch64}";
-	OPENJFX_SHA="${OPENJFX_SHA_aarch64}";
+JAVAFX_VERSION=21.0.1
+JAVAFX_ARCH="x64"
+JAVAFX_JMODS_SHA256='7baed11ca56d5fee85995fa6612d4299f1e8b7337287228f7f12fd50407c56f8'
+if [ "${CPU_ARCH}" = "aarch64" ]; then
+    JAVAFX_ARCH="aarch64"
+    JAVAFX_JMODS_SHA256='871e7b9d7af16aef2e55c1b7830d0e0b2503b13dd8641374ba7e55ecb81d2ef9'
 fi
 
-curl -L ${OPENJFX_URL} -o openjfx-jmods.zip
-echo "${OPENJFX_SHA}  openjfx-jmods.zip" | shasum -a256 --check
+# download javaFX jmods
+JAVAFX_JMODS_URL="https://download2.gluonhq.com/openjfx/${JAVAFX_VERSION}/openjfx-21.0.1_linux-${JAVAFX_ARCH}_bin-jmods.zip"
+
+
+curl -L ${JAVAFX_JMODS_URL} -o openjfx-jmods.zip
+echo "${JAVAFX_JMODS_SHA256}  openjfx-jmods.zip" | shasum -a256 --check
 mkdir -p openjfx-jmods
 unzip -o -j openjfx-jmods.zip \*/javafx.base.jmod \*/javafx.controls.jmod \*/javafx.fxml.jmod \*/javafx.graphics.jmod -d openjfx-jmods
 JMOD_VERSION=$(jmod describe ./openjfx-jmods/javafx.base.jmod | head -1)
@@ -114,17 +114,17 @@ ln -s usr/share/applications/org.cryptomator.Cryptomator.desktop Cryptomator.App
 ln -s bin/cryptomator.sh Cryptomator.AppDir/AppRun
 
 # load AppImageTool
-curl -L https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-${MACHINE_TYPE}.AppImage -o /tmp/appimagetool.AppImage
+curl -L https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-${CPU_ARCH}.AppImage -o /tmp/appimagetool.AppImage
 chmod +x /tmp/appimagetool.AppImage
 
 # create AppImage
 /tmp/appimagetool.AppImage \
     Cryptomator.AppDir \
-    cryptomator-${SEMVER_STR}-${MACHINE_TYPE}.AppImage  \
-    -u 'gh-releases-zsync|cryptomator|cryptomator|latest|cryptomator-*-${MACHINE_TYPE}.AppImage.zsync'
+    cryptomator-${SEMVER_STR}-${CPU_ARCH}.AppImage  \
+    -u 'gh-releases-zsync|cryptomator|cryptomator|latest|cryptomator-*-${CPU_ARCH}.AppImage.zsync'
 
 echo ""
-echo "Done. AppImage successfully created: cryptomator-${SEMVER_STR}-${MACHINE_TYPE}.AppImage"
+echo "Done. AppImage successfully created: cryptomator-${SEMVER_STR}-${CPU_ARCH}.AppImage"
 echo ""
 echo >&2 "To clean up, run: rm -rf Cryptomator.AppDir appdir runtime squashfs-root openjfx-jmods; rm /tmp/appimagetool.AppImage openjfx-jmods.zip"
 echo ""

--- a/dist/mac/dmg/build.sh
+++ b/dist/mac/dmg/build.sh
@@ -29,13 +29,17 @@ REVISION_NO=`git rev-list --count HEAD`
 VERSION_NO=`mvn -f../../../pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout | sed -rn 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p'`
 FUSE_LIB="FUSE-T"
 
-ARCH="undefined"
+JAVAFX_VERISON=21.0.1
+JAVAFX_ARCH="undefined"
+JAVAFX_JMODS_SHA256="undefined"
 if [ "$(machine)" = "arm64e" ]; then
-    ARCH="aarch64"
+    JAVAFX_ARCH="aarch64"
+    JAVAFX_JMODS_SHA256="7afaa1c57a6cc3c384d636e597b9a5364693e2db4aaec0a6e63d2fa964400b58"
 else
-    ARCH="x64"
+    JAVAFX_ARCH="x64"
+    JAVAFX_JMODS_SHA256="bd6abab20da73d5a968dcf2fd915d81b5fb919340e3bb84979ee9a888a829939"
 fi
-OPENJFX_JMODS="https://download2.gluonhq.com/openjfx/21.0.1/openjfx-21.0.1_osx-${ARCH}_bin-jmods.zip"
+JAVAFX_JMODS_URL="https://download2.gluonhq.com/openjfx/${JAVAFX_VERSION}/openjfx-${JAVAFX_VERSION}_osx-${JAVAFX_ARCH}_bin-jmods.zip"
 
 # check preconditions
 if [ -z "${JAVA_HOME}" ]; then echo "JAVA_HOME not set. Run using JAVA_HOME=/path/to/jdk ./build.sh"; exit 1; fi
@@ -47,7 +51,8 @@ if [ -n "${CODESIGN_IDENTITY}" ]; then
 fi
 
 # download and check jmods
-curl -L ${OPENJFX_JMODS} -o openjfx-jmods.zip
+curl -L ${JAVAFX_JMODS_URL} -o openjfx-jmods.zip
+echo "${JAVAFX_JMODS_SHA256} openjfx-jmods.zip" | shasum -a256 --check
 mkdir -p openjfx-jmods/
 unzip -jo openjfx-jmods.zip \*/javafx.base.jmod \*/javafx.controls.jmod \*/javafx.fxml.jmod \*/javafx.graphics.jmod -d openjfx-jmods
 JMOD_VERSION=$(jmod describe openjfx-jmods/javafx.base.jmod | head -1)

--- a/dist/mac/dmg/build.sh
+++ b/dist/mac/dmg/build.sh
@@ -29,15 +29,15 @@ REVISION_NO=`git rev-list --count HEAD`
 VERSION_NO=`mvn -f../../../pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout | sed -rn 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p'`
 FUSE_LIB="FUSE-T"
 
-JAVAFX_VERISON=21.0.1
+JAVAFX_VERISON=22.0.1
 JAVAFX_ARCH="undefined"
 JAVAFX_JMODS_SHA256="undefined"
 if [ "$(machine)" = "arm64e" ]; then
     JAVAFX_ARCH="aarch64"
-    JAVAFX_JMODS_SHA256="7afaa1c57a6cc3c384d636e597b9a5364693e2db4aaec0a6e63d2fa964400b58"
+    JAVAFX_JMODS_SHA256="572fce94b9b09d316b960a49e3c2b5d35231ed0463e3b1c4020b8de89783b51d"
 else
     JAVAFX_ARCH="x64"
-    JAVAFX_JMODS_SHA256="bd6abab20da73d5a968dcf2fd915d81b5fb919340e3bb84979ee9a888a829939"
+    JAVAFX_JMODS_SHA256="e07a11c112abbdebe7c058b44c151e1e475de748671d896aef3d73f32453c248"
 fi
 JAVAFX_JMODS_URL="https://download2.gluonhq.com/openjfx/${JAVAFX_VERSION}/openjfx-${JAVAFX_VERSION}_osx-${JAVAFX_ARCH}_bin-jmods.zip"
 

--- a/dist/win/build.ps1
+++ b/dist/win/build.ps1
@@ -51,21 +51,22 @@ if ($clean -and (Test-Path -Path $runtimeImagePath)) {
 }
 
 ## download jfx jmods
-$jmodsVersion='21.0.1'
-$jmodsUrl = "https://download2.gluonhq.com/openjfx/${jmodsVersion}/openjfx-${jmodsVersion}_windows-x64_bin-jmods.zip"
-$jfxJmodsChecksum = 'daf8acae631c016c24cfe23f88469400274d3441dd890615a42dfb501f3eb94a'
-$jfxJmodsZip = '.\resources\jfxJmods.zip'
-if( !(Test-Path -Path $jfxJmodsZip) ) {
-	Write-Output "Downloading ${jmodsUrl}..."
-	Invoke-WebRequest $jmodsUrl -OutFile $jfxJmodsZip # redirects are followed by default
+$javaFxVersion='21.0.1'
+$javaFxJmodsUrl = "https://download2.gluonhq.com/openjfx/${javaFxVersion}/openjfx-${javaFxVersion}_windows-x64_bin-jmods.zip"
+$javaFxJmodsSHA256 = 'daf8acae631c016c24cfe23f88469400274d3441dd890615a42dfb501f3eb94a'
+$javaFxJmods = '.\resources\jfxJmods.zip'
+if( !(Test-Path -Path $javaFxJmods) ) {
+	Write-Output "Downloading ${javaFxJmodsUrl}..."
+	Invoke-WebRequest $javaFxJmodsUrl -OutFile $javaFxJmods # redirects are followed by default
 }
 
-$jmodsChecksumActual = $(Get-FileHash -Path $jfxJmodsZip -Algorithm SHA256).Hash
-if( $jmodsChecksumActual -ne $jfxJmodsChecksum ) {
-	Write-Error "Checksum mismatch for jfxJmods.zip. Expected: $jfxJmodsChecksum, actual: $jmodsChecksumActual"
+$jmodsChecksumActual = $(Get-FileHash -Path $javaFxJmods -Algorithm SHA256).Hash
+if( $jmodsChecksumActual -ne $javaFxJmodsSHA256 ) {
+	Write-Error "Checksum mismatch for jfxJmods.zip. Expected: $javaFxJmodsSHA256
+, actual: $jmodsChecksumActual"
 	exit 1;
 }
-Expand-Archive -Path $jfxJmodsZip -Force -DestinationPath ".\resources\"
+Expand-Archive -Path $javaFxJmods -Force -DestinationPath ".\resources\"
 Remove-Item -Recurse -Force -Path ".\resources\javafx-jmods"
 Move-Item -Force -Path ".\resources\javafx-jmods-*" -Destination ".\resources\javafx-jmods" -ErrorAction Stop
 

--- a/dist/win/build.ps1
+++ b/dist/win/build.ps1
@@ -51,9 +51,9 @@ if ($clean -and (Test-Path -Path $runtimeImagePath)) {
 }
 
 ## download jfx jmods
-$javaFxVersion='21.0.1'
+$javaFxVersion='22.0.1'
 $javaFxJmodsUrl = "https://download2.gluonhq.com/openjfx/${javaFxVersion}/openjfx-${javaFxVersion}_windows-x64_bin-jmods.zip"
-$javaFxJmodsSHA256 = 'daf8acae631c016c24cfe23f88469400274d3441dd890615a42dfb501f3eb94a'
+$javaFxJmodsSHA256 = 'de82e53179032a49bec005deb4438e8f261d08c4b58864a5c17e1d87286b09dd'
 $javaFxJmods = '.\resources\jfxJmods.zip'
 if( !(Test-Path -Path $javaFxJmods) ) {
 	Write-Output "Downloading ${javaFxJmodsUrl}..."

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 		<easybind.version>2.2</easybind.version>
 		<guava.version>33.2.1-jre</guava.version>
 		<jackson.version>2.17.1</jackson.version>
-		<javafx.version>21.0.1</javafx.version>
+		<javafx.version>22.0.1</javafx.version>
 		<jwt.version>4.4.0</jwt.version>
 		<nimbus-jose.version>9.37.3</nimbus-jose.version>
 		<logback.version>1.5.6</logback.version>


### PR DESCRIPTION
We cannot update the Java 21 LTS version, since there are no more linux aarch64 artifacts released for it.