### PR TITLE
Added unlock flow when opening vault via app launch event

### DIFF
--- a/src/main/java/org/cryptomator/common/vaults/VaultListManager.java
+++ b/src/main/java/org/cryptomator/common/vaults/VaultListManager.java
@@ -106,7 +106,7 @@ public class VaultListManager {
 		vaultList.addAll(vaults);
 	}
 
-	private Optional<Vault> get(Path vaultPath) {
+	public Optional<Vault> get(Path vaultPath) {
 		assert vaultPath.isAbsolute();
 		assert vaultPath.normalize().equals(vaultPath);
 		return vaultList.stream() //


### PR DESCRIPTION
Improved the user experience when opening vaults through external app launch events (double-clicking vault files, opening from file system). Previously, you could only reveal an unlocked vault. Now, you can also unlock a locked vault.

This implementation makes sure that newly added vaults don't unlock automatically and just get added to the vault list as before.

Ideally, for existing vaults, it should auto-select the vault in the vault list, but I must honestly admit that I don't know how to solve this without making bigger changes in the codebase. Auto-selecting a newly added vault works, because a change listener on the vault list does this right now, but it obviously won't get triggered for an existing vault.