### PR TITLE
Include AppStream metadata in AppImage

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -133,9 +133,8 @@ jobs:
           cp dist/linux/common/org.cryptomator.Cryptomator.desktop Cryptomator.AppDir/usr/share/applications/org.cryptomator.Cryptomator.desktop
           cp dist/linux/common/application-vnd.cryptomator.vault.xml Cryptomator.AppDir/usr/share/mime/packages/application-vnd.cryptomator.vault.xml
           ln -s usr/share/icons/hicolor/scalable/apps/org.cryptomator.Cryptomator.svg Cryptomator.AppDir/org.cryptomator.Cryptomator.svg
-          ln -s usr/share/icons/hicolor/scalable/apps/org.cryptomator.Cryptomator.svg Cryptomator.AppDir/Cryptomator.svg
           ln -s usr/share/icons/hicolor/scalable/apps/org.cryptomator.Cryptomator.svg Cryptomator.AppDir/.DirIcon
-          ln -s usr/share/applications/org.cryptomator.Cryptomator.desktop Cryptomator.AppDir/Cryptomator.desktop
+          ln -s usr/share/applications/org.cryptomator.Cryptomator.desktop Cryptomator.AppDir/org.cryptomator.Cryptomator.desktop
           ln -s bin/cryptomator.sh Cryptomator.AppDir/AppRun
       - name: Download AppImageKit
         run: |

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -135,6 +135,7 @@ jobs:
           ln -s usr/share/icons/hicolor/scalable/apps/org.cryptomator.Cryptomator.svg Cryptomator.AppDir/org.cryptomator.Cryptomator.svg
           ln -s usr/share/icons/hicolor/scalable/apps/org.cryptomator.Cryptomator.svg Cryptomator.AppDir/.DirIcon
           ln -s usr/share/applications/org.cryptomator.Cryptomator.desktop Cryptomator.AppDir/org.cryptomator.Cryptomator.desktop
+          ln -s org.cryptomator.Cryptomator.metainfo.xml Cryptomator.AppDir/usr/share/metainfo/org.cryptomator.Cryptomator.appdata.xml
           ln -s bin/cryptomator.sh Cryptomator.AppDir/AppRun
       - name: Download AppImageKit
         run: |

--- a/dist/linux/appimage/build.sh
+++ b/dist/linux/appimage/build.sh
@@ -111,6 +111,7 @@ cp ../common/application-vnd.cryptomator.vault.xml Cryptomator.AppDir/usr/share/
 ln -s usr/share/icons/hicolor/scalable/apps/org.cryptomator.Cryptomator.svg Cryptomator.AppDir/org.cryptomator.Cryptomator.svg
 ln -s usr/share/icons/hicolor/scalable/apps/org.cryptomator.Cryptomator.svg Cryptomator.AppDir/.DirIcon
 ln -s usr/share/applications/org.cryptomator.Cryptomator.desktop Cryptomator.AppDir/org.cryptomator.Cryptomator.desktop
+ln -s org.cryptomator.Cryptomator.metainfo.xml Cryptomator.AppDir/usr/share/metainfo/org.cryptomator.Cryptomator.appdata.xml
 ln -s bin/cryptomator.sh Cryptomator.AppDir/AppRun
 
 # load AppImageTool

--- a/dist/linux/appimage/build.sh
+++ b/dist/linux/appimage/build.sh
@@ -109,9 +109,8 @@ cp ../common/org.cryptomator.Cryptomator.desktop Cryptomator.AppDir/usr/share/ap
 cp ../common/org.cryptomator.Cryptomator.metainfo.xml Cryptomator.AppDir/usr/share/metainfo/org.cryptomator.Cryptomator.metainfo.xml
 cp ../common/application-vnd.cryptomator.vault.xml Cryptomator.AppDir/usr/share/mime/packages/application-vnd.cryptomator.vault.xml
 ln -s usr/share/icons/hicolor/scalable/apps/org.cryptomator.Cryptomator.svg Cryptomator.AppDir/org.cryptomator.Cryptomator.svg
-ln -s usr/share/icons/hicolor/scalable/apps/org.cryptomator.Cryptomator.svg Cryptomator.AppDir/Cryptomator.svg
 ln -s usr/share/icons/hicolor/scalable/apps/org.cryptomator.Cryptomator.svg Cryptomator.AppDir/.DirIcon
-ln -s usr/share/applications/org.cryptomator.Cryptomator.desktop Cryptomator.AppDir/Cryptomator.desktop
+ln -s usr/share/applications/org.cryptomator.Cryptomator.desktop Cryptomator.AppDir/org.cryptomator.Cryptomator.desktop
 ln -s bin/cryptomator.sh Cryptomator.AppDir/AppRun
 
 # load AppImageTool


### PR DESCRIPTION
Did some research on why appimagetool is disdaining our metadata. The name of the metadata file *must* match the included `id`:

https://github.com/cryptomator/cryptomator/blob/3d0647bce3117e00ef627d2199228f70b5139ff9/dist/linux/common/org.cryptomator.Cryptomator.metainfo.xml#L4

Furthermore the name of the metadata file *must* match the name of the desktop file, as it is [directly derived from it](https://github.com/AppImage/appimagetool/blob/8e5b4c00a32f8753c6f20740d32999cfde75096a/src/appimagetool.c#L854-L856) when appimagetool looks for it.

Luckily, according to [the specs](https://github.com/AppImage/docs.appimage.org/blob/eb56843e7f525895bbc9d5ddfbd6863b517d0c68/source/reference/appdir.rst?plain=1#L42C311-L42C397) the base name of the desktop file is arbitrary:

> The name of the file doesn't matter, as long as it carries the `.desktop` extension.

Furthermore, I removed `Cryptomator.svg` from the app root, as we already have `org.cryptomator.Cryptomator.svg`, which satisfies [the spec](https://github.com/AppImage/docs.appimage.org/blob/eb56843e7f525895bbc9d5ddfbd6863b517d0c68/source/reference/appdir.rst?plain=1#L46-L50):

> The filename must be equal to what is set in the ``Icon=`` entry in the desktop file. It is recommended by AppImage and also the XDG icon specifications to use a lower-case filename which is equal to the desktop file's name.

https://github.com/cryptomator/cryptomator/blob/3d0647bce3117e00ef627d2199228f70b5139ff9/dist/linux/common/org.cryptomator.Cryptomator.desktop#L5

I ignored the "lower-case filename" part for now, as it conflicts with the "is equal to the desktop file's name" part. It is just a recommendation, after all.

---

Here is a [successful build](https://github.com/cryptomator/cryptomator/actions/runs/12843697461/job/35815921807#step:14:21). Let's hope, that our listing on https://appimage.github.io/Cryptomator/ can then be updated as well.