### PR TITLE
Fix: Show Change Password tab after vault migration by improving KeyLoader scheme handling

### DIFF
--- a/src/main/java/org/cryptomator/common/vaults/VaultListManager.java
+++ b/src/main/java/org/cryptomator/common/vaults/VaultListManager.java
@@ -9,13 +9,13 @@
 package org.cryptomator.common.vaults;
 
 import org.apache.commons.lang3.SystemUtils;
-import org.cryptomator.common.Constants;
 import org.cryptomator.common.settings.Settings;
 import org.cryptomator.common.settings.VaultSettings;
 import org.cryptomator.cryptofs.CryptoFileSystemProvider;
 import org.cryptomator.cryptofs.DirStructure;
 import org.cryptomator.cryptofs.migration.Migrators;
 import org.cryptomator.integrations.mount.MountService;
+import org.cryptomator.ui.keyloading.masterkeyfile.MasterkeyFileLoadingStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,7 +125,7 @@ public class VaultListManager {
 					vaultSettings.lastKnownKeyLoader.set(keyIdScheme);
 				}
 			} else if (vaultState == NEEDS_MIGRATION) {
-				vaultSettings.lastKnownKeyLoader.set(Constants.DEFAULT_KEY_ID.toString());
+				vaultSettings.lastKnownKeyLoader.set(MasterkeyFileLoadingStrategy.SCHEME);
 			}
 			return vaultComponentFactory.create(vaultSettings, wrapper, vaultState, null).vault();
 		} catch (IOException e) {

--- a/src/main/java/org/cryptomator/ui/keyloading/KeyLoadingStrategy.java
+++ b/src/main/java/org/cryptomator/ui/keyloading/KeyLoadingStrategy.java
@@ -46,15 +46,16 @@ public interface KeyLoadingStrategy extends MasterkeyLoader {
 	/**
 	 * Determines whether the provided key loader scheme corresponds to a Masterkey File Vault.
 	 * <p>
-	 * This method checks if the {@code keyLoader} parameter matches the known Masterkey File Vault scheme
+	 * This method checks if the {@code keyLoader} parameter starts with the known Masterkey File Vault scheme
 	 * {@link MasterkeyFileLoadingStrategy#SCHEME}.
+	 * This allows identifying not only exact matches but also variants or extended schemes based on the Masterkey scheme.
 	 * </p>
 	 *
 	 * @param keyLoader A string representing the key loader scheme to be checked.
-	 * @return {@code true} if the given key loader scheme represents a Masterkey File Vault; {@code false} otherwise.
+	 * @return {@code true} if the given key loader scheme starts with the Masterkey File Vault scheme; {@code false} otherwise.
 	 */
 	static boolean isMasterkeyFileVault(String keyLoader) {
-		return MasterkeyFileLoadingStrategy.SCHEME.equals(keyLoader);
+		return keyLoader.startsWith(MasterkeyFileLoadingStrategy.SCHEME);
 	}
 
 	/**


### PR DESCRIPTION
This pull request addresses the issue #3917 where migrated legacy vaults did not display the Change Password tab in the vault options.

**Root Cause**
The KeyLoader was previously set to a fixed scheme value that did not tolerate variants or extended identifiers. As a result, migrated vaults with slightly different KeyLoader strings were not recognized as Masterkey File Vaults, so the password tab in vault options went missing.

**Changes Introduced**

- Adjusted the isMasterkeyFileVault method to use startsWith() instead of equals(), allowing compatibility with extended scheme strings.
- Ensured that incorrectly stored but compatible KeyLoader values are still accepted.
- Made sure that the correct KeyLoader value is now set during migrations.
