### PR TITLE
Feature: Use user and system certificate stores on macOS

### DIFF
--- a/src/main/java/org/cryptomator/networking/CombinedKeyStoreSpi.java
+++ b/src/main/java/org/cryptomator/networking/CombinedKeyStoreSpi.java
@@ -1,0 +1,175 @@
+package org.cryptomator.networking;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.Key;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.KeyStoreSpi;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.Vector;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class CombinedKeyStoreSpi extends KeyStoreSpi {
+
+	private final KeyStore primary;
+	private final KeyStore fallback;
+
+	public CombinedKeyStoreSpi(KeyStore primary, KeyStore fallback) {
+		this.primary = primary;
+		this.fallback = fallback;
+	}
+
+	@Override
+	public Key engineGetKey(String alias, char[] password) throws NoSuchAlgorithmException, UnrecoverableKeyException {
+		try {
+			Key key = primary.getKey(alias, password);
+			if (key == null) {
+				key = fallback.getKey(alias, password);
+			}
+			return key;
+		} catch (KeyStoreException e) {
+			throw new IllegalStateException("At least one keystore of [%s, %s] is not initialized.".formatted(primary.getType(), fallback.getType()), e);
+		}
+	}
+
+	@Override
+	public Certificate[] engineGetCertificateChain(String alias) {
+		try {
+			Certificate[] chain = primary.getCertificateChain(alias);
+			if (chain == null) {
+				chain = fallback.getCertificateChain(alias);
+			}
+			return chain;
+		} catch (KeyStoreException e) {
+			throw new IllegalStateException("At least one keystore of [%s, %s] is not initialized.".formatted(primary.getType(), fallback.getType()), e);
+		}
+	}
+
+	@Override
+	public Certificate engineGetCertificate(String alias) {
+		try {
+			Certificate cert = primary.getCertificate(alias);
+			if (cert == null) {
+				cert = fallback.getCertificate(alias);
+			}
+			return cert;
+		} catch (KeyStoreException e) {
+			throw new IllegalStateException("At least one keystore of [%s, %s] is not initialized.".formatted(primary.getType(), fallback.getType()), e);
+		}
+	}
+
+	@Override
+	public Date engineGetCreationDate(String alias) {
+		try {
+			Date date = primary.getCreationDate(alias);
+			if (date == null) {
+				date = fallback.getCreationDate(alias);
+			}
+			return date;
+		} catch (KeyStoreException e) {
+			throw new IllegalStateException("At least one keystore of [%s, %s] is not initialized.".formatted(primary.getType(), fallback.getType()), e);
+		}
+	}
+
+	@Override
+	public void engineSetKeyEntry(String alias, Key key, char[] password, Certificate[] chain) throws KeyStoreException {
+		throw new UnsupportedOperationException("Read-only KeyStore");
+	}
+
+	@Override
+	public void engineSetKeyEntry(String alias, byte[] key, Certificate[] chain) throws KeyStoreException {
+		throw new UnsupportedOperationException("Read-only KeyStore");
+	}
+
+	@Override
+	public void engineSetCertificateEntry(String alias, Certificate cert) throws KeyStoreException {
+		throw new UnsupportedOperationException("Read-only KeyStore");
+	}
+
+	@Override
+	public void engineDeleteEntry(String alias) throws KeyStoreException {
+		throw new UnsupportedOperationException("Read-only KeyStore");
+	}
+
+	@Override
+	public Enumeration<String> engineAliases() {
+		var aliases = new Vector<String>();
+		try {
+			var it1 = primary.aliases().asIterator();
+			while (it1.hasNext()) {
+				aliases.add(it1.next());
+			}
+			var it2 = fallback.aliases().asIterator();
+			while (it2.hasNext()) {
+				var alias = it2.next();
+				if (!aliases.contains(alias)) {
+					aliases.add(alias);
+				}
+			}
+			return aliases.elements();
+		} catch (KeyStoreException e) {
+			throw new IllegalStateException("At least one keystore of [%s, %s] is not initialized.".formatted(primary.getType(), fallback.getType()), e);
+		}
+	}
+
+	@Override
+	public boolean engineContainsAlias(String alias) {
+		try {
+			return primary.containsAlias(alias) || fallback.containsAlias(alias);
+		} catch (KeyStoreException e) {
+			throw new IllegalStateException("At least one keystore of [%s, %s] is not initialized.".formatted(primary.getType(), fallback.getType()), e);
+		}
+	}
+
+	@Override
+	public int engineSize() {
+		var aliases = engineAliases();
+		if (!aliases.hasMoreElements()) {
+			return 0;
+		}
+
+		var i = new AtomicInteger(0);
+		aliases.asIterator().forEachRemaining(_ -> i.incrementAndGet());
+		return i.get();
+	}
+
+	@Override
+	public boolean engineIsKeyEntry(String alias) {
+		return false;
+	}
+
+	@Override
+	public boolean engineIsCertificateEntry(String alias) {
+		return false;
+	}
+
+	@Override
+	public String engineGetCertificateAlias(Certificate cert) {
+		try {
+			String alias = primary.getCertificateAlias(cert);
+			if (alias == null) {
+				alias = fallback.getCertificateAlias(cert);
+			}
+			return alias;
+		} catch (KeyStoreException e) {
+			throw new IllegalStateException("At least one keystore of [%s, %s] is not initialized.".formatted(primary.getType(), fallback.getType()), e);
+		}
+	}
+
+	@Override
+	public void engineStore(OutputStream stream, char[] password) throws IOException, NoSuchAlgorithmException, CertificateException {
+		throw new UnsupportedOperationException("Read-only KeyStore");
+	}
+
+	@Override
+	public void engineLoad(InputStream stream, char[] password) throws IOException, NoSuchAlgorithmException, CertificateException {
+		// Nothing to do; the real keystores are already loaded.
+	}
+}

