### PR TITLE
Cleanup: Dagger+Guava dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,9 +43,8 @@
 
 		<!-- 3rd party dependencies -->
 		<commons-lang3.version>3.16.0</commons-lang3.version>
-		<dagger.version>2.51.1</dagger.version>
+		<dagger.version>2.52</dagger.version>
 		<easybind.version>2.2</easybind.version>
-		<guava.version>33.3.0-jre</guava.version>
 		<jackson.version>2.17.2</jackson.version>
 		<javafx.version>22.0.2</javafx.version>
 		<jwt.version>4.4.0</jwt.version>
@@ -192,37 +191,14 @@
 
 		<!-- Google -->
 		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>${guava.version}</version>
-			<exclusions>
-				<!-- see https://github.com/google/guava/wiki/UseGuavaInYourBuild#what-about-guavas-own-dependencies -->
-				<exclusion>
-					<groupId>com.google.guava</groupId>
-					<artifactId>listenablefuture</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.google.code.findbugs</groupId>
-					<artifactId>jsr305</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.checkerframework</groupId>
-					<artifactId>checker-qual</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.google.errorprone</groupId>
-					<artifactId>error_prone_annotations</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.google.j2objc</groupId>
-					<artifactId>j2objc-annotations</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
 			<groupId>com.google.dagger</groupId>
 			<artifactId>dagger</artifactId>
 			<version>${dagger.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.inject</groupId>
+			<artifactId>jakarta.inject-api</artifactId>
+			<version>2.0.1</version>
 		</dependency>
 
 		<!-- JUnit / Mockito / Hamcrest -->

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -42,13 +42,13 @@ open module org.cryptomator.desktop {
 	requires com.nulabinc.zxcvbn;
 	requires com.tobiasdiez.easybind;
 	requires dagger;
-	requires java.compiler;
 	requires io.github.coffeelibs.tinyoauth2client;
 	requires org.slf4j;
 	requires org.apache.commons.lang3;
 
-	/* TODO: filename-based modules: */
-	requires static javax.inject; /* ugly dagger/guava crap */
+	/* dagger bs */
+	requires jakarta.inject;
+	requires java.compiler;
 
 	uses org.cryptomator.common.locationpresets.LocationPresetsProvider;
 


### PR DESCRIPTION
This PR
* updates dagger to the latest version
* adds jakarta-inject-api as a dependency and
* removces guava as a dependency

Guava is not used anymore in the project. ` jakarta-inject-api` is required with updating dagger to 2.52, see also https://github.com/google/dagger/issues/4391.