### PR TITLE
Feature: Add Option to Enable Compact Vault List View

### DIFF
--- a/src/main/java/org/cryptomator/common/settings/Settings.java
+++ b/src/main/java/org/cryptomator/common/settings/Settings.java
@@ -60,6 +60,7 @@ public class Settings {
 	public final ObjectProperty<NodeOrientation> userInterfaceOrientation;
 	public final StringProperty licenseKey;
 	public final BooleanProperty showTrayIcon;
+	public final BooleanProperty useCondensedMode;
 	public final IntegerProperty windowXPosition;
 	public final IntegerProperty windowYPosition;
 	public final IntegerProperty windowWidth;
@@ -96,6 +97,7 @@ public class Settings {
 		this.userInterfaceOrientation = new SimpleObjectProperty<>(this, "userInterfaceOrientation", parseEnum(json.uiOrientation, NodeOrientation.class, NodeOrientation.LEFT_TO_RIGHT));
 		this.licenseKey = new SimpleStringProperty(this, "licenseKey", json.licenseKey);
 		this.showTrayIcon = new SimpleBooleanProperty(this, "showTrayIcon", json.showTrayIcon);
+		this.useCondensedMode = new SimpleBooleanProperty(this, "useCondensedMode", json.useCondensedMode);
 		this.windowXPosition = new SimpleIntegerProperty(this, "windowXPosition", json.windowXPosition);
 		this.windowYPosition = new SimpleIntegerProperty(this, "windowYPosition", json.windowYPosition);
 		this.windowWidth = new SimpleIntegerProperty(this, "windowWidth", json.windowWidth);
@@ -122,6 +124,7 @@ public class Settings {
 		userInterfaceOrientation.addListener(this::somethingChanged);
 		licenseKey.addListener(this::somethingChanged);
 		showTrayIcon.addListener(this::somethingChanged);
+		useCondensedMode.addListener(this::somethingChanged);
 		windowXPosition.addListener(this::somethingChanged);
 		windowYPosition.addListener(this::somethingChanged);
 		windowWidth.addListener(this::somethingChanged);
@@ -175,6 +178,7 @@ public class Settings {
 		json.uiOrientation = userInterfaceOrientation.get().name();
 		json.licenseKey = licenseKey.get();
 		json.showTrayIcon = showTrayIcon.get();
+		json.useCondensedMode = useCondensedMode.get();
 		json.windowXPosition = windowXPosition.get();
 		json.windowYPosition = windowYPosition.get();
 		json.windowWidth = windowWidth.get();

--- a/src/main/java/org/cryptomator/common/settings/Settings.java
+++ b/src/main/java/org/cryptomator/common/settings/Settings.java
@@ -60,7 +60,7 @@ public class Settings {
 	public final ObjectProperty<NodeOrientation> userInterfaceOrientation;
 	public final StringProperty licenseKey;
 	public final BooleanProperty showTrayIcon;
-	public final BooleanProperty useCondensedMode;
+	public final BooleanProperty compactMode;
 	public final IntegerProperty windowXPosition;
 	public final IntegerProperty windowYPosition;
 	public final IntegerProperty windowWidth;
@@ -97,7 +97,7 @@ public class Settings {
 		this.userInterfaceOrientation = new SimpleObjectProperty<>(this, "userInterfaceOrientation", parseEnum(json.uiOrientation, NodeOrientation.class, NodeOrientation.LEFT_TO_RIGHT));
 		this.licenseKey = new SimpleStringProperty(this, "licenseKey", json.licenseKey);
 		this.showTrayIcon = new SimpleBooleanProperty(this, "showTrayIcon", json.showTrayIcon);
-		this.useCondensedMode = new SimpleBooleanProperty(this, "useCondensedMode", json.useCondensedMode);
+		this.compactMode = new SimpleBooleanProperty(this, "compactMode", json.compactMode);
 		this.windowXPosition = new SimpleIntegerProperty(this, "windowXPosition", json.windowXPosition);
 		this.windowYPosition = new SimpleIntegerProperty(this, "windowYPosition", json.windowYPosition);
 		this.windowWidth = new SimpleIntegerProperty(this, "windowWidth", json.windowWidth);
@@ -124,7 +124,7 @@ public class Settings {
 		userInterfaceOrientation.addListener(this::somethingChanged);
 		licenseKey.addListener(this::somethingChanged);
 		showTrayIcon.addListener(this::somethingChanged);
-		useCondensedMode.addListener(this::somethingChanged);
+		compactMode.addListener(this::somethingChanged);
 		windowXPosition.addListener(this::somethingChanged);
 		windowYPosition.addListener(this::somethingChanged);
 		windowWidth.addListener(this::somethingChanged);
@@ -178,7 +178,7 @@ public class Settings {
 		json.uiOrientation = userInterfaceOrientation.get().name();
 		json.licenseKey = licenseKey.get();
 		json.showTrayIcon = showTrayIcon.get();
-		json.useCondensedMode = useCondensedMode.get();
+		json.compactMode = compactMode.get();
 		json.windowXPosition = windowXPosition.get();
 		json.windowYPosition = windowYPosition.get();
 		json.windowWidth = windowWidth.get();

--- a/src/main/java/org/cryptomator/common/settings/SettingsJson.java
+++ b/src/main/java/org/cryptomator/common/settings/SettingsJson.java
@@ -54,8 +54,8 @@ class SettingsJson {
 	@JsonProperty("showTrayIcon")
 	boolean showTrayIcon;
 
-	@JsonProperty("useCondensedMode")
-	boolean useCondensedMode;
+	@JsonProperty("compactMode")
+	boolean compactMode;
 
 	@JsonProperty("startHidden")
 	boolean startHidden = Settings.DEFAULT_START_HIDDEN;

--- a/src/main/java/org/cryptomator/common/settings/SettingsJson.java
+++ b/src/main/java/org/cryptomator/common/settings/SettingsJson.java
@@ -54,6 +54,9 @@ class SettingsJson {
 	@JsonProperty("showTrayIcon")
 	boolean showTrayIcon;
 
+	@JsonProperty("useCondensedMode")
+	boolean useCondensedMode;
+
 	@JsonProperty("startHidden")
 	boolean startHidden = Settings.DEFAULT_START_HIDDEN;
 

--- a/src/main/java/org/cryptomator/ui/mainwindow/VaultListCellController.java
+++ b/src/main/java/org/cryptomator/ui/mainwindow/VaultListCellController.java
@@ -21,7 +21,7 @@ public class VaultListCellController implements FxController {
 
 	private final ObjectProperty<Vault> vault = new SimpleObjectProperty<>();
 	private final ObservableValue<FontAwesome5Icon> glyph;
-	private final BooleanBinding useCondensedMode;
+	private final BooleanBinding compactMode;
 
 	private AutoAnimator spinAnimation;
 
@@ -31,7 +31,7 @@ public class VaultListCellController implements FxController {
 	@Inject
 	VaultListCellController(Settings settings) {
 		this.glyph = vault.flatMap(Vault::stateProperty).map(this::getGlyphForVaultState);
-		this.useCondensedMode = Bindings.createBooleanBinding(settings.useCondensedMode::get, settings.useCondensedMode);
+		this.compactMode = Bindings.createBooleanBinding(settings.compactMode::get, settings.compactMode);
 	}
 
 	public void initialize() {
@@ -73,11 +73,11 @@ public class VaultListCellController implements FxController {
 		return vault.get();
 	}
 
-	public BooleanBinding useCondensedModeProperty() {
-		return useCondensedMode;
+	public BooleanBinding compactModeProperty() {
+		return compactMode;
 	}
-	public boolean isUseCondensedMode() {
-		return useCondensedMode.get();
+	public boolean getCompactMode() {
+		return compactMode.get();
 	}
 
 	public void setVault(Vault value) {

--- a/src/main/java/org/cryptomator/ui/mainwindow/VaultListCellController.java
+++ b/src/main/java/org/cryptomator/ui/mainwindow/VaultListCellController.java
@@ -21,7 +21,7 @@ public class VaultListCellController implements FxController {
 
 	private final ObjectProperty<Vault> vault = new SimpleObjectProperty<>();
 	private final ObservableValue<FontAwesome5Icon> glyph;
-	private final BooleanBinding compactMode;
+	private final ObservableValue<Boolean> compactMode;
 
 	private AutoAnimator spinAnimation;
 
@@ -31,7 +31,7 @@ public class VaultListCellController implements FxController {
 	@Inject
 	VaultListCellController(Settings settings) {
 		this.glyph = vault.flatMap(Vault::stateProperty).map(this::getGlyphForVaultState);
-		this.compactMode = Bindings.createBooleanBinding(settings.compactMode::get, settings.compactMode);
+		this.compactMode = settings.compactMode;
 	}
 
 	public void initialize() {
@@ -73,11 +73,12 @@ public class VaultListCellController implements FxController {
 		return vault.get();
 	}
 
-	public BooleanBinding compactModeProperty() {
+	public ObservableValue<Boolean> compactModeProperty() {
 		return compactMode;
 	}
+
 	public boolean getCompactMode() {
-		return compactMode.get();
+		return compactMode.getValue();
 	}
 
 	public void setVault(Vault value) {

--- a/src/main/java/org/cryptomator/ui/mainwindow/VaultListCellController.java
+++ b/src/main/java/org/cryptomator/ui/mainwindow/VaultListCellController.java
@@ -1,5 +1,6 @@
 package org.cryptomator.ui.mainwindow;
 
+import org.cryptomator.common.settings.Settings;
 import org.cryptomator.common.vaults.Vault;
 import org.cryptomator.common.vaults.VaultState;
 import org.cryptomator.ui.common.Animations;
@@ -9,6 +10,8 @@ import org.cryptomator.ui.controls.FontAwesome5Icon;
 import org.cryptomator.ui.controls.FontAwesome5IconView;
 
 import javax.inject.Inject;
+import javafx.beans.binding.Bindings;
+import javafx.beans.binding.BooleanBinding;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ObservableValue;
@@ -18,6 +21,7 @@ public class VaultListCellController implements FxController {
 
 	private final ObjectProperty<Vault> vault = new SimpleObjectProperty<>();
 	private final ObservableValue<FontAwesome5Icon> glyph;
+	private final BooleanBinding useCondensedMode;
 
 	private AutoAnimator spinAnimation;
 
@@ -25,8 +29,9 @@ public class VaultListCellController implements FxController {
 	public FontAwesome5IconView vaultStateView;
 
 	@Inject
-	VaultListCellController() {
+	VaultListCellController(Settings settings) {
 		this.glyph = vault.flatMap(Vault::stateProperty).map(this::getGlyphForVaultState);
+		this.useCondensedMode = Bindings.createBooleanBinding(settings.useCondensedMode::get, settings.useCondensedMode);
 	}
 
 	public void initialize() {
@@ -66,6 +71,13 @@ public class VaultListCellController implements FxController {
 
 	public Vault getVault() {
 		return vault.get();
+	}
+
+	public BooleanBinding useCondensedModeProperty() {
+		return useCondensedMode;
+	}
+	public boolean isUseCondensedMode() {
+		return useCondensedMode.get();
 	}
 
 	public void setVault(Vault value) {

--- a/src/main/java/org/cryptomator/ui/mainwindow/VaultListCellController.java
+++ b/src/main/java/org/cryptomator/ui/mainwindow/VaultListCellController.java
@@ -10,8 +10,6 @@ import org.cryptomator.ui.controls.FontAwesome5Icon;
 import org.cryptomator.ui.controls.FontAwesome5IconView;
 
 import javax.inject.Inject;
-import javafx.beans.binding.Bindings;
-import javafx.beans.binding.BooleanBinding;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ObservableValue;

--- a/src/main/java/org/cryptomator/ui/mainwindow/VaultListController.java
+++ b/src/main/java/org/cryptomator/ui/mainwindow/VaultListController.java
@@ -1,6 +1,7 @@
 package org.cryptomator.ui.mainwindow;
 
 import org.apache.commons.lang3.SystemUtils;
+import org.cryptomator.common.settings.Settings;
 import org.cryptomator.common.vaults.Vault;
 import org.cryptomator.common.vaults.VaultListManager;
 import org.cryptomator.cryptofs.CryptoFileSystemProvider;
@@ -71,6 +72,7 @@ public class VaultListController implements FxController {
 	private final BooleanProperty draggingVaultOver = new SimpleBooleanProperty();
 	private final ResourceBundle resourceBundle;
 	private final FxApplicationWindows appWindows;
+	private final BooleanBinding useCondensedMode;
 
 	public ListView<Vault> vaultList;
 	public VBox vbox;
@@ -89,7 +91,8 @@ public class VaultListController implements FxController {
 						RemoveVaultComponent.Builder removeVaultDialogue, //
 						VaultListManager vaultListManager, //
 						ResourceBundle resourceBundle, //
-						FxApplicationWindows appWindows) {
+						FxApplicationWindows appWindows, //
+						Settings settings) {
 		this.mainWindow = mainWindow;
 		this.vaults = vaults;
 		this.selectedVault = selectedVault;
@@ -102,6 +105,7 @@ public class VaultListController implements FxController {
 		this.appWindows = appWindows;
 
 		this.emptyVaultList = Bindings.isEmpty(vaults);
+		this.useCondensedMode = Bindings.createBooleanBinding(settings.useCondensedMode::get, settings.useCondensedMode);
 
 		selectedVault.addListener(this::selectedVaultDidChange);
 	}
@@ -109,6 +113,9 @@ public class VaultListController implements FxController {
 	public void initialize() {
 		vaultList.setItems(vaults);
 		vaultList.setCellFactory(cellFactory);
+
+		vaultList.fixedCellSizeProperty().bind(Bindings.createDoubleBinding(() ->
+				useCondensedMode.get() ? 30.0 : 60.0, useCondensedMode));
 
 		selectedVault.bind(vaultList.getSelectionModel().selectedItemProperty());
 		vaults.addListener((ListChangeListener.Change<? extends Vault> c) -> {

--- a/src/main/java/org/cryptomator/ui/mainwindow/VaultListController.java
+++ b/src/main/java/org/cryptomator/ui/mainwindow/VaultListController.java
@@ -71,7 +71,7 @@ public class VaultListController implements FxController {
 	private final BooleanProperty draggingVaultOver = new SimpleBooleanProperty();
 	private final ResourceBundle resourceBundle;
 	private final FxApplicationWindows appWindows;
-	private final BooleanBinding useCondensedMode;
+	private final BooleanBinding compactMode;
 
 	public ListView<Vault> vaultList;
 	public StackPane root;
@@ -104,7 +104,7 @@ public class VaultListController implements FxController {
 		this.appWindows = appWindows;
 
 		this.emptyVaultList = Bindings.isEmpty(vaults);
-		this.useCondensedMode = Bindings.createBooleanBinding(settings.useCondensedMode::get, settings.useCondensedMode);
+		this.compactMode = Bindings.createBooleanBinding(settings.compactMode::get, settings.compactMode);
 
 		selectedVault.addListener(this::selectedVaultDidChange);
 	}
@@ -114,7 +114,7 @@ public class VaultListController implements FxController {
 		vaultList.setCellFactory(cellFactory);
 
 		vaultList.fixedCellSizeProperty().bind(Bindings.createDoubleBinding(() ->
-				useCondensedMode.get() ? 30.0 : 60.0, useCondensedMode));
+				compactMode.get() ? 30.0 : 60.0, compactMode));
 
 		selectedVault.bind(vaultList.getSelectionModel().selectedItemProperty());
 		vaults.addListener((ListChangeListener.Change<? extends Vault> c) -> {

--- a/src/main/java/org/cryptomator/ui/mainwindow/VaultListController.java
+++ b/src/main/java/org/cryptomator/ui/mainwindow/VaultListController.java
@@ -71,7 +71,7 @@ public class VaultListController implements FxController {
 	private final BooleanProperty draggingVaultOver = new SimpleBooleanProperty();
 	private final ResourceBundle resourceBundle;
 	private final FxApplicationWindows appWindows;
-	private final BooleanBinding compactMode;
+	private final Settings settings;
 
 	public ListView<Vault> vaultList;
 	public StackPane root;
@@ -102,9 +102,9 @@ public class VaultListController implements FxController {
 		this.vaultListManager = vaultListManager;
 		this.resourceBundle = resourceBundle;
 		this.appWindows = appWindows;
+		this.settings = settings;
 
 		this.emptyVaultList = Bindings.isEmpty(vaults);
-		this.compactMode = Bindings.createBooleanBinding(settings.compactMode::get, settings.compactMode);
 
 		selectedVault.addListener(this::selectedVaultDidChange);
 	}
@@ -114,7 +114,7 @@ public class VaultListController implements FxController {
 		vaultList.setCellFactory(cellFactory);
 
 		vaultList.fixedCellSizeProperty().bind(Bindings.createDoubleBinding(() ->
-				compactMode.get() ? 30.0 : 60.0, compactMode));
+				settings.compactMode.get() ? 30.0 : 60.0, settings.compactMode));
 
 		selectedVault.bind(vaultList.getSelectionModel().selectedItemProperty());
 		vaults.addListener((ListChangeListener.Change<? extends Vault> c) -> {

--- a/src/main/java/org/cryptomator/ui/mainwindow/VaultListController.java
+++ b/src/main/java/org/cryptomator/ui/mainwindow/VaultListController.java
@@ -71,8 +71,7 @@ public class VaultListController implements FxController {
 	private final BooleanProperty draggingVaultOver = new SimpleBooleanProperty();
 	private final ResourceBundle resourceBundle;
 	private final FxApplicationWindows appWindows;
-	private final Settings settings;
-
+	private final ObservableValue<Double> cellSize;
 	public ListView<Vault> vaultList;
 	public StackPane root;
 	@FXML
@@ -102,19 +101,16 @@ public class VaultListController implements FxController {
 		this.vaultListManager = vaultListManager;
 		this.resourceBundle = resourceBundle;
 		this.appWindows = appWindows;
-		this.settings = settings;
 
 		this.emptyVaultList = Bindings.isEmpty(vaults);
 
 		selectedVault.addListener(this::selectedVaultDidChange);
+		cellSize = settings.compactMode.map(compact -> compact ? 30.0 : 60.0);
 	}
 
 	public void initialize() {
 		vaultList.setItems(vaults);
 		vaultList.setCellFactory(cellFactory);
-
-		vaultList.fixedCellSizeProperty().bind(Bindings.createDoubleBinding(() ->
-				settings.compactMode.get() ? 30.0 : 60.0, settings.compactMode));
 
 		selectedVault.bind(vaultList.getSelectionModel().selectedItemProperty());
 		vaults.addListener((ListChangeListener.Change<? extends Vault> c) -> {
@@ -280,5 +276,12 @@ public class VaultListController implements FxController {
 		return draggingVaultOver.get();
 	}
 
+	public ObservableValue<Double> cellSizeProperty() {
+		return cellSize;
+	}
+
+	public Double getCellSize() {
+		return cellSize.getValue();
+	}
 
 }

--- a/src/main/java/org/cryptomator/ui/preferences/InterfacePreferencesController.java
+++ b/src/main/java/org/cryptomator/ui/preferences/InterfacePreferencesController.java
@@ -37,7 +37,7 @@ public class InterfacePreferencesController implements FxController {
 	private final SupportedLanguages supportedLanguages;
 	public ChoiceBox<UiTheme> themeChoiceBox;
 	public CheckBox showTrayIconCheckbox;
-	public CheckBox useCondensedModeCheckbox;
+	public CheckBox compactModeCheckbox;
 	public ChoiceBox<String> preferredLanguageChoiceBox;
 	public ToggleGroup nodeOrientation;
 	public RadioButton nodeOrientationLtr;
@@ -64,7 +64,7 @@ public class InterfacePreferencesController implements FxController {
 		themeChoiceBox.setConverter(new UiThemeConverter(resourceBundle));
 
 		showTrayIconCheckbox.selectedProperty().bindBidirectional(settings.showTrayIcon);
-		useCondensedModeCheckbox.selectedProperty().bindBidirectional(settings.useCondensedMode);
+		compactModeCheckbox.selectedProperty().bindBidirectional(settings.compactMode);
 
 		preferredLanguageChoiceBox.getItems().addAll(supportedLanguages.getLanguageTags());
 		preferredLanguageChoiceBox.valueProperty().bindBidirectional(settings.language);

--- a/src/main/java/org/cryptomator/ui/preferences/InterfacePreferencesController.java
+++ b/src/main/java/org/cryptomator/ui/preferences/InterfacePreferencesController.java
@@ -37,6 +37,7 @@ public class InterfacePreferencesController implements FxController {
 	private final SupportedLanguages supportedLanguages;
 	public ChoiceBox<UiTheme> themeChoiceBox;
 	public CheckBox showTrayIconCheckbox;
+	public CheckBox useCondensedModeCheckbox;
 	public ChoiceBox<String> preferredLanguageChoiceBox;
 	public ToggleGroup nodeOrientation;
 	public RadioButton nodeOrientationLtr;
@@ -63,6 +64,7 @@ public class InterfacePreferencesController implements FxController {
 		themeChoiceBox.setConverter(new UiThemeConverter(resourceBundle));
 
 		showTrayIconCheckbox.selectedProperty().bindBidirectional(settings.showTrayIcon);
+		useCondensedModeCheckbox.selectedProperty().bindBidirectional(settings.useCondensedMode);
 
 		preferredLanguageChoiceBox.getItems().addAll(supportedLanguages.getLanguageTags());
 		preferredLanguageChoiceBox.valueProperty().bindBidirectional(settings.language);

--- a/src/main/resources/fxml/preferences_interface.fxml
+++ b/src/main/resources/fxml/preferences_interface.fxml
@@ -38,5 +38,6 @@
 		</HBox>
 
 		<CheckBox fx:id="showTrayIconCheckbox" text="%preferences.interface.showTrayIcon" visible="${controller.trayMenuSupported}" managed="${controller.trayMenuSupported}"/>
+		<CheckBox fx:id="useCondensedModeCheckbox" text="%preferences.interface.condensedVaultList"/>
 	</children>
 </VBox>

--- a/src/main/resources/fxml/preferences_interface.fxml
+++ b/src/main/resources/fxml/preferences_interface.fxml
@@ -38,6 +38,6 @@
 		</HBox>
 
 		<CheckBox fx:id="showTrayIconCheckbox" text="%preferences.interface.showTrayIcon" visible="${controller.trayMenuSupported}" managed="${controller.trayMenuSupported}"/>
-		<CheckBox fx:id="useCondensedModeCheckbox" text="%preferences.interface.condensedVaultList"/>
+		<CheckBox fx:id="compactModeCheckbox" text="%preferences.interface.compactMode"/>
 	</children>
 </VBox>

--- a/src/main/resources/fxml/vault_list.fxml
+++ b/src/main/resources/fxml/vault_list.fxml
@@ -18,7 +18,7 @@
 		   minWidth="206">
 	<VBox>
 		<StackPane VBox.vgrow="ALWAYS">
-			<ListView fx:id="vaultList" editable="true" fixedCellSize="60">
+			<ListView fx:id="vaultList" editable="true" fixedCellSize="${controller.cellSize}">
 				<contextMenu>
 					<fx:include source="vault_list_contextmenu.fxml"/>
 				</contextMenu>

--- a/src/main/resources/fxml/vault_list_cell.fxml
+++ b/src/main/resources/fxml/vault_list_cell.fxml
@@ -23,7 +23,7 @@
 		</VBox>
 		<VBox spacing="4" HBox.hgrow="ALWAYS">
 			<Label styleClass="header-label" text="${controller.vault.displayName}"/>
-			<Label styleClass="detail-label" text="${controller.vault.displayablePath}" textOverrun="CENTER_ELLIPSIS">
+			<Label styleClass="detail-label" text="${controller.vault.displayablePath}" textOverrun="CENTER_ELLIPSIS" visible="${!controller.useCondensedMode}" managed="${!controller.useCondensedMode}">
 				<tooltip>
 					<Tooltip text="${controller.vault.displayablePath}"/>
 				</tooltip>

--- a/src/main/resources/fxml/vault_list_cell.fxml
+++ b/src/main/resources/fxml/vault_list_cell.fxml
@@ -23,7 +23,7 @@
 		</VBox>
 		<VBox spacing="4" HBox.hgrow="ALWAYS">
 			<Label styleClass="header-label" text="${controller.vault.displayName}"/>
-			<Label styleClass="detail-label" text="${controller.vault.displayablePath}" textOverrun="CENTER_ELLIPSIS" visible="${!controller.useCondensedMode}" managed="${!controller.useCondensedMode}">
+			<Label styleClass="detail-label" text="${controller.vault.displayablePath}" textOverrun="CENTER_ELLIPSIS" visible="${!controller.compactMode}" managed="${!controller.compactMode}">
 				<tooltip>
 					<Tooltip text="${controller.vault.displayablePath}"/>
 				</tooltip>

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -301,6 +301,7 @@ preferences.interface.interfaceOrientation=Interface Orientation
 preferences.interface.interfaceOrientation.ltr=Left to Right
 preferences.interface.interfaceOrientation.rtl=Right to Left
 preferences.interface.showTrayIcon=Show tray icon (requires restart)
+preferences.interface.condensedVaultList=Enable compact vault list
 ## Volume
 preferences.volume=Virtual Drive
 preferences.volume.type=Default Volume Type

--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -301,7 +301,7 @@ preferences.interface.interfaceOrientation=Interface Orientation
 preferences.interface.interfaceOrientation.ltr=Left to Right
 preferences.interface.interfaceOrientation.rtl=Right to Left
 preferences.interface.showTrayIcon=Show tray icon (requires restart)
-preferences.interface.condensedVaultList=Enable compact vault list
+preferences.interface.compactMode=Enable compact vault list
 ## Volume
 preferences.volume=Virtual Drive
 preferences.volume.type=Default Volume Type


### PR DESCRIPTION
This PR introduces the ability to display the vault list in a compact view.

The option can be found under Preferences > Interface with the label "Enable compact vault list". When enabled, the vault list is displayed in a more condensed format, and the display is updated immediately.
<img width="762" alt="Bildschirmfoto 2024-09-20 um 15 22 17" src="https://github.com/user-attachments/assets/af6f6072-3d02-481d-a8b4-6c94f7114483">
<img width="718" alt="Bildschirmfoto 2024-09-20 um 14 59 31" src="https://github.com/user-attachments/assets/615d0bb0-2e9e-46a1-995a-2905144ad907">
<img width="718" alt="Bildschirmfoto 2024-09-20 um 15 17 05" src="https://github.com/user-attachments/assets/b864e3c4-1964-493c-97cf-305b66edfcaf">
