### PR TITLE
Refactor: Out-of-bounds-check

### DIFF
--- a/src/main/java/org/cryptomator/ui/mainwindow/MainWindowController.java
+++ b/src/main/java/org/cryptomator/ui/mainwindow/MainWindowController.java
@@ -110,11 +110,13 @@ public class MainWindowController implements FxController {
 			LOG.debug("Resetting window position due to insufficient screen overlap");
 			var centeredX = (primaryScreenBounds.getWidth() - window.getMinWidth()) / 2;
 			var centeredY = (primaryScreenBounds.getHeight() - window.getMinHeight()) / 2;
-			if (isWithinDisplayBounds((int) centeredX, (int) centeredY, width, height)) { //just reset position of upper left corner, keep window size
+			//check if we can keep width and height
+			if (isWithinDisplayBounds((int) centeredX, (int) centeredY, width, height)) {
+				//if so, keep window size
 				window.setWidth(Math.clamp(width, window.getMinWidth(), window.getMaxWidth()));
 				window.setHeight(Math.clamp(height, window.getMinHeight(), window.getMaxHeight()));
 			}
-			// If the position is illegal, then the window appears on the main screen in the middle of the window.
+			//reset position of upper left corner
 			window.setX(centeredX);
 			window.setY(centeredY);
 		}

--- a/src/main/java/org/cryptomator/ui/mainwindow/MainWindowController.java
+++ b/src/main/java/org/cryptomator/ui/mainwindow/MainWindowController.java
@@ -108,14 +108,14 @@ public class MainWindowController implements FxController {
 		Rectangle2D primaryScreenBounds = Screen.getPrimary().getBounds();
 		if (!isWithinDisplayBounds(x, y, width, height)) { //use stored window position
 			LOG.debug("Resetting window position due to insufficient screen overlap");
-			var centerdX = (primaryScreenBounds.getWidth() - window.getMinWidth()) / 2;
+			var centeredX = (primaryScreenBounds.getWidth() - window.getMinWidth()) / 2;
 			var centeredY = (primaryScreenBounds.getHeight() - window.getMinHeight()) / 2;
-			if (isWithinDisplayBounds((int) centerdX, (int) centeredY, width, height)) { //just reset position of upper left corner, keep window size
+			if (isWithinDisplayBounds((int) centeredX, (int) centeredY, width, height)) { //just reset position of upper left corner, keep window size
 				window.setWidth(Math.clamp(width, window.getMinWidth(), window.getMaxWidth()));
 				window.setHeight(Math.clamp(height, window.getMinHeight(), window.getMaxHeight()));
 			}
 			// If the position is illegal, then the window appears on the main screen in the middle of the window.
-			window.setX(centerdX);
+			window.setX(centeredX);
 			window.setY(centeredY);
 		}
 	}


### PR DESCRIPTION
fixes #3723 and #3722.

This PR refactors the window-out-of-bounds check (re)added in #3729.

Since during the `@FXML initialize()` method the window is not already displayed, the computations were wrong (e.g. `window.getX()` returnend `NaN`.
To fix this, out-of-bounds computations are now when showing the window. Additionally, a workaround for a Windows pecularity causing to #3723 is added again.
