### PR TITLE
fix appimage build

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -153,7 +153,7 @@ jobs:
         run: >
           ./squashfs-root/AppRun Cryptomator.AppDir cryptomator-${{  needs.get-version.outputs.semVerStr }}-${{ matrix.appimage-suffix }}.AppImage
           -u 'gh-releases-zsync|cryptomator|cryptomator|latest|cryptomator-*-${{ matrix.appimage-suffix }}.AppImage.zsync'
-          --sign --sign-key=615D449FE6E6A235 --sign-args="--batch --pinentry-mode loopback"
+          --sign --sign-key=615D449FE6E6A235
       - name: Create detached GPG signatures
         run: |
           gpg --batch --quiet --passphrase-fd 0 --pinentry-mode loopback -u 615D449FE6E6A235 --detach-sign -a cryptomator-*.AppImage

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -136,6 +136,7 @@ jobs:
           ln -s usr/share/icons/hicolor/scalable/apps/org.cryptomator.Cryptomator.svg Cryptomator.AppDir/Cryptomator.svg
           ln -s usr/share/icons/hicolor/scalable/apps/org.cryptomator.Cryptomator.svg Cryptomator.AppDir/.DirIcon
           ln -s usr/share/applications/org.cryptomator.Cryptomator.desktop Cryptomator.AppDir/Cryptomator.desktop
+          ln -s org.cryptomator.Cryptomator.metainfo.xml Cryptomator.AppDir/usr/share/metainfo/Cryptomator.appdata.xml
           ln -s bin/cryptomator.sh Cryptomator.AppDir/AppRun
       - name: Download AppImageKit
         run: |

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -136,7 +136,6 @@ jobs:
           ln -s usr/share/icons/hicolor/scalable/apps/org.cryptomator.Cryptomator.svg Cryptomator.AppDir/Cryptomator.svg
           ln -s usr/share/icons/hicolor/scalable/apps/org.cryptomator.Cryptomator.svg Cryptomator.AppDir/.DirIcon
           ln -s usr/share/applications/org.cryptomator.Cryptomator.desktop Cryptomator.AppDir/Cryptomator.desktop
-          ln -s org.cryptomator.Cryptomator.metainfo.xml Cryptomator.AppDir/usr/share/metainfo/Cryptomator.appdata.xml
           ln -s bin/cryptomator.sh Cryptomator.AppDir/AppRun
       - name: Download AppImageKit
         run: |


### PR DESCRIPTION
`--sign-args` is an unsupported argument, however it is not strictly required in our case.

According to https://github.com/AppImage/appimagetool/issues/39, it is not planned to re-add it, even though it is still documented.