### PR TITLE
Text changed to fit hub

### DIFF
--- a/src/main/resources/i18n/strings.properties
+++ b/src/main/resources/i18n/strings.properties
@@ -177,7 +177,7 @@ hub.registerFailed.description.generic=An error was thrown in the registration p
 hub.registerFailed.description.deviceAlreadyExists=This device is already registered for a different user. Try to change the user account or use a different device.
 ### Unauthorized
 hub.unauthorized.message=Access denied
-hub.unauthorized.description=Your device has not yet been authorized to access this vault. Ask the vault owner to authorize it.
+hub.unauthorized.description=Your user has not yet been authorized to access this vault. Ask the vault owner to authorize it
 ### Requires Account Initialization
 hub.requireAccountInit.message=Action required
 hub.requireAccountInit.description.0=To proceed, please complete the steps required in your


### PR DESCRIPTION
This pull request addresses an issue in Cryptomator 1.14.2 where the error message displayed when attempting to access a vault without proper authorization incorrectly refers to a "device" instead of a "user".

Since Cryptomator Hub 1.3.0, the vault owner is responsible for authorizing users, not devices. This update corrects the terminology to ensure clarity and accuracy in the error message.

### Changes Made
Updated the error message from:

> "Your device has not yet been authorized to access this vault. Ask the vault owner to authorize it." to: "Your user has not yet 
> been authorized to access this vault. Ask the vault owner to authorize it."

### Steps to Reproduce

1. Attempt to unlock a vault for which you do not have access.
2. Observe the error message.

### Expected Behavior
The updated error message should accurately reflect that the user is unauthorized.

### Actual Behavior
The current message incorrectly references the device instead of the user.

### Testing

1. Verified that the updated message displays correctly in scenarios where a user lacks authorization.
2. Confirmed that the change does not impact related functionality.

### Issue Reference
[#3623]
