### PR TITLE
build.sh improvements

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Build AppImage
         run: >
           ./squashfs-root/AppRun Cryptomator.AppDir cryptomator-${{  needs.get-version.outputs.semVerStr }}-${{ matrix.appimage-suffix }}.AppImage
-          -u 'gh-releases-zsync|cryptomator|cryptomator|latest|cryptomator-*-${{ matrix.appimage-suffix }}.AppImage.zsync'
+          -u "gh-releases-zsync|cryptomator|cryptomator|latest|cryptomator-*-${{ matrix.appimage-suffix }}.AppImage.zsync"
           --sign --sign-key=615D449FE6E6A235
       - name: Create detached GPG signatures
         run: |

--- a/dist/linux/appimage/build.sh
+++ b/dist/linux/appimage/build.sh
@@ -12,7 +12,7 @@ command -v unzip >/dev/null 2>&1 || { echo >&2 "unzip not found."; exit 1; }
 
 VERSION=$(mvn -f ../../../pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
 SEMVER_STR=${VERSION}
-CPU_ARCH=$(uname -p)
+CPU_ARCH=$(uname -m)
 
 if [[ ! "${CPU_ARCH}" =~ x86_64|aarch64 ]]; then echo "Platform ${CPU_ARCH} not supported"; exit 1; fi
 
@@ -128,7 +128,7 @@ chmod +x /tmp/appimagetool.AppImage
 /tmp/appimagetool.AppImage \
     Cryptomator.AppDir \
     cryptomator-${SEMVER_STR}-${CPU_ARCH}.AppImage  \
-    -u 'gh-releases-zsync|cryptomator|cryptomator|latest|cryptomator-*-${CPU_ARCH}.AppImage.zsync'
+    -u "gh-releases-zsync|cryptomator|cryptomator|latest|cryptomator-*-${CPU_ARCH}.AppImage.zsync"
 
 echo ""
 echo "Done. AppImage successfully created: cryptomator-${SEMVER_STR}-${CPU_ARCH}.AppImage"


### PR DESCRIPTION
This PR fixes two issues:

## `uname -p` prints out unknown
Running this command on different machines only prints out something other than unknown on KUbuntu 24.04 for me.
unknown gets printed out on Arch linux (x86_64 and aarch64), Debian Bookworm (x86_64) and Fedora 42 (aarch64).

`uname -m` prints out the desired value on all the machines mentioned before.

```bash
ralph@arch ~ % uname --help
Usage: uname [OPTION]...
Print certain system information.  With no OPTION, same as -s.

  -a, --all                print all information, in the following order,
                             except omit -p and -i if unknown:
  -s, --kernel-name        print the kernel name
  -n, --nodename           print the network node hostname
  -r, --kernel-release     print the kernel release
  -v, --kernel-version     print the kernel version
  -m, --machine            print the machine hardware name
  -p, --processor          print the processor type (non-portable)
  -i, --hardware-platform  print the hardware platform (non-portable)
  -o, --operating-system   print the operating system
      --help        display this help and exit
      --version     output version information and exit

GNU coreutils online help: <https://www.gnu.org/software/coreutils/>
Report any translation bugs to <https://translationproject.org/team/>
Full documentation <https://www.gnu.org/software/coreutils/uname>
or available locally via: info '(coreutils) uname invocation'
```
## Fix GitHub Releases information
The AppImage already contains the required information to be updated with AppImageUpdate.AppImage.

Currently, this fails with an error, as the provided update information is incorrect due to the `${CPU_ARCH}` variable not being resolved.