--- a/src/main/java/org/cryptomator/networking/CombinedKeyStoreSpi.java
+++ b/src/main/java/org/cryptomator/networking/CombinedKeyStoreSpi.java
@@ -170,6 +170,7 @@ public class CombinedKeyStoreSpi extends KeyStoreSpi {
 
 	@Override
 	public void engineLoad(InputStream stream, char[] password) throws IOException, NoSuchAlgorithmException, CertificateException {
-		// Nothing to do; the real keystores are already loaded.
+		primary.load(stream, password);
+		fallback.load(stream, password);
 	}
 }

--- a/src/main/java/org/cryptomator/networking/CombinedKeyStoreSpi.java
+++ b/src/main/java/org/cryptomator/networking/CombinedKeyStoreSpi.java
@@ -21,7 +21,21 @@ public class CombinedKeyStoreSpi extends KeyStoreSpi {
 	private final KeyStore primary;
 	private final KeyStore fallback;
 
-	public CombinedKeyStoreSpi(KeyStore primary, KeyStore fallback) {
+	public static CombinedKeyStoreSpi create(KeyStore primary, KeyStore fallback) {
+		checkIfLoaded(primary);
+		checkIfLoaded(fallback);
+		return new CombinedKeyStoreSpi(primary, fallback);
+	}
+
+	private static void checkIfLoaded(KeyStore s) {
+		try {
+			s.aliases();
+		} catch (KeyStoreException e) {
+			throw new IllegalArgumentException("Keystore %s is not loaded.".formatted(s.getType()));
+		}
+	}
+
+	private CombinedKeyStoreSpi(KeyStore primary, KeyStore fallback) {
 		this.primary = primary;
 		this.fallback = fallback;
 	}

--- a/src/main/java/org/cryptomator/networking/CombinedKeyStoreSpi.java
+++ b/src/main/java/org/cryptomator/networking/CombinedKeyStoreSpi.java
@@ -145,10 +145,6 @@ public class CombinedKeyStoreSpi extends KeyStoreSpi {
 	@Override
 	public int engineSize() {
 		var aliases = engineAliases();
-		if (!aliases.hasMoreElements()) {
-			return 0;
-		}
-
 		var i = new AtomicInteger(0);
 		aliases.asIterator().forEachRemaining(_ -> i.incrementAndGet());
 		return i.get();
@@ -156,12 +152,20 @@ public class CombinedKeyStoreSpi extends KeyStoreSpi {
 
 	@Override
 	public boolean engineIsKeyEntry(String alias) {
-		return false;
+		try {
+			return primary.isKeyEntry(alias) || fallback.isKeyEntry(alias);
+		} catch (KeyStoreException e) {
+			throw new IllegalStateException("At least one keystore of [%s, %s] is not initialized.".formatted(primary.getType(), fallback.getType()), e);
+		}
 	}
 
 	@Override
 	public boolean engineIsCertificateEntry(String alias) {
-		return false;
+		try {
+			return primary.isCertificateEntry(alias) || fallback.isCertificateEntry(alias);
+		} catch (KeyStoreException e) {
+			throw new IllegalStateException("At least one keystore of [%s, %s] is not initialized.".formatted(primary.getType(), fallback.getType()), e);
+		}
 	}
 
 	@Override

--- a/src/main/java/org/cryptomator/networking/CombinedKeyStoreSpi.java
+++ b/src/main/java/org/cryptomator/networking/CombinedKeyStoreSpi.java
@@ -11,9 +11,10 @@ import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Enumeration;
-import java.util.Vector;
+import java.util.LinkedHashSet;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class CombinedKeyStoreSpi extends KeyStoreSpi {
@@ -114,20 +115,11 @@ public class CombinedKeyStoreSpi extends KeyStoreSpi {
 
 	@Override
 	public Enumeration<String> engineAliases() {
-		var aliases = new Vector<String>();
+		var aliases = new LinkedHashSet<String>();
 		try {
-			var it1 = primary.aliases().asIterator();
-			while (it1.hasNext()) {
-				aliases.add(it1.next());
-			}
-			var it2 = fallback.aliases().asIterator();
-			while (it2.hasNext()) {
-				var alias = it2.next();
-				if (!aliases.contains(alias)) {
-					aliases.add(alias);
-				}
-			}
-			return aliases.elements();
+			primary.aliases().asIterator().forEachRemaining(aliases::add);
+			fallback.aliases().asIterator().forEachRemaining(aliases::add);
+			return Collections.enumeration(aliases);
 		} catch (KeyStoreException e) {
 			throw new IllegalStateException("At least one keystore of [%s, %s] is not initialized.".formatted(primary.getType(), fallback.getType()), e);
 		}

--- a/src/main/java/org/cryptomator/networking/CombinedKeyStoreSpi.java
+++ b/src/main/java/org/cryptomator/networking/CombinedKeyStoreSpi.java
@@ -170,7 +170,6 @@ public class CombinedKeyStoreSpi extends KeyStoreSpi {
 
 	@Override
 	public void engineLoad(InputStream stream, char[] password) throws IOException, NoSuchAlgorithmException, CertificateException {
-		primary.load(stream, password);
-		fallback.load(stream, password);
+		// Nothing to do; the real keystores are already loaded.
 	}
 }

--- a/src/main/java/org/cryptomator/networking/SSLContextWithMacKeychain.java
+++ b/src/main/java/org/cryptomator/networking/SSLContextWithMacKeychain.java
@@ -19,8 +19,12 @@ public class SSLContextWithMacKeychain extends SSLContextDifferentTrustStoreBase
 	KeyStore getTruststore() throws KeyStoreException, CertificateException, IOException, NoSuchAlgorithmException {
 		var userKeyStore = KeyStore.getInstance("KeychainStore");
 		var systemRootKeyStore = KeyStore.getInstance("KeychainStore-ROOT");
-		CombinedKeyStoreSpi spi = new CombinedKeyStoreSpi(userKeyStore, systemRootKeyStore);
-		Provider dummyProvider = new Provider("CombinedKeyStoreProvider", "1.0", "Provides a combined, read-only KeyStore") {};
-		return new KeyStore(spi, dummyProvider, "CombinedKeyStoreProvider") {};
+		try {
+			CombinedKeyStoreSpi spi = CombinedKeyStoreSpi.create(userKeyStore, systemRootKeyStore);
+			Provider dummyProvider = new Provider("CombinedKeyStoreProvider", "1.0", "Provides a combined, read-only KeyStore") {};
+			return new KeyStore(spi, dummyProvider, "CombinedKeyStoreProvider") {};
+		} catch (IllegalArgumentException e) {
+			throw new KeyStoreException(e);
+		}
 	}
 }

--- a/src/main/java/org/cryptomator/networking/SSLContextWithMacKeychain.java
+++ b/src/main/java/org/cryptomator/networking/SSLContextWithMacKeychain.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
 import java.security.cert.CertificateException;
 
 /**
@@ -16,6 +17,10 @@ public class SSLContextWithMacKeychain extends SSLContextDifferentTrustStoreBase
 
 	@Override
 	KeyStore getTruststore() throws KeyStoreException, CertificateException, IOException, NoSuchAlgorithmException {
-		return KeyStore.getInstance("KeychainStore-ROOT");
+		var userKeyStore = KeyStore.getInstance("KeychainStore");
+		var systemRootKeyStore = KeyStore.getInstance("KeychainStore-ROOT");
+		CombinedKeyStoreSpi spi = new CombinedKeyStoreSpi(userKeyStore, systemRootKeyStore);
+		Provider dummyProvider = new Provider("CombinedKeyStoreProvider", "1.0", "Provides a combined, read-only KeyStore") {};
+		return new KeyStore(spi, dummyProvider, "CombinedKeyStoreProvider") {};
 	}
 }

--- a/src/main/java/org/cryptomator/networking/SSLContextWithMacKeychain.java
+++ b/src/main/java/org/cryptomator/networking/SSLContextWithMacKeychain.java
@@ -19,6 +19,8 @@ public class SSLContextWithMacKeychain extends SSLContextDifferentTrustStoreBase
 	KeyStore getTruststore() throws KeyStoreException, CertificateException, IOException, NoSuchAlgorithmException {
 		var userKeyStore = KeyStore.getInstance("KeychainStore");
 		var systemRootKeyStore = KeyStore.getInstance("KeychainStore-ROOT");
+		userKeyStore.load(null);
+		systemRootKeyStore.load(null);
 		try {
 			CombinedKeyStoreSpi spi = CombinedKeyStoreSpi.create(userKeyStore, systemRootKeyStore);
 			Provider dummyProvider = new Provider("CombinedKeyStoreProvider", "1.0", "Provides a combined, read-only KeyStore") {};


### PR DESCRIPTION
This PR fixes #3834 

This PR adds the `CombinedKeyStoreSpi` class, which is a [`KeyStoreSpi`](https://docs.oracle.com/en/java/javase/23/docs/api/java.base/java/security/KeyStoreSpi.html). Its key features are, that it takes two already loaded Keystores and represents a "merge" of those stores. E.g., if `combinedKeyStore.getKey("foobar")` first looks up the key in the first Keystore and if it cannot be found, looks up the key in the second one. The keystore is read-only.

This keystore impl is used for the macOS SSLContextProvider.