### PR TITLE
Feature: JDK 23

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   JAVA_DIST: 'zulu'
-  JAVA_VERSION: '22.0.2+9'
+  JAVA_VERSION: '23.0.1+11'
 
 jobs:
   get-version:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   JAVA_DIST: 'zulu'
-  JAVA_VERSION: 22
+  JAVA_VERSION: 23
 
 defaults:
   run:

--- a/.github/workflows/check-jdk-updates.yml
+++ b/.github/workflows/check-jdk-updates.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 0 1 * *' # run once a month at the first day of month
 
 env:
-  JDK_VERSION: '22.0.1+8'
+  JDK_VERSION: '23.0.1+11'
   JDK_VENDOR: zulu
 
 jobs:
@@ -28,13 +28,18 @@ jobs:
   jdk-latest:
     name: Checkout latest jdk version
     runs-on: ubuntu-latest
+    env:
+        JDK_MAJOR_VERSION: 23
     outputs:
       jdk-date: ${{ steps.get-data.outputs.jdk-date}}
       jdk-version: ${{ steps.get-data.outputs.jdk-version}}
     steps:
+      - name: Extract major version
+        run: echo 'JDK_MAJOR_VERSION=${{ env.JDK_VERSION }}'.substring(0,20) >> "$env:GITHUB_ENV"
+        shell: pwsh
       - uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: ${{ env.JDK_MAJOR_VERSION}}
           distribution: ${{ env.JDK_VENDOR }}
           check-latest: true
       - name: Read JAVA_VERSION_DATE and store in env variable

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -17,9 +17,9 @@ on:
 
 env:
   JAVA_DIST: 'zulu'
-  JAVA_VERSION: '22.0.2+9'
-  COFFEELIBS_JDK: 22
-  COFFEELIBS_JDK_VERSION: '22.0.2+9-0ppa1'
+  JAVA_VERSION: '23.0.1+11'
+  COFFEELIBS_JDK: 23
+  COFFEELIBS_JDK_VERSION: '23.0.1+11-0ppa1'
   OPENJFX_JMODS_AMD64: 'https://download2.gluonhq.com/openjfx/22.0.2/openjfx-22.0.2_linux-x64_bin-jmods.zip'
   OPENJFX_JMODS_AMD64_HASH: 'd44bff3b94d5668fdee18a938d7b1269026d663d44765f02d29a9bdfd3fa1eb0'
   OPENJFX_JMODS_AARCH64: 'https://download2.gluonhq.com/openjfx/22.0.2/openjfx-22.0.2_linux-aarch64_bin-jmods.zip'

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -11,7 +11,7 @@ jobs:
     with:
       runner-os: 'ubuntu-latest'
       java-distribution: 'temurin'
-      java-version: 22
+      java-version: 23
       check-command: 'mvn -B validate -Pdependency-check -Djavafx.platform=linux'
     secrets:
       nvd-api-key: ${{ secrets.NVD_API_KEY }}

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -23,7 +23,7 @@ on:
 
 env:
   JAVA_DIST: 'zulu'
-  JAVA_VERSION: 22
+  JAVA_VERSION: 23
 
 jobs:
   determine-version:

--- a/.github/workflows/mac-dmg.yml
+++ b/.github/workflows/mac-dmg.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   JAVA_DIST: 'zulu'
-  JAVA_VERSION: '22.0.2+9'
+  JAVA_VERSION: '23.0.1+11'
 
 jobs:
   get-version:

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   JAVA_DIST: 'zulu'
-  JAVA_VERSION: 22
+  JAVA_VERSION: 23
 
 defaults:
   run:

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -12,7 +12,7 @@ defaults:
 
 env:
   JAVA_DIST: 'zulu'
