### PR TITLE
Fix missing German translation for "Remove Vault" confirmation button

### DIFF
--- a/src/main/resources/i18n/strings_de.properties
+++ b/src/main/resources/i18n/strings_de.properties
@@ -106,6 +106,7 @@ addvaultwizard.success.unlockNow=Jetzt entsperren
 removeVault.title=„%s“ entfernen
 removeVault.message=Tresor entfernen?
 removeVault.description=Dieser Tresor wird nur aus der Tresorliste entfernt; du kannst ihn später jederzeit wieder hinzufügen. Es werden keine verschlüsselten Daten gelöscht.
+removeVault.confirmBtn=Tresor entfernen
 
 # Change Password
 changepassword.title=Passwort ändern


### PR DESCRIPTION
Fixes #3739

This pull request adds the missing German translation key `removeVault.confirmBtn` to the `strings_de.properties` file.

### Problem
In the German UI, the confirmation button when removing a vault was displayed in English ("Remove Vault") instead of the expected German translation.

### Cause
The key `removeVault.confirmBtn` was present in the default (English) translation file, but missing from the German one. When a key is not found in the localized file, Cryptomator falls back to the default – hence the English text appeared.

### Solution
Added the following line to `strings_de.properties`:

```strings_de.properties
removeVault.confirmBtn=Tresor entfernen
```

Notes
This is my first open source contribution – feedback is very welcome!


Fixes #3739


