### PR TITLE
configure -XX:ErrorFile to write JVM crash logs to app log directory #3649

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -133,6 +133,7 @@ jobs:
           --java-options "-Dcryptomator.integrationsLinux.trayIconsDir=\"@{appdir}/usr/share/icons/hicolor/symbolic/apps\""
           --java-options "-Dcryptomator.buildNumber=\"appimage-${{  needs.get-version.outputs.revNum }}\""
           --java-options "-Dcryptomator.networking.truststore.p12Path=\"/etc/cryptomator/certs.p12\""
+          --java-options "-XX:ErrorFile=/cryptomator/cryptomator_crash.log"
           --resource-dir dist/linux/resources
       - name: Patch Cryptomator.AppDir
         run: |

--- a/.github/workflows/mac-dmg.yml
+++ b/.github/workflows/mac-dmg.yml
@@ -136,6 +136,7 @@ jobs:
           --java-options "-Dcryptomator.mountPointsDir=\"@{userhome}/Library/Application Support/Cryptomator/mnt\""
           --java-options "-Dcryptomator.showTrayIcon=true"
           --java-options "-Dcryptomator.buildNumber=\"dmg-${{ needs.get-version.outputs.revNum }}\""
+          --java-options "-XX:ErrorFile=/cryptomator/cryptomator_crash.log"
           --mac-package-identifier org.cryptomator
           --resource-dir dist/mac/resources
       - name: Patch Cryptomator.app

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -163,6 +163,7 @@ jobs:
           --java-options "-Dcryptomator.integrationsWin.keychainPaths=\"@{appdata}/Cryptomator/keychain.json;@{userhome}/AppData/Roaming/Cryptomator/keychain.json\""
           --java-options "-Dcryptomator.integrationsWin.windowsHelloKeychainPaths=\"@{appdata}/Cryptomator/windowsHelloKeychain.json\""
           --java-options "-Dcryptomator.disableUpdateCheck=false"
+          --java-options "-XX:ErrorFile=C:/cryptomator/cryptomator_crash.log"
           --resource-dir dist/win/resources
           --icon dist/win/resources/Cryptomator.ico
           --add-launcher "Cryptomator (Debug)=dist/win/debug-launcher.properties"

--- a/dist/linux/appimage/build.sh
+++ b/dist/linux/appimage/build.sh
@@ -98,6 +98,7 @@ ${JAVA_HOME}/bin/jpackage \
     --java-options "-Dcryptomator.integrationsLinux.trayIconsDir=\"@{appdir}/usr/share/icons/hicolor/symbolic/apps\"" \
     --java-options "-Dcryptomator.buildNumber=\"appimage-${REVISION_NO}\"" \
     --java-options "-Dcryptomator.networking.truststore.p12Path=\"/etc/cryptomator/certs.p12\"" \
+    --java-options "-XX:ErrorFile=/cryptomator/cryptomator_crash.log" \
     --resource-dir ../resources
 
 # transform AppDir

--- a/dist/mac/dmg/build.sh
+++ b/dist/mac/dmg/build.sh
@@ -115,6 +115,7 @@ ${JAVA_HOME}/bin/jpackage \
     --java-options "-Dsun.java2d.metal=true" \
     --java-options "-Dcryptomator.appVersion=\"${VERSION_NO}\"" \
     --java-options "-Dcryptomator.logDir=\"@{userhome}/Library/Logs/${APP_NAME}\"" \
+    --java-options "-XX:ErrorFile=/cryptomator/cryptomator_crash.log" \
     --java-options "-Dcryptomator.pluginDir=\"@{userhome}/Library/Application Support/${APP_NAME}/Plugins\"" \
     --java-options "-Dcryptomator.settingsPath=\"@{userhome}/Library/Application Support/${APP_NAME}/settings.json\"" \
     --java-options "-Dcryptomator.ipcSocketPath=\"@{userhome}/Library/Application Support/${APP_NAME}/ipc.socket\"" \

