### PR TITLE
Add underline effect to clickable notification labels

### DIFF
--- a/src/main/resources/css/dark_theme.css
+++ b/src/main/resources/css/dark_theme.css
@@ -347,18 +347,10 @@
 	-fx-background-color: RED_5;
 }
 
-.notification-debug:hover .notification-label {
-	-fx-underline:true;
-}
-
 .notification-update {
 	-fx-min-height:24px;
 	-fx-max-height:24px;
 	-fx-background-color: YELLOW_5;
-}
-
-.notification-update:hover .notification-label {
- 	-fx-underline:true;
 }
 
 .notification-support {
@@ -367,6 +359,8 @@
 	-fx-background-color: PRIMARY;
 }
 
+.notification-debug:hover .notification-label,
+.notification-update:hover .notification-label,
 .notification-support:hover .notification-label {
  	-fx-underline:true;
 }

--- a/src/main/resources/css/dark_theme.css
+++ b/src/main/resources/css/dark_theme.css
@@ -347,16 +347,28 @@
 	-fx-background-color: RED_5;
 }
 
+.notification-debug:hover .notification-label {
+	-fx-underline:true;
+}
+
 .notification-update {
 	-fx-min-height:24px;
 	-fx-max-height:24px;
 	-fx-background-color: YELLOW_5;
 }
 
+.notification-update:hover .notification-label {
+ 	-fx-underline:true;
+}
+
 .notification-support {
 	-fx-min-height:24px;
 	-fx-max-height:24px;
 	-fx-background-color: PRIMARY;
+}
+
+.notification-support:hover .notification-label {
+ 	-fx-underline:true;
 }
 
 /*******************************************************************************

--- a/src/main/resources/css/light_theme.css
+++ b/src/main/resources/css/light_theme.css
@@ -346,16 +346,28 @@
 	-fx-background-color: RED_5;
 }
 
+.notification-debug:hover .notification-label {
+	-fx-underline:true;
+}
+
 .notification-update {
 	-fx-min-height:24px;
 	-fx-max-height:24px;
 	-fx-background-color: YELLOW_5;
 }
 
+.notification-update:hover .notification-label {
+	-fx-underline:true;
+}
+
 .notification-support {
 	-fx-min-height:24px;
 	-fx-max-height:24px;
 	-fx-background-color: PRIMARY;
+}
+
+.notification-support:hover .notification-label {
+	-fx-underline:true;
 }
 
 /*******************************************************************************

--- a/src/main/resources/css/light_theme.css
+++ b/src/main/resources/css/light_theme.css
@@ -346,18 +346,10 @@
 	-fx-background-color: RED_5;
 }
 
-.notification-debug:hover .notification-label {
-	-fx-underline:true;
-}
-
 .notification-update {
 	-fx-min-height:24px;
 	-fx-max-height:24px;
 	-fx-background-color: YELLOW_5;
-}
-
-.notification-update:hover .notification-label {
-	-fx-underline:true;
 }
 
 .notification-support {
@@ -366,6 +358,8 @@
 	-fx-background-color: PRIMARY;
 }
 
+.notification-debug:hover .notification-label,
+.notification-update:hover .notification-label,
 .notification-support:hover .notification-label {
 	-fx-underline:true;
 }


### PR DESCRIPTION
Related issue: https://github.com/cryptomator/cryptomator/issues/3726

As discussed, the notification area is now visible with underlined text as visual feedback. The above issue mentioned only “update notification” but I assume all clickable notifications should have the same property, i.e. support and debug notifications as well.