### PR TITLE
Feature: URL checking

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -57,6 +57,11 @@ jobs:
             dependency-check
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
+      - name: Validate urls used in app
+        uses:  urlstechie/urlchecker-action@0.0.34
+        with:
+          file_types: .md,.json
+          include_files: README.md,src/main/resources/hyperlinks.json
       - name: Run org.owasp:dependency-check plugin
         id: dependency-check
         continue-on-error: true

--- a/src/main/java/org/cryptomator/common/Hyperlinks.java
+++ b/src/main/java/org/cryptomator/common/Hyperlinks.java
@@ -1,0 +1,31 @@
+package org.cryptomator.common;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+public record Hyperlinks(String docsVolumeType, String docsGettingStarted, String homepageHub) {
+
+	private static final ObjectMapper JSON_DESERIALIZER = new ObjectMapper();
+	/*
+	String docsAccessingVaults;
+	String docsExpertSettings;
+	String docsManualMigration;
+	String homepageDownload;
+	String homepageHub;
+	String homepageDonate;
+	String homepageSponsors;
+	String storeDesktop;
+	 */
+
+
+	public static Hyperlinks load() {
+		try {
+			return JSON_DESERIALIZER.readValue(Hyperlinks.class.getResource("/hyperlinks.json"), Hyperlinks.class);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+}

--- a/src/main/java/org/cryptomator/launcher/CryptomatorModule.java
+++ b/src/main/java/org/cryptomator/launcher/CryptomatorModule.java
@@ -2,6 +2,7 @@ package org.cryptomator.launcher;
 
 import dagger.Module;
 import dagger.Provides;
+import org.cryptomator.common.Hyperlinks;
 import org.cryptomator.integrations.autostart.AutoStartProvider;
 import org.cryptomator.integrations.tray.TrayIntegrationProvider;
 import org.cryptomator.integrations.uiappearance.UiAppearanceProvider;
@@ -21,6 +22,12 @@ class CryptomatorModule {
 	@Singleton
 	static ResourceBundle provideLocalization() {
 		return ResourceBundle.getBundle("i18n.strings");
+	}
+
+	@Provides
+	@Singleton
+	static Hyperlinks provideHyperlinks() {
+		return Hyperlinks.load();
 	}
 
 	@Provides

--- a/src/main/java/org/cryptomator/ui/sharevault/ShareVaultController.java
+++ b/src/main/java/org/cryptomator/ui/sharevault/ShareVaultController.java
@@ -1,6 +1,7 @@
 package org.cryptomator.ui.sharevault;
 
 import dagger.Lazy;
+import org.cryptomator.common.Hyperlinks;
 import org.cryptomator.common.vaults.Vault;
 import org.cryptomator.ui.common.FxController;
 import org.cryptomator.ui.keyloading.hub.HubKeyLoadingStrategy;
@@ -18,9 +19,9 @@ import java.net.URISyntaxException;
 public class ShareVaultController implements FxController {
 
 	private static final String SCHEME_PREFIX = "hub+";
-	private static final String VISIT_HUB_URL = "https://cryptomator.org/hub/";
 	private static final String BEST_PRACTICES_URL = "https://docs.cryptomator.org/en/latest/security/best-practices/#sharing-of-vaults";
 
+	private final String VISIT_HUB_URL;
 	private final Stage window;
 	private final Lazy<Application> application;
 	private final Vault vault;
@@ -29,10 +30,12 @@ public class ShareVaultController implements FxController {
 	@Inject
 	ShareVaultController(@ShareVaultWindow Stage window, //
 						 Lazy<Application> application, //
+						 Hyperlinks links, //
 						 @ShareVaultWindow Vault vault) {
 		this.window = window;
 		this.application = application;
 		this.vault = vault;
+		this.VISIT_HUB_URL =links.homepageHub();
 		var vaultScheme = vault.getVaultConfigCache().getUnchecked().getKeyId().getScheme();
 		this.hubVault = (vaultScheme.equals(HubKeyLoadingStrategy.SCHEME_HUB_HTTP) || vaultScheme.equals(HubKeyLoadingStrategy.SCHEME_HUB_HTTPS));
 	}

--- a/src/main/resources/hyperlinks.json
+++ b/src/main/resources/hyperlinks.json
@@ -1,0 +1,4 @@
+{
+  "docsGettingStarted": "https://docs.cryptomator.org/desktop/getting-started/",
+  "homepageHub": "https://cryptomator.org/hub"
+}


### PR DESCRIPTION
This PR improves maintainability of the app.

Links can get stale/unreachable without the developers to notice. There are url-checker tools for this task, but we have the links cluttered all over the project, which would require to either scan the whole project (might take a long time) or to specify directories/single files, which would just move the maintenance to the ci script.

In order to reduce the number of files, this PR moves all non-api URLs to a single resource file, which is loaded during app startup. The parsing fails, if a URL is missing.

TODO:
* Specify more files to check urls for.