### PR TITLE
fix broken doc links

### DIFF
--- a/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultExpertSettingsController.java
+++ b/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultExpertSettingsController.java
@@ -26,7 +26,7 @@ public class CreateNewVaultExpertSettingsController implements FxController {
 
 	public static final int MAX_SHORTENING_THRESHOLD = 220;
 	public static final int MIN_SHORTENING_THRESHOLD = 36;
-	private static final String DOCS_NAME_SHORTENING_URL = "https://docs.cryptomator.org/en/1.7/security/architecture/#name-shortening";
+	private static final String DOCS_NAME_SHORTENING_URL = "https://docs.cryptomator.org/security/architecture/#name-shortening";
 
 	private final Stage window;
 	private final Lazy<Application> application;

--- a/src/main/java/org/cryptomator/ui/mainwindow/WelcomeController.java
+++ b/src/main/java/org/cryptomator/ui/mainwindow/WelcomeController.java
@@ -16,7 +16,7 @@ import javafx.fxml.FXML;
 public class WelcomeController implements FxController {
 
 	private static final Logger LOG = LoggerFactory.getLogger(WelcomeController.class);
-	private static final String GETTING_STARTED_URI = "https://docs.cryptomator.org/en/1.7/desktop/getting-started/";
+	private static final String GETTING_STARTED_URI = "https://docs.cryptomator.org/desktop/getting-started/";
 
 	private final Application application;
 	private final BooleanBinding noVaultPresent;

--- a/src/main/java/org/cryptomator/ui/migration/MigrationImpossibleController.java
+++ b/src/main/java/org/cryptomator/ui/migration/MigrationImpossibleController.java
@@ -10,7 +10,7 @@ import javafx.stage.Stage;
 
 public class MigrationImpossibleController implements FxController {
 
-	private static final String HELP_URI = "https://docs.cryptomator.org/en/1.7/help/manual-migration/";
+	private static final String HELP_URI = "https://docs.cryptomator.org/help/manual-migration/";
 
 	private final Application application;
 	private final Stage window;

--- a/src/main/java/org/cryptomator/ui/preferences/VolumePreferencesController.java
+++ b/src/main/java/org/cryptomator/ui/preferences/VolumePreferencesController.java
@@ -22,7 +22,7 @@ import java.util.ResourceBundle;
 @PreferencesScoped
 public class VolumePreferencesController implements FxController {
 
-	public static final String DOCS_MOUNTING_URL = "https://docs.cryptomator.org/en/1.7/desktop/volume-type/";
+	public static final String DOCS_MOUNTING_URL = "https://docs.cryptomator.org/desktop/volume-type/";
 	public static final int MIN_PORT = 1024;
 	public static final int MAX_PORT = 65535;
 

--- a/src/main/java/org/cryptomator/ui/wrongfilealert/WrongFileAlertController.java
+++ b/src/main/java/org/cryptomator/ui/wrongfilealert/WrongFileAlertController.java
@@ -15,7 +15,7 @@ import java.io.UncheckedIOException;
 @WrongFileAlertScoped
 public class WrongFileAlertController implements FxController {
 
-	private static final String DOCUMENTATION_URI = "https://docs.cryptomator.org/en/1.7/desktop/accessing-vaults/";
+	private static final String DOCUMENTATION_URI = "https://docs.cryptomator.org/desktop/accessing-vaults/";
 
 	private final Application app;
 	private final Stage window;


### PR DESCRIPTION
Some doc links in the UI of the current release 1.14 are outdated and broken (lead to docs.cryptomator.org/en/1.7). This makes it harder for new users to find (for instance) any info about volume types.

This patch replaces the broken links with the current doc location docs.cryptomator.org
(as has been done in the readme file in [3f7501836967e093839c10d202d8864696d73fbc](https://github.com/Kulesko/cryptomator/commit/3f7501836967e093839c10d202d8864696d73fbc))