### PR TITLE
Feature: Default to previously used vault directory when creating a vault

### DIFF
--- a/src/main/java/org/cryptomator/common/settings/Settings.java
+++ b/src/main/java/org/cryptomator/common/settings/Settings.java
@@ -25,6 +25,8 @@ import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.geometry.NodeOrientation;
+
+import java.nio.file.Path;
 import java.time.Instant;
 import java.util.function.Consumer;
 
@@ -75,7 +77,7 @@ public class Settings {
 	public final BooleanProperty checkForUpdates;
 	public final ObjectProperty<Instant> lastUpdateCheckReminder;
 	public final ObjectProperty<Instant> lastSuccessfulUpdateCheck;
-	public final StringProperty previouslyUsedVaultDirectory;
+	public final ObjectProperty<Path> previouslyUsedVaultDirectory;
 
 	private Consumer<Settings> saveCmd;
 
@@ -115,7 +117,7 @@ public class Settings {
 		this.checkForUpdates = new SimpleBooleanProperty(this, "checkForUpdates", json.checkForUpdatesEnabled);
 		this.lastUpdateCheckReminder = new SimpleObjectProperty<>(this, "lastUpdateCheckReminder", json.lastReminderForUpdateCheck);
 		this.lastSuccessfulUpdateCheck = new SimpleObjectProperty<>(this, "lastSuccessfulUpdateCheck", json.lastSuccessfulUpdateCheck);
-		this.previouslyUsedVaultDirectory = new SimpleStringProperty(this, "previouslyUsedVaultDirectory", json.previouslyUsedVaultDirectory);
+		this.previouslyUsedVaultDirectory = new SimpleObjectProperty<>(this, "previouslyUsedVaultDirectory", json.previouslyUsedVaultDirectory);
 
 		this.directories.addAll(json.directories.stream().map(VaultSettings::new).toList());
 

--- a/src/main/java/org/cryptomator/common/settings/Settings.java
+++ b/src/main/java/org/cryptomator/common/settings/Settings.java
@@ -25,7 +25,6 @@ import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.geometry.NodeOrientation;
-import java.nio.file.Path;
 import java.time.Instant;
 import java.util.function.Consumer;
 

--- a/src/main/java/org/cryptomator/common/settings/Settings.java
+++ b/src/main/java/org/cryptomator/common/settings/Settings.java
@@ -25,6 +25,7 @@ import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.geometry.NodeOrientation;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.util.function.Consumer;
 
@@ -75,6 +76,7 @@ public class Settings {
 	public final BooleanProperty checkForUpdates;
 	public final ObjectProperty<Instant> lastUpdateCheckReminder;
 	public final ObjectProperty<Instant> lastSuccessfulUpdateCheck;
+	public final StringProperty previouslyUsedVaultDirectory;
 
 	private Consumer<Settings> saveCmd;
 
@@ -114,6 +116,7 @@ public class Settings {
 		this.checkForUpdates = new SimpleBooleanProperty(this, "checkForUpdates", json.checkForUpdatesEnabled);
 		this.lastUpdateCheckReminder = new SimpleObjectProperty<>(this, "lastUpdateCheckReminder", json.lastReminderForUpdateCheck);
 		this.lastSuccessfulUpdateCheck = new SimpleObjectProperty<>(this, "lastSuccessfulUpdateCheck", json.lastSuccessfulUpdateCheck);
+		this.previouslyUsedVaultDirectory = new SimpleStringProperty(this, "previouslyUsedDirectory", json.previouslyUsedVaultDirectory);
 
 		this.directories.addAll(json.directories.stream().map(VaultSettings::new).toList());
 
@@ -143,6 +146,7 @@ public class Settings {
 		checkForUpdates.addListener(this::somethingChanged);
 		lastUpdateCheckReminder.addListener(this::somethingChanged);
 		lastSuccessfulUpdateCheck.addListener(this::somethingChanged);
+		previouslyUsedVaultDirectory.addListener(this::somethingChanged);
 	}
 
 	@SuppressWarnings("deprecation")
@@ -204,6 +208,7 @@ public class Settings {
 		json.checkForUpdatesEnabled = checkForUpdates.get();
 		json.lastReminderForUpdateCheck = lastUpdateCheckReminder.get();
 		json.lastSuccessfulUpdateCheck = lastSuccessfulUpdateCheck.get();
+		json.previouslyUsedVaultDirectory = previouslyUsedVaultDirectory.get();
 		return json;
 	}
 

--- a/src/main/java/org/cryptomator/common/settings/Settings.java
+++ b/src/main/java/org/cryptomator/common/settings/Settings.java
@@ -115,7 +115,7 @@ public class Settings {
 		this.checkForUpdates = new SimpleBooleanProperty(this, "checkForUpdates", json.checkForUpdatesEnabled);
 		this.lastUpdateCheckReminder = new SimpleObjectProperty<>(this, "lastUpdateCheckReminder", json.lastReminderForUpdateCheck);
 		this.lastSuccessfulUpdateCheck = new SimpleObjectProperty<>(this, "lastSuccessfulUpdateCheck", json.lastSuccessfulUpdateCheck);
-		this.previouslyUsedVaultDirectory = new SimpleStringProperty(this, "previouslyUsedDirectory", json.previouslyUsedVaultDirectory);
+		this.previouslyUsedVaultDirectory = new SimpleStringProperty(this, "previouslyUsedVaultDirectory", json.previouslyUsedVaultDirectory);
 
 		this.directories.addAll(json.directories.stream().map(VaultSettings::new).toList());
 

--- a/src/main/java/org/cryptomator/common/settings/SettingsJson.java
+++ b/src/main/java/org/cryptomator/common/settings/SettingsJson.java
@@ -92,4 +92,7 @@ class SettingsJson {
 
 	@JsonProperty("quickAccessService")
 	String quickAccessService = Settings.DEFAULT_QUICKACCESS_SERVICE;
+
+	@JsonProperty("previouslyUsedVaultDirectory")
+	String previouslyUsedVaultDirectory;
 }

--- a/src/main/java/org/cryptomator/common/settings/SettingsJson.java
+++ b/src/main/java/org/cryptomator/common/settings/SettingsJson.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
 
@@ -94,5 +95,5 @@ class SettingsJson {
 	String quickAccessService = Settings.DEFAULT_QUICKACCESS_SERVICE;
 
 	@JsonProperty("previouslyUsedVaultDirectory")
-	String previouslyUsedVaultDirectory;
+	Path previouslyUsedVaultDirectory;
 }

--- a/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
+++ b/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
@@ -106,8 +106,7 @@ public class CreateNewVaultLocationController implements FxController {
 		if (previouslyUsedDirectory != null) {
 			try {
 				Path cachedPath = Path.of(previouslyUsedDirectory);
-				VaultPathStatus cachedPathParentStatus = validatePath(cachedPath.getParent());
-				if (cachedPathParentStatus.valid()) {
+				if (Files.exists(cachedPath) && Files.isDirectory(cachedPath) && isActuallyWritable(cachedPath)) {
 					this.customVaultPath = cachedPath;
 				}
 			} catch (InvalidPathException | NullPointerException e) {

--- a/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
+++ b/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
@@ -4,6 +4,8 @@ import dagger.Lazy;
 import org.cryptomator.common.ObservableUtil;
 import org.cryptomator.common.locationpresets.LocationPreset;
 import org.cryptomator.common.locationpresets.LocationPresetsProvider;
+import org.cryptomator.common.settings.Settings;
+import org.cryptomator.common.settings.SettingsProvider;
 import org.cryptomator.ui.common.FxController;
 import org.cryptomator.ui.common.FxmlFile;
 import org.cryptomator.ui.common.FxmlScene;
@@ -64,6 +66,7 @@ public class CreateNewVaultLocationController implements FxController {
 	private final BooleanProperty loadingPresetLocations = new SimpleBooleanProperty(false);
 	private final ObservableList<Node> radioButtons;
 	private final ObservableList<Node> sortedRadioButtons;
+	private final Settings settings;
 
 	private Path customVaultPath = DEFAULT_CUSTOM_VAULT_PATH;
 
@@ -82,6 +85,7 @@ public class CreateNewVaultLocationController implements FxController {
 									 @FxmlScene(FxmlFile.ADDVAULT_NEW_EXPERT_SETTINGS) Lazy<Scene> chooseExpertSettingsScene, //
 									 ObjectProperty<Path> vaultPath, //
 									 @Named("vaultName") StringProperty vaultName, //
+									 Settings settings, //
 									 ExecutorService backgroundExecutor, ResourceBundle resourceBundle) {
 		this.window = window;
 		this.chooseNameScene = chooseNameScene;
@@ -96,6 +100,12 @@ public class CreateNewVaultLocationController implements FxController {
 		this.usePresetPath = new SimpleBooleanProperty();
 		this.radioButtons = FXCollections.observableArrayList();
 		this.sortedRadioButtons = radioButtons.sorted(this::compareLocationPresets);
+		this.settings = settings;
+
+		var previouslyUsedDirectory = settings.previouslyUsedVaultDirectory.get();
+		if (previouslyUsedDirectory != null) {
+			this.customVaultPath = Paths.get(previouslyUsedDirectory);
+		}
 	}
 
 	private VaultPathStatus validatePath(Path p) throws NullPointerException {
@@ -196,6 +206,7 @@ public class CreateNewVaultLocationController implements FxController {
 	@FXML
 	public void next() {
 		if (validVaultPath.getValue()) {
+			this.settings.previouslyUsedVaultDirectory.setValue(this.vaultPath.get().getParent().toString());
 			window.setScene(chooseExpertSettingsScene.get());
 		}
 	}

--- a/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
+++ b/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
@@ -39,6 +39,7 @@ import javafx.stage.WindowEvent;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
@@ -103,7 +104,11 @@ public class CreateNewVaultLocationController implements FxController {
 
 		var previouslyUsedDirectory = settings.previouslyUsedVaultDirectory.get();
 		if (previouslyUsedDirectory != null) {
-			this.customVaultPath = Paths.get(previouslyUsedDirectory);
+			try {
+				this.customVaultPath = Paths.get(previouslyUsedDirectory);
+			} catch (InvalidPathException e) {
+				LOG.warn("Invalid previously used vault directory path: {}", previouslyUsedDirectory, e);
+			}
 		}
 	}
 
@@ -205,7 +210,10 @@ public class CreateNewVaultLocationController implements FxController {
 	@FXML
 	public void next() {
 		if (validVaultPath.getValue()) {
-			this.settings.previouslyUsedVaultDirectory.setValue(this.vaultPath.get().getParent().toString());
+			Path parentPath;
+			if (this.getVaultPath() != null && (parentPath = this.getVaultPath().getParent()) != null) {
+				this.settings.previouslyUsedVaultDirectory.setValue(parentPath.toString());
+			}
 			window.setScene(chooseExpertSettingsScene.get());
 		}
 	}

--- a/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
+++ b/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
@@ -105,7 +105,7 @@ public class CreateNewVaultLocationController implements FxController {
 		var previouslyUsedDirectory = settings.previouslyUsedVaultDirectory.get();
 		if (previouslyUsedDirectory != null) {
 			try {
-				Path cachedPath = Paths.get(previouslyUsedDirectory);
+				Path cachedPath = Path.of(previouslyUsedDirectory);
 				VaultPathStatus cachedPathStatus = validatePath(cachedPath);
 				if (cachedPathStatus.valid()) {
 					this.customVaultPath = cachedPath;
@@ -214,9 +214,11 @@ public class CreateNewVaultLocationController implements FxController {
 	@FXML
 	public void next() {
 		if (validVaultPath.getValue()) {
-			Path parentPath;
-			if (this.getVaultPath() != null && (parentPath = this.getVaultPath().getParent()) != null) {
-				this.settings.previouslyUsedVaultDirectory.setValue(parentPath.toString());
+			if (this.getVaultPath() != null) {
+				Path parentPath = this.getVaultPath().getParent();
+				if (parentPath != null) {
+					this.settings.previouslyUsedVaultDirectory.setValue(parentPath.toString());
+				}
 			}
 			window.setScene(chooseExpertSettingsScene.get());
 		}

--- a/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
+++ b/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
@@ -105,8 +105,12 @@ public class CreateNewVaultLocationController implements FxController {
 		var previouslyUsedDirectory = settings.previouslyUsedVaultDirectory.get();
 		if (previouslyUsedDirectory != null) {
 			try {
-				this.customVaultPath = Paths.get(previouslyUsedDirectory);
-			} catch (InvalidPathException e) {
+				Path cachedPath = Paths.get(previouslyUsedDirectory);
+				VaultPathStatus cachedPathStatus = validatePath(cachedPath);
+				if (cachedPathStatus.valid()) {
+					this.customVaultPath = cachedPath;
+				}
+			} catch (InvalidPathException | NullPointerException e) {
 				LOG.warn("Invalid previously used vault directory path: {}", previouslyUsedDirectory, e);
 			}
 		}

--- a/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
+++ b/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
@@ -102,12 +102,11 @@ public class CreateNewVaultLocationController implements FxController {
 		this.sortedRadioButtons = radioButtons.sorted(this::compareLocationPresets);
 		this.settings = settings;
 
-		var previouslyUsedDirectory = settings.previouslyUsedVaultDirectory.get();
+		Path previouslyUsedDirectory = settings.previouslyUsedVaultDirectory.get();
 		if (previouslyUsedDirectory != null) {
 			try {
-				Path cachedPath = Path.of(previouslyUsedDirectory);
-				if (Files.exists(cachedPath) && Files.isDirectory(cachedPath) && isActuallyWritable(cachedPath)) {
-					this.customVaultPath = cachedPath;
+				if (Files.exists(previouslyUsedDirectory) && Files.isDirectory(previouslyUsedDirectory) && isActuallyWritable(previouslyUsedDirectory)) {
+					this.customVaultPath = previouslyUsedDirectory;
 				}
 			} catch (InvalidPathException | NullPointerException e) {
 				LOG.warn("Invalid previously used vault directory path: {}", previouslyUsedDirectory, e);
@@ -216,7 +215,7 @@ public class CreateNewVaultLocationController implements FxController {
 			if (this.getVaultPath() != null) {
 				Path parentPath = this.getVaultPath().getParent();
 				if (parentPath != null) {
-					this.settings.previouslyUsedVaultDirectory.setValue(parentPath.toString());
+					this.settings.previouslyUsedVaultDirectory.setValue(parentPath);
 				}
 			}
 			window.setScene(chooseExpertSettingsScene.get());

--- a/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
+++ b/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
@@ -106,8 +106,8 @@ public class CreateNewVaultLocationController implements FxController {
 		if (previouslyUsedDirectory != null) {
 			try {
 				Path cachedPath = Path.of(previouslyUsedDirectory);
-				VaultPathStatus cachedPathStatus = validatePath(cachedPath);
-				if (cachedPathStatus.valid()) {
+				VaultPathStatus cachedPathParentStatus = validatePath(cachedPath.getParent());
+				if (cachedPathParentStatus.valid()) {
 					this.customVaultPath = cachedPath;
 				}
 			} catch (InvalidPathException | NullPointerException e) {

--- a/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
+++ b/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultLocationController.java
@@ -5,7 +5,6 @@ import org.cryptomator.common.ObservableUtil;
 import org.cryptomator.common.locationpresets.LocationPreset;
 import org.cryptomator.common.locationpresets.LocationPresetsProvider;
 import org.cryptomator.common.settings.Settings;
-import org.cryptomator.common.settings.SettingsProvider;
 import org.cryptomator.ui.common.FxController;
 import org.cryptomator.ui.common.FxmlFile;
 import org.cryptomator.ui.common.FxmlScene;


### PR DESCRIPTION
Fixes #3669

Adds support for automatically saving the previously used custom vault directory, so that new vaults default to the previously used directory.