### PR TITLE
CI: Update and split up anti virus whitelisting flow

### DIFF
--- a/.github/workflows/av-whitelist.yml
+++ b/.github/workflows/av-whitelist.yml
@@ -57,7 +57,6 @@ jobs:
           path: upload
       - name: Upload to Kaspersky
         uses: SamKirkland/FTP-Deploy-Action@v4.3.5
-        continue-on-error: true
         with:
           protocol: ftps
           server: allowlist.kaspersky-labs.com

--- a/.github/workflows/av-whitelist.yml
+++ b/.github/workflows/av-whitelist.yml
@@ -23,25 +23,26 @@ on:
         required: false
         type: boolean
         default: false
-env:
-  FILE_NAME: ""
 
 jobs:
   download-file:
     name: Downloads the file into the VM
     runs-on: ubuntu-latest
+    outputs:
+      fileName: ${{ steps.extractName.outputs.fileName}}
     steps:
-      - name: Get file name
+      - name: Extract file name
+        id: extractName
         run: |
           url="${{ inputs.url }}"
-          echo "FILE_NAME=${url##*/}" >> $GITHUB_ENV
+          echo "fileName=${url##*/}" >> $GITHUB_OUTPUT
       - name: Download file
-        run: curl --remote-name ${{ inputs.url }} -L -o ${{env.FILE_NAME}}
+        run: curl --remote-name ${{ inputs.url }} -L -o ${{steps.extractName.outputs.fileName}}
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.FILE_NAME}}
-          path: ${{ env.FILE_NAME }}
+          name: ${{ steps.extractName.outputs.fileName }}
+          path: ${{ steps.extractName.outputs.fileName }}
           if-no-files-found: error
   allowlist-kaspersky:
     name: Anti Virus Allowlisting Kaspersky
@@ -52,7 +53,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.FILE_NAME}}
+          name: ${{ job.download-file.outputs.fileName }}
           path: upload
       - name: Upload to Kaspersky
         uses: SamKirkland/FTP-Deploy-Action@v4.3.5
@@ -65,7 +66,7 @@ jobs:
           password: ${{ secrets.ALLOWLIST_KASPERSKY_PASSWORD }}
           local-dir: ./upload/
   allowlist-avast:
-    name: Anti Virus Allowlisting Kaspersky
+    name: Anti Virus Allowlisting Avast
     runs-on: ubuntu-latest
     needs: download-file
     if: inputs.avast || github.event_name == 'workflow_call'
@@ -73,7 +74,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.FILE_NAME}}
+          name: ${{ job.download-file.outputs.fileName }}
           path: upload
       - name: Upload to Avast
         uses: SamKirkland/FTP-Deploy-Action@v4.3.5

--- a/.github/workflows/av-whitelist.yml
+++ b/.github/workflows/av-whitelist.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ job.download-file.outputs.fileName }}
+          name: ${{ needs.download-file.outputs.fileName }}
           path: upload
       - name: Upload to Kaspersky
         uses: SamKirkland/FTP-Deploy-Action@v4.3.5
@@ -74,7 +74,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ job.download-file.outputs.fileName }}
+          name: ${{ needs.download-file.outputs.fileName }}
           path: upload
       - name: Upload to Avast
         uses: SamKirkland/FTP-Deploy-Action@v4.3.5

--- a/.github/workflows/av-whitelist.yml
+++ b/.github/workflows/av-whitelist.yml
@@ -76,12 +76,13 @@ jobs:
         with:
           name: ${{ needs.download-file.outputs.fileName }}
           path: upload
-      - name: Upload to Avast
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+      - name: SFTP Deploy
+        uses: wlixcc/SFTP-Deploy-Action@v1.2.5
         with:
-          protocol: ftp
           server: whitelisting.avast.com
-          port: 21
+          port: 22
           username: ${{ secrets.ALLOWLIST_AVAST_USERNAME }}
           password: ${{ secrets.ALLOWLIST_AVAST_PASSWORD }}
-          local-dir: ./upload/
+          ssh_private_key: ''
+          local_path: './upload/*'
+          remote_path: '/data'

