### PR TITLE
Add keyLoader entry to VaultSettings

### DIFF
--- a/src/main/java/org/cryptomator/common/settings/VaultSettings.java
+++ b/src/main/java/org/cryptomator/common/settings/VaultSettings.java
@@ -58,6 +58,7 @@ public class VaultSettings {
 	public final StringExpression mountName;
 	public final StringProperty mountService;
 	public final IntegerProperty port;
+	public final StringProperty keyLoader;
 
 	VaultSettings(VaultSettingsJson json) {
 		this.id = json.id;
@@ -74,6 +75,7 @@ public class VaultSettings {
 		this.mountPoint = new SimpleObjectProperty<>(this, "mountPoint", json.mountPoint == null ? null : Path.of(json.mountPoint));
 		this.mountService = new SimpleStringProperty(this, "mountService", json.mountService);
 		this.port = new SimpleIntegerProperty(this, "port", json.port);
+		this.keyLoader = new SimpleStringProperty(this, "keyLoader", json.keyLoader);
 		// mount name is no longer an explicit setting, see https://github.com/cryptomator/cryptomator/pull/1318
 		this.mountName = StringExpression.stringExpression(Bindings.createStringBinding(() -> {
 			final String name;
@@ -130,6 +132,7 @@ public class VaultSettings {
 		json.mountPoint = mountPoint.map(Path::toString).getValue();
 		json.mountService = mountService.get();
 		json.port = port.get();
+		json.keyLoader = keyLoader.get();
 		return json;
 	}
 

--- a/src/main/java/org/cryptomator/common/settings/VaultSettingsJson.java
+++ b/src/main/java/org/cryptomator/common/settings/VaultSettingsJson.java
@@ -48,6 +48,9 @@ class VaultSettingsJson {
 	@JsonProperty("mountService")
 	String mountService;
 
+	@JsonProperty("keyLoader")
+	String keyLoader;
+
 	@JsonProperty("port")
 	int port = VaultSettings.DEFAULT_PORT;
 

--- a/src/main/java/org/cryptomator/common/vaults/Vault.java
+++ b/src/main/java/org/cryptomator/common/vaults/Vault.java
@@ -75,6 +75,7 @@ public class Vault {
 	private final Mounter mounter;
 	private final Settings settings;
 	private final BooleanProperty showingStats;
+	private final StringBinding keyLoader;
 
 	private final AtomicReference<Mounter.MountHandle> mountHandle = new AtomicReference<>(null);
 
@@ -104,6 +105,7 @@ public class Vault {
 		this.settings = settings;
 		this.showingStats = new SimpleBooleanProperty(false);
 		this.quickAccessEntry = new AtomicReference<>(null);
+		this.keyLoader = Bindings.createStringBinding(this::getKeyLoader, vaultSettings.keyLoader);
 	}
 
 	// ******************************************************************************
@@ -338,6 +340,14 @@ public class Vault {
 	public Mountpoint getMountPoint() {
 		var handle = mountHandle.get();
 		return handle == null ? null : handle.mountObj().getMountpoint();
+	}
+
+	public StringBinding keyLoaderProperty() {
+		return keyLoader;
+	}
+
+	public String getKeyLoader() {
+		return vaultSettings.keyLoader.get();
 	}
 
 	public StringBinding displayablePathProperty() {

--- a/src/main/java/org/cryptomator/ui/convertvault/HubToPasswordConvertController.java
+++ b/src/main/java/org/cryptomator/ui/convertvault/HubToPasswordConvertController.java
@@ -15,6 +15,7 @@ import org.cryptomator.ui.common.FxController;
 import org.cryptomator.ui.common.FxmlFile;
 import org.cryptomator.ui.common.FxmlScene;
 import org.cryptomator.ui.fxapp.FxApplicationWindows;
+import org.cryptomator.ui.keyloading.masterkeyfile.MasterkeyFileLoadingStrategy;
 import org.cryptomator.ui.recoverykey.RecoveryKeyFactory;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.slf4j.Logger;
@@ -108,6 +109,7 @@ public class HubToPasswordConvertController implements FxController {
 				.thenRunAsync(this::convertInternal, backgroundExecutorService) //
 				.whenCompleteAsync((result, exception) -> {
 					if (exception == null) {
+						vault.getVaultSettings().keyLoader.set(MasterkeyFileLoadingStrategy.SCHEME);
 						LOG.info("Conversion of vault {} succeeded.", vault.getPath());
 						window.setScene(successScene.get());
 					} else {

--- a/src/main/java/org/cryptomator/ui/sharevault/ShareVaultController.java
+++ b/src/main/java/org/cryptomator/ui/sharevault/ShareVaultController.java
@@ -33,8 +33,8 @@ public class ShareVaultController implements FxController {
 		this.window = window;
 		this.application = application;
 		this.vault = vault;
-		var vaultScheme = vault.getVaultConfigCache().getUnchecked().getKeyId().getScheme();
-		this.hubVault = (vaultScheme.equals(HubKeyLoadingStrategy.SCHEME_HUB_HTTP) || vaultScheme.equals(HubKeyLoadingStrategy.SCHEME_HUB_HTTPS));
+		var vaultKeyLoader = vault.getVaultSettings().keyLoader.get();
+		this.hubVault = (vaultKeyLoader.equals(HubKeyLoadingStrategy.SCHEME_HUB_HTTP) || vaultKeyLoader.equals(HubKeyLoadingStrategy.SCHEME_HUB_HTTPS));
 	}
 
 	@FXML

--- a/src/main/java/org/cryptomator/ui/vaultoptions/VaultOptionsController.java
+++ b/src/main/java/org/cryptomator/ui/vaultoptions/VaultOptionsController.java
@@ -42,11 +42,11 @@ public class VaultOptionsController implements FxController {
 		window.setOnShowing(this::windowWillAppear);
 		selectedTabProperty.addListener(observable -> this.selectChosenTab());
 		tabPane.getSelectionModel().selectedItemProperty().addListener(observable -> this.selectedTabChanged());
-		var vaultScheme = vault.getVaultConfigCache().getUnchecked().getKeyId().getScheme();
-		if(!vaultScheme.equals(MasterkeyFileLoadingStrategy.SCHEME)){
+		var vaultKeyLoader = vault.getVaultSettings().keyLoader.get();
+		if(!vaultKeyLoader.equals(MasterkeyFileLoadingStrategy.SCHEME)){
 			tabPane.getTabs().remove(keyTab);
 		}
-		if(!(vaultScheme.equals(HubKeyLoadingStrategy.SCHEME_HUB_HTTP) || vaultScheme.equals(HubKeyLoadingStrategy.SCHEME_HUB_HTTPS))){
+		if(!(vaultKeyLoader.equals(HubKeyLoadingStrategy.SCHEME_HUB_HTTP) || vaultKeyLoader.equals(HubKeyLoadingStrategy.SCHEME_HUB_HTTPS))){
 			tabPane.getTabs().remove(hubTab);
 		}
 


### PR DESCRIPTION
With this PR, a new entry named `keyLoader` is added to VaultSettings, making the keyLoader scheme easily accessible for configuration and usage.