### PR TITLE
fix unicode escaping for rtf file

### DIFF
--- a/src/main/java/org/cryptomator/ui/addvaultwizard/ReadmeGenerator.java
+++ b/src/main/java/org/cryptomator/ui/addvaultwizard/ReadmeGenerator.java
@@ -79,7 +79,7 @@ public class ReadmeGenerator {
 			} else if (c <= 0xFF) {
 				sb.append("\\'").append(String.format("%02X", c));
 			} else if (c < 0xFFFF) {
-				sb.append("\\u").append(c);
+				sb.append("\\uc1\\u").append(c);
 			}
 		});
 	}

--- a/src/main/java/org/cryptomator/ui/addvaultwizard/ReadmeGenerator.java
+++ b/src/main/java/org/cryptomator/ui/addvaultwizard/ReadmeGenerator.java
@@ -76,6 +76,8 @@ public class ReadmeGenerator {
 		input.chars().forEachOrdered(c -> {
 			if (c < 128) {
 				sb.append((char) c);
+			} else if (c <= 0xFF) {
+				sb.append("\\'").append(String.format("%02X", c));
 			} else if (c < 0xFFFF) {
 				sb.append("\\u").append(c);
 			}

--- a/src/test/java/org/cryptomator/ui/addvaultwizard/ReadMeGeneratorTest.java
+++ b/src/test/java/org/cryptomator/ui/addvaultwizard/ReadMeGeneratorTest.java
@@ -15,8 +15,8 @@ public class ReadMeGeneratorTest {
 	@ParameterizedTest
 	@CsvSource({ //
 			"test,test", //
-			"t\u00E4st,t\\u228st", //
-			"t\uD83D\uDE09st,t\\u55357\\u56841st", //
+			"t\u00E4st,t\\'E4st", //
+			"t\uD83D\uDE09st,t\\uc1\\u55357\\uc1\\u56841st", //
 	})
 	public void testEscapeNonAsciiChars(String input, String expectedResult) {
 		ReadmeGenerator readmeGenerator = new ReadmeGenerator(null);
@@ -40,7 +40,7 @@ public class ReadMeGeneratorTest {
 		MatcherAssert.assertThat(result, CoreMatchers.startsWith("{\\rtf1\\fbidis\\ansi\\uc0\\fs32"));
 		MatcherAssert.assertThat(result, CoreMatchers.containsString("{\\sa80 Dear User,}\\par"));
 		MatcherAssert.assertThat(result, CoreMatchers.containsString("{\\sa80 \\b please don't touch the \"d\" directory.}\\par "));
-		MatcherAssert.assertThat(result, CoreMatchers.containsString("{\\sa80 Thank you for your cooperation \\u55357\\u56841}\\par"));
+		MatcherAssert.assertThat(result, CoreMatchers.containsString("{\\sa80 Thank you for your cooperation \\uc1\\u55357\\uc1\\u56841}\\par"));
 		MatcherAssert.assertThat(result, CoreMatchers.endsWith("}"));
 	}
 


### PR DESCRIPTION
This fixes #3252 

The issue was incorrect escaping of unicode characters in the rtf file. I adjusted it to the way this [book](https://www.oreilly.com/library/view/rtf-pocket-guide/9781449302047/ch01.html#character_formatting) recommends.

- for characters < 256 it is recommended to escape using \'xy where xy is the hexadecimal value
- for characters >= 256 it is recommended to escape using \uc1\ux* where x is the decimal value

Maybe the code should be adjusted to meet the second recommendation as well because now only \ux is used. For now I didn't make that adjustment though because it is not related to the reported bug.