--- a/.github/workflows/av-whitelist.yml
+++ b/.github/workflows/av-whitelist.yml
@@ -84,5 +84,6 @@ jobs:
           username: ${{ secrets.ALLOWLIST_AVAST_USERNAME }}
           password: ${{ secrets.ALLOWLIST_AVAST_PASSWORD }}
           ssh_private_key: ''
+          sftp_only: true
           local_path: './upload/*'
           remote_path: '/data'

--- a/.github/workflows/av-whitelist.yml
+++ b/.github/workflows/av-whitelist.yml
@@ -48,7 +48,7 @@ jobs:
     name: Anti Virus Allowlisting Kaspersky
     runs-on: ubuntu-latest
     needs: download-file
-    if: inputs.kaspersky || github.event_name == 'workflow_call'
+    if: github.event_name == 'workflow_call' || inputs.kaspersky
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -68,14 +68,14 @@ jobs:
     name: Anti Virus Allowlisting Avast
     runs-on: ubuntu-latest
     needs: download-file
-    if: inputs.avast || github.event_name == 'workflow_call'
+    if: github.event_name == 'workflow_call'  || inputs.avast
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.download-file.outputs.fileName }}
           path: upload
-      - name: SFTP Deploy
+      - name: Upload to Avast 
         uses: wlixcc/SFTP-Deploy-Action@v1.2.5
         with:
           server: whitelisting.avast.com

--- a/.github/workflows/av-whitelist.yml
+++ b/.github/workflows/av-whitelist.yml
@@ -13,23 +13,68 @@ on:
         description: "Url to the file to upload"
         required: true
         type: string
+      avast:
+        description: "Upload to Avast"
+        required: false
+        type: boolean
+        default: false
+      kaspersky:
+        description: "Upload to Kaspersky"
+        required: false
+        type: boolean
+        default: false
+env:
+  FILE_NAME: ""
 
 jobs:
-  allowlist:
-    name: Anti Virus Allowlisting
+  download-file:
+    name: Downloads the file into the VM
     runs-on: ubuntu-latest
     steps:
-      - name: Download file
+      - name: Get file name
         run: |
-          curl --remote-name ${{ inputs.url }} -L
+          url="${{ inputs.url }}"
+          echo "FILE_NAME=${url##*/}" >> $GITHUB_ENV
+      - name: Download file
+        run: curl --remote-name ${{ inputs.url }} -L -o ${{env.FILE_NAME}}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.FILE_NAME}}
+          path: ${{ env.FILE_NAME }}
+          if-no-files-found: error
+  allowlist-kaspersky:
+    name: Anti Virus Allowlisting Kaspersky
+    runs-on: ubuntu-latest
+    needs: download-file
+    if: inputs.kaspersky || github.event_name == 'workflow_call'
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.FILE_NAME}}
+          path: upload
       - name: Upload to Kaspersky
         uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        continue-on-error: true
         with:
           protocol: ftps
           server: allowlist.kaspersky-labs.com
           port: 990
           username: ${{ secrets.ALLOWLIST_KASPERSKY_USERNAME }}
           password: ${{ secrets.ALLOWLIST_KASPERSKY_PASSWORD }}
+          local-dir: ./upload/
+  allowlist-avast:
+    name: Anti Virus Allowlisting Kaspersky
+    runs-on: ubuntu-latest
+    needs: download-file
+    if: inputs.avast || github.event_name == 'workflow_call'
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.FILE_NAME}}
+          path: upload
       - name: Upload to Avast
         uses: SamKirkland/FTP-Deploy-Action@v4.3.5
         with:
@@ -38,3 +83,4 @@ jobs:
           port: 21
           username: ${{ secrets.ALLOWLIST_AVAST_USERNAME }}
           password: ${{ secrets.ALLOWLIST_AVAST_PASSWORD }}
+          local-dir: ./upload/

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -394,7 +394,7 @@ jobs:
 
   allowlist-exe:
     uses: ./.github/workflows/av-whitelist.yml
-    needs: [publish]
+    needs: [publish, allowlist-msi]
     with:
       url: ${{ needs.publish.outputs.download-url-exe }}
     secrets: inherit


### PR DESCRIPTION
Due to problems in the Kaspersky upload, the av whitelisting is split in two jobs. Additionally, avast is updated to use SFTP