### PR TITLE
CI: Trigger the appropiate build workflows based on changed files

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -8,6 +8,12 @@ on:
       version:
         description: 'Version'
         required: false
+  push:
+    paths:
+      - '.github/workflows/appimage.yml'
+      - 'dist/linux/appimage/**'
+      - 'dist/linux/common/**'
+      - 'dist/linux/resources/**'
 
 env:
   JAVA_DIST: 'temurin'
@@ -17,7 +23,7 @@ jobs:
   get-version:
     uses: ./.github/workflows/get-version.yml
     with:
-      version: ${{ inputs.version }}
+      version: ${{ inputs.version }} #okay if not defined
 
   build:
     name: Build AppImage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: Build
 
 on:
   push:
+    paths:
+      - 'pom.xml'
+      - 'src/**'
   pull_request_target:
     types: [labeled]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: Build
 on:
   push:
     paths:
+      - '.github/workflows/build.yml'
       - 'pom.xml'
       - 'src/**'
   pull_request_target:

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -5,15 +5,19 @@ on:
     inputs:
       semver:
         description: 'SemVer String (e.g. 1.7.0-beta1)'
-        required: true
       ppaver:
         description: 'Base PPA Version String (e.g. 1.6.16+1.7.0~beta1) without -0ppa1'
-        required: true
       dput:
         description: 'Upload to PPA'
         required: true
         default: false
         type: boolean
+  push:
+    paths:
+      - '.github/workflows/debian.yml'
+      - 'dist/linux/debian/**'
+      - 'dist/linux/common/**'
+      - 'dist/linux/resources/**'
 
 env:
   JAVA_DIST: 'temurin'
@@ -26,20 +30,25 @@ env:
   OPENJFX_JMODS_AARCH64_HASH: '9bbedaeae1590b69e2b22237bda310936df33e344dbc243bea2e86acaab3a0d8'
 
 jobs:
+  get-version:
+    uses: ./.github/workflows/get-version.yml
+    with:
+      version: ${{ inputs.semver }} #okay if not defined
+
   build:
     name: Build Debian Package
     runs-on: ubuntu-22.04
+    needs: [get-version]
     steps:
       - uses: actions/checkout@v4
-      - id: versions
-        name: Get version information
+      - id: deb-version
+        name: Determine deb-version
         run: |
-          SEM_VER_STR="${{ inputs.semver }}"
-          SEM_VER_NUM=`echo ${SEM_VER_STR} | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/'`
-          REVCOUNT=`git rev-list --count HEAD`
-          echo "semVerStr=${SEM_VER_STR}" >> $GITHUB_OUTPUT
-          echo "semVerNum=${SEM_VER_NUM}" >> $GITHUB_OUTPUT
-          echo "revNum=${REVCOUNT}" >> $GITHUB_OUTPUT
+          if [ -n "${{inputs.ppaver}}" ]; then
+            echo "debVersion=${{inputs.ppaver }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "debVersion=${{needs.get-version.outputs.semVerStr}}" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install build tools
         run: |
           sudo add-apt-repository ppa:coffeelibs/openjdk
@@ -94,7 +103,7 @@ jobs:
           cp -r jmods pkgdir
           cp -r dist/linux/common/ pkgdir
           cp target/cryptomator-*.jar pkgdir/mods
-          tar -cJf cryptomator_${{ inputs.ppaver }}.orig.tar.xz -C pkgdir .
+          tar -cJf cryptomator_${{ steps.deb-version.outputs.debVersion }}.orig.tar.xz -C pkgdir .
       - name: Patch and rename pkgdir
         run: |
           cp -r dist/linux/debian/ pkgdir
@@ -103,12 +112,12 @@ jobs:
           envsubst '${SEMVER_STR} ${VERSION_NUM} ${REVISION_NUM} ${DISABLE_UPDATE_CHECK}' < dist/linux/debian/rules > pkgdir/debian/rules
           envsubst '${PPA_VERSION} ${RFC2822_TIMESTAMP}' < dist/linux/debian/changelog > pkgdir/debian/changelog
           find . -name "*.jar" >> pkgdir/debian/source/include-binaries
-          mv pkgdir cryptomator_${{ inputs.ppaver }}
+          mv pkgdir cryptomator_${{ steps.deb-version.outputs.debVersion }}
         env:
-          SEMVER_STR: ${{ steps.versions.outputs.semVerStr }}
-          VERSION_NUM: ${{ steps.versions.outputs.semVerNum }}
-          REVISION_NUM: ${{ steps.versions.outputs.revNum }}
-          PPA_VERSION: ${{ inputs.ppaver }}-0ppa1
+          SEMVER_STR: ${{ needs.get-version.outputs.semVerStr }}
+          VERSION_NUM: ${{ needs.get-version.outputs.semVerNum }}
+          REVISION_NUM: ${{ needs.get-version.outputs.revNum }}
+          PPA_VERSION: ${{ steps.deb-version.outputs.debVersion }}-0ppa1
       - name: Prepare GPG-Agent for signing with key 615D449FE6E6A235
         run: |
           echo "${GPG_PRIVATE_KEY}" | gpg --batch --quiet --import
@@ -124,7 +133,7 @@ jobs:
         env:
           DEBSIGN_PROGRAM: gpg --batch --pinentry-mode loopback
           DEBSIGN_KEYID: 615D449FE6E6A235
-        working-directory: cryptomator_${{ inputs.ppaver }}
+        working-directory: cryptomator_${{ steps.deb-version.outputs.debVersion }}
       - name: Create detached GPG signatures
         run: |
           gpg --batch --quiet --passphrase-fd 0 --pinentry-mode loopback -u 615D449FE6E6A235 --detach-sign -a cryptomator_*_amd64.deb
@@ -141,7 +150,7 @@ jobs:
             cryptomator_*_amd64.deb
             cryptomator_*.asc
       - name: Publish on PPA
-        if: inputs.dput
+        if: inputs.dput && inputs.ppaver != ''
         run: dput ppa:sebastian-stenzel/cryptomator-beta cryptomator_*_source.changes
       # If ref is a tag, also upload to GitHub Releases:
       - name: Publish Debian package on GitHub Releases

--- a/.github/workflows/mac-dmg.yml
+++ b/.github/workflows/mac-dmg.yml
@@ -13,6 +13,10 @@ on:
         required: true
         default: false
         type: boolean
+  push:
+    paths:
+      - '.github/workflows/mac-dmg.yml'
+      - 'dist/mac/**'
 
 env:
   JAVA_DIST: 'temurin'

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -12,6 +12,10 @@ on:
         description: 'Build debug version with console output'
         type: boolean
         default: false
+  push:
+    paths:
+      - '.github/workflows/win-exe.yml'
+      - 'dist/win/**'
 
 
 env:


### PR DESCRIPTION
This PR improves the CI scripts by only executing those build phases, where files were changed.

E.g. if the pom is adjusted or any Java source code is changed, the build workflow is triggered. If i adjust something for the appimage in the dist folder, the appimage is build.