-  JAVA_VERSION: 22
+  JAVA_VERSION: 23
 
 jobs:
   check-preconditions:

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   JAVA_DIST: 'zulu'
-  JAVA_VERSION: '22.0.2+9'
+  JAVA_VERSION: '23.0.1+11'
   OPENJFX_JMODS_AMD64: 'https://download2.gluonhq.com/openjfx/22.0.2/openjfx-22.0.2_windows-x64_bin-jmods.zip'
   OPENJFX_JMODS_AMD64_HASH: 'f9376d200f5c5b85327d575c1ec1482e6455f19916577f7e2fc9be2f48bb29b6'
   WINFSP_MSI: 'https://github.com/winfsp/winfsp/releases/download/v2.0/winfsp-2.0.23075.msi'

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_22" project-jdk-name="22" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_23" project-jdk-name="23" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/dist/linux/debian/rules
+++ b/dist/linux/debian/rules
@@ -4,7 +4,7 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
-JAVA_HOME = /usr/lib/jvm/java-22-coffeelibs
+JAVA_HOME = /usr/lib/jvm/java-23-coffeelibs
 DEB_BUILD_ARCH ?= $(shell dpkg-architecture -qDEB_BUILD_ARCH)
 ifeq ($(DEB_BUILD_ARCH),amd64)
 JMODS_PATH = jmods/amd64:${JAVA_HOME}/jmods

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.jdk.version>22</project.jdk.version>
+		<project.jdk.version>23</project.jdk.version>
 
 		<!-- Group IDs of jars that need to stay on the class path for now -->
 		<!-- remove them, as soon they got modularized or support is dropped (i.e., WebDAV) -->

--- a/src/main/java/org/cryptomator/common/locationpresets/GoogleDriveMacLocationPresetsProvider.java
+++ b/src/main/java/org/cryptomator/common/locationpresets/GoogleDriveMacLocationPresetsProvider.java
@@ -67,7 +67,7 @@ public final class GoogleDriveMacLocationPresetsProvider implements LocationPres
 	 */
 	private String getDriveLocationString(Path accountPath) {
 		String accountName = accountPath.getFileName().toString().replace("GoogleDrive-", "");
-		return STR."Google Drive - \{accountName}";
+		return "Google Drive - " + accountName;
 	}
 
 	/**

--- a/src/main/java/org/cryptomator/common/mount/Mounter.java
+++ b/src/main/java/org/cryptomator/common/mount/Mounter.java
@@ -160,7 +160,7 @@ public class Mounter {
 		var mountService = mountProviders.stream().filter(s -> s.getClass().getName().equals(vaultSettings.mountService.getValue())).findFirst().orElse(defaultMountService.getValue());
 
 		if (isConflictingMountService(mountService)) {
-			var msg = STR."\{mountService.getClass()} unavailable due to conflict with either of \{CONFLICTING_MOUNT_SERVICES.get(mountService.getClass().getName())}";
+			var msg = mountService.getClass() + " unavailable due to conflict with either of " + CONFLICTING_MOUNT_SERVICES.get(mountService.getClass().getName());
 			throw new ConflictingMountServiceException(msg);
 		}
 

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/HubConfig.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/HubConfig.java
@@ -49,13 +49,20 @@ public class HubConfig {
 
 	public class URIProcessors {
 
+		public final URIProcessor API = this::fromApiEndpoint;
+
 		/**
 		 * Resolves paths relative to the <code>/api/</code> endpoint of this Hub instance.
 		 */
-		public URI getApi(String path) {
+		public URI fromApiEndpoint(String path) {
 			var relPath = path.startsWith("/") ? path.substring(1) : path;
 			return getApiBaseUrl().resolve(relPath);
-		};
+		}
+	}
 
