### PR TITLE
Send DeviceId to Hub during vault key retrieval

### DIFF
--- a/src/main/java/org/cryptomator/ui/keyloading/hub/ReceiveKeyController.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/hub/ReceiveKeyController.java
@@ -165,6 +165,7 @@ public class ReceiveKeyController implements FxController {
 		var vaultKeyUri = hubConfig.URIs.API.resolve("vaults/" + vaultId + "/access-token");
 		var request = HttpRequest.newBuilder(vaultKeyUri) //
 				.header("Authorization", "Bearer " + bearerToken) //
+				.header("deviceId", deviceId) //
 				.GET() //
 				.timeout(REQ_TIMEOUT) //
 				.build();


### PR DESCRIPTION
See https://github.com/cryptomator/hub/pull/320