### PR TITLE
Fix missing characters after Unicode in RTF files

### DIFF
--- a/src/main/java/org/cryptomator/ui/addvaultwizard/ReadmeGenerator.java
+++ b/src/main/java/org/cryptomator/ui/addvaultwizard/ReadmeGenerator.java
@@ -79,7 +79,7 @@ public class ReadmeGenerator {
 			} else if (c <= 0xFF) {
 				sb.append("\\'").append(String.format("%02X", c));
 			} else if (c < 0xFFFF) {
-				sb.append("\\uc1\\u").append(c);
+				sb.append("\\u").append(c);
 			}
 		});
 	}

--- a/src/test/java/org/cryptomator/ui/addvaultwizard/ReadMeGeneratorTest.java
+++ b/src/test/java/org/cryptomator/ui/addvaultwizard/ReadMeGeneratorTest.java
@@ -16,7 +16,7 @@ public class ReadMeGeneratorTest {
 	@CsvSource({ //
 			"test,test", //
 			"t\u00E4st,t\\'E4st", //
-			"t\uD83D\uDE09st,t\\uc1\\u55357\\uc1\\u56841st", //
+			"t\uD83D\uDE09st,t\\u55357\\u56841st", //
 	})
 	public void testEscapeNonAsciiChars(String input, String expectedResult) {
 		ReadmeGenerator readmeGenerator = new ReadmeGenerator(null);
@@ -40,7 +40,7 @@ public class ReadMeGeneratorTest {
 		MatcherAssert.assertThat(result, CoreMatchers.startsWith("{\\rtf1\\fbidis\\ansi\\uc0\\fs32"));
 		MatcherAssert.assertThat(result, CoreMatchers.containsString("{\\sa80 Dear User,}\\par"));
 		MatcherAssert.assertThat(result, CoreMatchers.containsString("{\\sa80 \\b please don't touch the \"d\" directory.}\\par "));
-		MatcherAssert.assertThat(result, CoreMatchers.containsString("{\\sa80 Thank you for your cooperation \\uc1\\u55357\\uc1\\u56841}\\par"));
+		MatcherAssert.assertThat(result, CoreMatchers.containsString("{\\sa80 Thank you for your cooperation \\u55357\\u56841}\\par"));
 		MatcherAssert.assertThat(result, CoreMatchers.endsWith("}"));
 	}
 


### PR DESCRIPTION
Remove `\uc1` from Unicode escapes as it causes RTF readers to skip the following character. This also led Microsoft Word to display an error when trying to open the RTF file. I believe this is a regression introduced in 1.16.0 with PR #3609. I also tested the French RTF and #3252 is still fixed.

Full disclosure, this is an explanation from Claude Code and I have no idea if this is true since I don't know the RTF specs:

> Since we don't provide fallback characters and the header declares `\uc0`, the `\uc1` was incorrectly consuming actual content characters.