+	@FunctionalInterface
+	public interface URIProcessor {
+
+		URI resolve(String path);
 	}
 }

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/HubConfig.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/HubConfig.java
@@ -20,7 +20,7 @@ public class HubConfig {
 	public String devicesResourceUrl;
 
 	/**
-	 * A collection of String template processors to construct URIs related to this Hub instance.
+	 * A collection of functions to construct URIs related to this Hub instance.
 	 */
 	@JsonIgnore
 	public final URIProcessors URIs = new URIProcessors();
@@ -52,8 +52,7 @@ public class HubConfig {
 		/**
 		 * Resolves paths relative to the <code>/api/</code> endpoint of this Hub instance.
 		 */
-		public final StringTemplate.Processor<URI, RuntimeException> API = template -> {
-			var path = template.interpolate();
+		public URI getApi(String path) {
 			var relPath = path.startsWith("/") ? path.substring(1) : path;
 			return getApiBaseUrl().resolve(relPath);
 		};

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/ReceiveKeyController.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/ReceiveKeyController.java
@@ -88,7 +88,7 @@ public class ReceiveKeyController implements FxController {
 	 * STEP 0 (Request): GET /api/config
 	 */
 	private void requestApiConfig() {
-		var configUri = hubConfig.URIs.API."config";
+		var configUri = hubConfig.URIs.getApi("config");
 		var request = HttpRequest.newBuilder(configUri) //
 				.GET() //
 				.timeout(REQ_TIMEOUT) //
@@ -122,7 +122,7 @@ public class ReceiveKeyController implements FxController {
 	 * STEP 1 (Request): GET user key for this device
 	 */
 	private void requestDeviceData() {
-		var deviceUri = hubConfig.URIs.API."devices/\{deviceId}";
+		var deviceUri = hubConfig.URIs.getApi("devices/" + deviceId);
 		var request = HttpRequest.newBuilder(deviceUri) //
 				.header("Authorization", "Bearer " + bearerToken) //
 				.GET() //
@@ -162,7 +162,7 @@ public class ReceiveKeyController implements FxController {
 	 * STEP 2 (Request): GET vault key for this user
 	 */
 	private void requestVaultMasterkey(String encryptedUserKey) {
-		var vaultKeyUri = hubConfig.URIs.API."vaults/\{vaultId}/access-token";
+		var vaultKeyUri = hubConfig.URIs.getApi("vaults/" + vaultId + "/access-token");
 		var request = HttpRequest.newBuilder(vaultKeyUri) //
 				.header("Authorization", "Bearer " + bearerToken) //
 				.GET() //
@@ -205,7 +205,7 @@ public class ReceiveKeyController implements FxController {
 	 */
 	@Deprecated
 	private void requestLegacyAccessToken() {
-		var legacyAccessTokenUri = hubConfig.URIs.API."vaults/\{vaultId}/keys/\{deviceId}";
+		var legacyAccessTokenUri = hubConfig.URIs.getApi("vaults/" + vaultId + "/keys/" + deviceId);
 		var request = HttpRequest.newBuilder(legacyAccessTokenUri) //
 				.header("Authorization", "Bearer " + bearerToken) //
 				.GET() //

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/ReceiveKeyController.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/ReceiveKeyController.java
@@ -88,7 +88,7 @@ public class ReceiveKeyController implements FxController {
 	 * STEP 0 (Request): GET /api/config
 	 */
 	private void requestApiConfig() {
-		var configUri = hubConfig.URIs.getApi("config");
+		var configUri = hubConfig.URIs.API.resolve("config");
 		var request = HttpRequest.newBuilder(configUri) //
 				.GET() //
 				.timeout(REQ_TIMEOUT) //
@@ -122,7 +122,7 @@ public class ReceiveKeyController implements FxController {
 	 * STEP 1 (Request): GET user key for this device
 	 */
 	private void requestDeviceData() {
-		var deviceUri = hubConfig.URIs.getApi("devices/" + deviceId);
+		var deviceUri = hubConfig.URIs.API.resolve("devices/" + deviceId);
 		var request = HttpRequest.newBuilder(deviceUri) //
 				.header("Authorization", "Bearer " + bearerToken) //
 				.GET() //
@@ -162,7 +162,7 @@ public class ReceiveKeyController implements FxController {
 	 * STEP 2 (Request): GET vault key for this user
 	 */
 	private void requestVaultMasterkey(String encryptedUserKey) {
-		var vaultKeyUri = hubConfig.URIs.getApi("vaults/" + vaultId + "/access-token");
+		var vaultKeyUri = hubConfig.URIs.API.resolve("vaults/" + vaultId + "/access-token");
 		var request = HttpRequest.newBuilder(vaultKeyUri) //
 				.header("Authorization", "Bearer " + bearerToken) //
 				.GET() //
@@ -205,7 +205,7 @@ public class ReceiveKeyController implements FxController {
 	 */
 	@Deprecated
 	private void requestLegacyAccessToken() {
-		var legacyAccessTokenUri = hubConfig.URIs.getApi("vaults/" + vaultId + "/keys/" + deviceId);
+		var legacyAccessTokenUri = hubConfig.URIs.API.resolve("vaults/" + vaultId + "/keys/" + deviceId);
 		var request = HttpRequest.newBuilder(legacyAccessTokenUri) //
 				.header("Authorization", "Bearer " + bearerToken) //
 				.GET() //

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/RegisterDeviceController.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/RegisterDeviceController.java
@@ -115,7 +115,7 @@ public class RegisterDeviceController implements FxController {
 		workInProgress.set(true);
 
 
-		var userReq = HttpRequest.newBuilder(hubConfig.URIs.API."users/me") //
+		var userReq = HttpRequest.newBuilder(hubConfig.URIs.getApi("users/me")) //
 				.GET() //
 				.timeout(REQ_TIMEOUT) //
 				.header("Authorization", "Bearer " + bearerToken) //
@@ -143,7 +143,7 @@ public class RegisterDeviceController implements FxController {
 					var now = Instant.now().toString();
 					var dto = new CreateDeviceDto(deviceId, deviceNameField.getText(), BaseEncoding.base64().encode(deviceKeyPair.getPublic().getEncoded()), "DESKTOP", jwe.serialize(), now);
 					var json = toJson(dto);
-					var deviceUri = hubConfig.URIs.API."devices/\{deviceId}";
+					var deviceUri = hubConfig.URIs.getApi("devices/" + deviceId);
 					var putDeviceReq = HttpRequest.newBuilder(deviceUri) //
 							.PUT(HttpRequest.BodyPublishers.ofString(json, StandardCharsets.UTF_8)) //
 							.timeout(REQ_TIMEOUT) //
@@ -164,7 +164,7 @@ public class RegisterDeviceController implements FxController {
 	private void migrateLegacyDevices(ECPublicKey userPublicKey) {
 		try {
 			// GET legacy access tokens
-			var getUri = hubConfig.URIs.API."devices/\{deviceId}/legacy-access-tokens";
+			var getUri = hubConfig.URIs.getApi("devices/" + deviceId + "/legacy-access-tokens");
 			var getReq = HttpRequest.newBuilder(getUri).GET().timeout(REQ_TIMEOUT).header("Authorization", "Bearer " + bearerToken).build();
 			var getRes = httpClient.send(getReq, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
 			if (getRes.statusCode() != 200) {
@@ -185,12 +185,12 @@ public class RegisterDeviceController implements FxController {
 					LOG.warn("Failed to decrypt legacy access token for vault {}. Skipping migration.", entry.getKey());
 				}
 			}).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-			var postUri = hubConfig.URIs.API."users/me/access-tokens";
+			var postUri = hubConfig.URIs.getApi("users/me/access-tokens");
 			var postBody = JSON.writer().writeValueAsString(newAccessTokens);
 			var postReq = HttpRequest.newBuilder(postUri).POST(HttpRequest.BodyPublishers.ofString(postBody)).timeout(REQ_TIMEOUT).header("Authorization", "Bearer " + bearerToken).build();
 			var postRes = httpClient.send(postReq, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
 			if (postRes.statusCode() != 200) {
-				throw new IOException(STR."Unexpected response from POST \{postUri}: \{postRes.statusCode()}");
+				throw new IOException("Unexpected response from POST " + postUri + ": " + postRes.statusCode());
 			}
 		} catch (IOException e) {
 			// log and ignore: this is merely a best-effort attempt of migrating legacy devices. Failure is uncritical as this is merely a convenience feature.

--- a/src/main/java/org/cryptomator/ui/keyloading/hub/RegisterDeviceController.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/RegisterDeviceController.java
@@ -115,7 +115,7 @@ public class RegisterDeviceController implements FxController {
 		workInProgress.set(true);
 
 
-		var userReq = HttpRequest.newBuilder(hubConfig.URIs.getApi("users/me")) //
+		var userReq = HttpRequest.newBuilder(hubConfig.URIs.API.resolve("users/me")) //
 				.GET() //
 				.timeout(REQ_TIMEOUT) //
 				.header("Authorization", "Bearer " + bearerToken) //
@@ -143,7 +143,7 @@ public class RegisterDeviceController implements FxController {
 					var now = Instant.now().toString();
 					var dto = new CreateDeviceDto(deviceId, deviceNameField.getText(), BaseEncoding.base64().encode(deviceKeyPair.getPublic().getEncoded()), "DESKTOP", jwe.serialize(), now);
 					var json = toJson(dto);
-					var deviceUri = hubConfig.URIs.getApi("devices/" + deviceId);
+					var deviceUri = hubConfig.URIs.fromApiEndpoint("devices/" + deviceId);
 					var putDeviceReq = HttpRequest.newBuilder(deviceUri) //
 							.PUT(HttpRequest.BodyPublishers.ofString(json, StandardCharsets.UTF_8)) //
 							.timeout(REQ_TIMEOUT) //
@@ -164,7 +164,7 @@ public class RegisterDeviceController implements FxController {
 	private void migrateLegacyDevices(ECPublicKey userPublicKey) {
 		try {
 			// GET legacy access tokens
-			var getUri = hubConfig.URIs.getApi("devices/" + deviceId + "/legacy-access-tokens");
+			var getUri = hubConfig.URIs.API.resolve("devices/" + deviceId + "/legacy-access-tokens");
 			var getReq = HttpRequest.newBuilder(getUri).GET().timeout(REQ_TIMEOUT).header("Authorization", "Bearer " + bearerToken).build();
 			var getRes = httpClient.send(getReq, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
 			if (getRes.statusCode() != 200) {
@@ -185,7 +185,7 @@ public class RegisterDeviceController implements FxController {
 					LOG.warn("Failed to decrypt legacy access token for vault {}. Skipping migration.", entry.getKey());
 				}
 			}).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-			var postUri = hubConfig.URIs.getApi("users/me/access-tokens");
+			var postUri = hubConfig.URIs.fromApiEndpoint("users/me/access-tokens");
 			var postBody = JSON.writer().writeValueAsString(newAccessTokens);
 			var postReq = HttpRequest.newBuilder(postUri).POST(HttpRequest.BodyPublishers.ofString(postBody)).timeout(REQ_TIMEOUT).header("Authorization", "Bearer " + bearerToken).build();
 			var postRes = httpClient.send(postReq, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));


### PR DESCRIPTION
This PR builds on top of #3621 and updates the used JDK to version 23.

A search revealed, that no library we use requires the `--enable-preview` flag anymore, we only have to update this repo and downstream.

TODOs:
* [x] test windows build (see https://github.com/cryptomator/cryptomator/actions/runs/12260871094)
* [x] test app image build (see https://github.com/cryptomator/cryptomator/actions/runs/12260861431)
* [x] test debian build (see https://github.com/cryptomator/cryptomator/actions/runs/12261064580)
* [x] test macOS build (see https://github.com/cryptomator/cryptomator/actions/runs/12260868541)