--- a/dist/win/build.ps1
+++ b/dist/win/build.ps1
@@ -154,6 +154,7 @@ $javaOptions = @(
 "--java-options", "-Dfile.encoding=`"utf-8`""
 "--java-options", "-Djava.net.useSystemProxies=true"
 "--java-options", "-Dcryptomator.logDir=`"@{localappdata}/$AppName`""
+"--java-options", "-XX:ErrorFile=`"C:/cryptomator/cryptomator_crash.log`""
 "--java-options", "-Dcryptomator.pluginDir=`"@{appdata}/$AppName/Plugins`""
 "--java-options", "-Dcryptomator.settingsPath=`"@{appdata}/$AppName/settings.json;@{userhome}/AppData/Roaming/$AppName/settings.json`""
 "--java-options", "-Dcryptomator.ipcSocketPath=`"@{localappdata}/$AppName/ipc.socket`""


### PR DESCRIPTION
**Closes #3649.**

### Changes
- Added `-XX:ErrorFile` to the `jpackage` `--java-options` in the build scripts for Linux (`dist/linux/build.sh`), macOS (`dist/mac/build.sh`), and Windows (`dist/windows/build.ps1`).
- Configured crash log paths using jpackage runtime placeholders (`@{userhome}` for Linux/macOS, `@{localappdata}` for Windows) to align with the app’s log directory (`-Dcryptomator.logDir`), ensuring `hs_err_pid*.log` files are stored in user-specific locations: `~/.local/share/Cryptomator/logs` (Linux), `~/Library/Logs/Cryptomator` (macOS), and `%LOCALAPPDATA%\Cryptomator` (Windows).

### Motivation
Addresses issue #3649 by redirecting JVM crash logs to the same directory as Cryptomator’s regular logs, simplifying log collection for support. The `-XX:ErrorFile` flag is set during the jpackage build phase to achieve this.

### Implementation Details
- **Runtime Placeholders**: Used `@{userhome}` and `@{localappdata}` to dynamically resolve to the user’s log directory at runtime, overcoming the limitation noted by @infeo (user account names are unknown at build time, and jpackaged apps cannot read environment variables like `$HOME`). These placeholders are already used in the scripts for `-Dcryptomator.logDir`, ensuring consistency.
- **Fallback Behavior**: Per Oracle JVM documentation, if the target directory is missing or unwritable (e.g., first run), the JVM stores the crash log in the OS temp directory — still more predictable than the default (current working directory).
- **Avoided Alternatives**: Global writable directories (e.g., /var/log, C:\ProgramData) were not used, as they often require elevated permissions and don’t align with user-specific log locations. A “never-existing” path (e.g., /nonexistent) was also avoided, as placeholders achieve the goal directly.

### Addressing issues
- @infeo highlighted the challenge of user-specific paths and jpackage’s inability to use environment variables. Runtime placeholders resolve this by expanding at launch to the correct user paths, as supported by Oracle’s jpackage documentation.
- @overheadhunter noted the lack of a `$APPDIR`-equivalent for user home. The placeholders (`@{userhome}`, `@{localappdata}`) serve this purpose, matching the existing script structure.

### Testing
- Built the app with `mvn clean install`.
- Verified that `-XX:ErrorFile` appears in the launcher config file ( with unexpanded placeholders ( `@{userhome}/...`).
- 
<img width="951" height="174" alt="build" src="https://github.com/user-attachments/assets/c050c56e-3c6f-4099-9cf2-0949e769b2a9" />

-wrote a Java class that used Unsafe to trigger a JVM crash, ran it with the same `-XX:ErrorFile ` option i added to the build script, and confirmed that the crash log was created in the expected directory.

<img width="960" height="342" alt="crash_linux" src="https://github.com/user-attachments/assets/ac119ac4-25eb-4d99-ae44-84880c50c93c" />

- Did not simulate JVM crashes on Cryptomator, as this requires complex setup. Relied instead on Oracle JVM documentation for `-XX:ErrorFile` behavior and consistency with existing placeholder usage in the scripts. Open to suggestions for safe crash testing methods.

@infeo @overheadhunter Please review and provide any feedback or suggestions.