### PR TITLE
Add Windows MSI installer option to disable update checks via DISABLEUPDATECHECK property

### DIFF
--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -165,7 +165,7 @@ jobs:
           --java-options "-Dcryptomator.integrationsWin.autoStartShellLinkName=\"Cryptomator\""
           --java-options "-Dcryptomator.integrationsWin.keychainPaths=\"@{appdata}/Cryptomator/keychain.json;@{userhome}/AppData/Roaming/Cryptomator/keychain.json\""
           --java-options "-Dcryptomator.integrationsWin.windowsHelloKeychainPaths=\"@{appdata}/Cryptomator/windowsHelloKeychain.json\""
-          --java-options "-Djavafx.verbose=${{ inputs.isDebug }}"
+          --java-options "-Dcryptomator.disableUpdateCheck=false"
           --resource-dir dist/win/resources
           --icon dist/win/resources/Cryptomator.ico
           --add-launcher "Cryptomator (Debug)=dist/win/debug-launcher.properties"

--- a/dist/win/build.ps1
+++ b/dist/win/build.ps1
@@ -165,6 +165,7 @@ $javaOptions = @(
 "--java-options", "-Dcryptomator.integrationsWin.windowsHelloKeychainPaths=`"@{appdata}/$AppName/windowsHelloKeychain.json`""
 "--java-options", "-Dcryptomator.showTrayIcon=true"
 "--java-options", "-Dcryptomator.buildNumber=`"msi-$revisionNo`""
+"--java-options", "-Dcryptomator.disableUpdateCheck=false"
 )
 
 

--- a/dist/win/bundle/bundleWithWinfsp.wxs
+++ b/dist/win/bundle/bundleWithWinfsp.wxs
@@ -27,6 +27,8 @@
             <ns0:Payload Name="Cryptobot.ico" SourceFile="bundle\resources\Cryptomator.ico"/>
         </ns0:BootstrapperApplication>
 
+        <ns0:Variable Name="DISABLEUPDATECHECK" bal:Overridable="yes" Type="string" Value="false"/>
+
         <ns0:Chain>
             <ns0:ExePackage Cache="keep" PerMachine="yes" Permanent="no" SourceFile="bundle\resources\winfsp-uninstaller.exe" DisplayName="Removing outdated WinFsp Driver" Description="Executable to remove old winfsp" DetectCondition="false" InstallCondition="(InstalledLegacyWinFspVersion &lt;&gt; v0.0.0.0) AND ((WixBundleAction = 7) OR (WixBundleAction = 5))" UninstallArguments="">
                 <ns0:CommandLine Condition="WixBundleUILevel &lt;= 3" InstallArgument="-q -l &quot;[WixBundleLog].winfsp-uninstaller.log&quot;" RepairArgument="-q" UninstallArgument="-s" />
@@ -41,7 +43,9 @@ Do you want to continue?&quot;" RepairArgument="-q" UninstallArgument="-s" />
                 <ns0:ExitCode Behavior="forceReboot" Value="4" />
                 <ns0:ExitCode Behavior="success" Value="5" />
             </ns0:ExePackage>
-            <ns0:MsiPackage SourceFile="bundle\resources\Cryptomator.msi" CacheId="cryptomator-bundle-cryptomator" Visible="no" />
+            <ns0:MsiPackage SourceFile="bundle\resources\Cryptomator.msi" CacheId="cryptomator-bundle-cryptomator" Visible="no">
+                <ns0:MsiProperty Name="DISABLEUPDATECHECK" Value="[DISABLEUPDATECHECK]"/>
+            </ns0:MsiPackage>
             <ns0:MsiPackage SourceFile="bundle\resources\winfsp.msi" CacheId="cryptomator-bundle-winfsp" Visible="yes" Permanent="yes" />
         </ns0:Chain>
     </ns0:Bundle>

--- a/dist/win/contrib/patchUpdateCheck.bat
+++ b/dist/win/contrib/patchUpdateCheck.bat
@@ -3,15 +3,19 @@
 :: This is executed as a Custom Action during MSI installation
 
 :: Get the install directory from the Custom Action property
-set "INSTALLDIR=%~1"
+set "INSTALLDIR=%~dp1"
 set "DISABLEUPDATECHECK=%~2"
 
 :: Log for debugging
 echo INSTALLDIR=%INSTALLDIR%
 echo DISABLEUPDATECHECK=%DISABLEUPDATECHECK%
 
-:: Execute the PowerShell script with bypass execution policy
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%INSTALLDIR%patchUpdateCheck.ps1" -InstallDir "%INSTALLDIR%" -DisableUpdateCheck "%DISABLEUPDATECHECK%"
+:: Execute the PowerShell script
+:: DO NOT REMOVE WHITE SPACE AFTER %INSTALLDIR%.
+:: The variable is expanded to a value ending with a slash "\", which would escape the double quote breaking the parameter parsing
+powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -File "%INSTALLDIR%patchUpdateCheck.ps1"^
+ -InstallDir "%INSTALLDIR% "^
+ -DisableUpdateCheck "%DISABLEUPDATECHECK%" 
 
 :: Return the exit code from PowerShell
 exit /b %ERRORLEVEL%

--- a/dist/win/contrib/patchUpdateCheck.bat
+++ b/dist/win/contrib/patchUpdateCheck.bat
@@ -1,23 +1,18 @@
 @echo off
 :: Batch wrapper for PowerShell script to modify Cryptomator update check settings
 :: This is executed as a Custom Action during MSI installation
+:: This file must be located in the INSTALLDIR
 
-:: Get the install directory from the Custom Action property
-set "INSTALLDIR=%~dp1"
-set "DISABLEUPDATECHECK=%~2"
+set "DISABLEUPDATECHECK=%~1"
 
 :: Log for debugging
-echo INSTALLDIR=%INSTALLDIR%
 echo DISABLEUPDATECHECK=%DISABLEUPDATECHECK%
 
-:: Normalize install directory (remove trailing slash if present)
-if "%INSTALLDIR:~-1%"=="\" set "INSTALLDIR=%INSTALLDIR:~0,-1%"
-
-
+:: Change to INSTALLDIR
+cd %~dp0
 :: Execute the PowerShell script
-powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -File "%INSTALLDIR%\patchUpdateCheck.ps1"^
- -InstallDir "%INSTALLDIR%"^
- -DisableUpdateCheck "%DISABLEUPDATECHECK%" 
+powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -File ".\patchUpdateCheck.ps1"^
+ -DisableUpdateCheck "%DISABLEUPDATECHECK%"
 
 :: Return the exit code from PowerShell
 exit /b %ERRORLEVEL%

--- a/dist/win/contrib/patchUpdateCheck.bat
+++ b/dist/win/contrib/patchUpdateCheck.bat
@@ -10,11 +10,13 @@ set "DISABLEUPDATECHECK=%~2"
 echo INSTALLDIR=%INSTALLDIR%
 echo DISABLEUPDATECHECK=%DISABLEUPDATECHECK%
 
+:: Normalize install directory (remove trailing slash if present)
+if "%INSTALLDIR:~-1%"=="\" set "INSTALLDIR=%INSTALLDIR:~0,-1%"
+
+
 :: Execute the PowerShell script
-:: DO NOT REMOVE WHITE SPACE AFTER %INSTALLDIR%.
-:: The variable is expanded to a value ending with a slash "\", which would escape the double quote breaking the parameter parsing
-powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -File "%INSTALLDIR%patchUpdateCheck.ps1"^
- -InstallDir "%INSTALLDIR% "^
+powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -File "%INSTALLDIR%\patchUpdateCheck.ps1"^
+ -InstallDir "%INSTALLDIR%"^
  -DisableUpdateCheck "%DISABLEUPDATECHECK%" 
 
 :: Return the exit code from PowerShell

--- a/dist/win/contrib/patchUpdateCheck.bat
+++ b/dist/win/contrib/patchUpdateCheck.bat
@@ -1,0 +1,17 @@
+@echo off
+:: Batch wrapper for PowerShell script to modify Cryptomator update check settings
+:: This is executed as a Custom Action during MSI installation
+
+:: Get the install directory from the Custom Action property
+set "INSTALLDIR=%~1"
+set "DISABLEUPDATECHECK=%~2"
+
+:: Log for debugging
+echo INSTALLDIR=%INSTALLDIR%
+echo DISABLEUPDATECHECK=%DISABLEUPDATECHECK%
+
+:: Execute the PowerShell script with bypass execution policy
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%INSTALLDIR%patchUpdateCheck.ps1" -InstallDir "%INSTALLDIR%" -DisableUpdateCheck "%DISABLEUPDATECHECK%"
+
+:: Return the exit code from PowerShell
+exit /b %ERRORLEVEL%

--- a/dist/win/contrib/patchUpdateCheck.ps1
+++ b/dist/win/contrib/patchUpdateCheck.ps1
@@ -1,10 +1,11 @@
 # PowerShell script to modify Cryptomator.cfg to set disableUpdateCheck property
 # This script is executed as a Custom Action during MSI installation
 # It reads the DISABLEUPDATECHECK property from the MSI and modifies the .cfg file accordingly
+# NOTE: This script only modifies the config, if the config already contains the cryptomator.disableUpdateCheck property!
 
 param(
-    [string]$InstallDir = $env:INSTALLDIR,
-    [string]$DisableUpdateCheck = $env:DISABLEUPDATECHECK
+    [Parameter(Mandatory)][string]$InstallDir,
+    [Parameter(Mandatory)][string]$DisableUpdateCheck
 )
 
 try {
@@ -12,9 +13,22 @@ try {
     Write-Host "InstallDir: $InstallDir"
     Write-Host "DisableUpdateCheck: $DisableUpdateCheck"
     
+    # Parse DisableUpdateCheck value (handle various input formats)
+    $shouldDisable = $false
+    if ($DisableUpdateCheck) {
+        $DisableUpdateCheck = $DisableUpdateCheck.Trim().ToLower()
+        $shouldDisable = ($DisableUpdateCheck -eq 'true') -or ($DisableUpdateCheck -eq '1') -or ($DisableUpdateCheck -eq 'yes')
+    }
+
+    Write-Host "Setting cryptomator.disableUpdateCheck to: $shouldDisable"
+    if (-not $shouldDisable) {
+        Write-Host "Disable-Update-Check property is set to 'false'. Skipping config modification, nothing to do."
+        exit 0
+    }
+
     # Determine the .cfg file path
-    $cfgFile = Join-Path $InstallDir "app\Cryptomator.cfg"
-    
+    $cfgFile = Join-Path $($InstallDir.Trim()) "app\Cryptomator.cfg"
+
     if (-not (Test-Path $cfgFile)) {
         Write-Error "Configuration file not found at: $cfgFile"
         exit 1
@@ -22,44 +36,15 @@ try {
     
     # Read the current configuration
     $content = Get-Content $cfgFile -Raw
-    
-    # Parse DisableUpdateCheck value (handle various input formats)
-    $shouldDisable = $false
-    if ($DisableUpdateCheck) {
-        $DisableUpdateCheck = $DisableUpdateCheck.Trim().ToLower()
-        $shouldDisable = $DisableUpdateCheck -eq "true" -or $DisableUpdateCheck -eq "1" -or $DisableUpdateCheck -eq "yes"
-    }
-    
-    Write-Host "Setting cryptomator.disableUpdateCheck to: $shouldDisable"
-    
-    # Check if [JavaOptions] section exists
-    if ($content -notmatch '\[JavaOptions\]') {
-        Write-Error "[JavaOptions] section not found in configuration file"
-        exit 1
-    }
-    
-    # Remove any existing disableUpdateCheck option to avoid duplicates
-    $content = $content -replace 'java-options=-Dcryptomator\.disableUpdateCheck=(true|false)\r?\n', ''
-    
+       
     # Add the new option based on the property value
-    # We need to add it after [JavaOptions] but before [ArgOptions] or end of file
-    if ($shouldDisable) {
-        # Find the position to insert the new option
-        if ($content -match '(\[JavaOptions\])([\s\S]*?)(\[ArgOptions\]|\z)') {
-            $beforeSection = $matches[1]
-            $javaOptionsContent = $matches[2]
-            $afterSection = $matches[3]
-            
-            # Add our option at the end of JavaOptions section
-            $newOption = "java-options=-Dcryptomator.disableUpdateCheck=true`r`n"
-            $content = $beforeSection + $javaOptionsContent + $newOption + $afterSection
-        }
-    }
-    # If shouldDisable is false, we don't need to add anything (default behavior)
-    
+    # Use regular expressions substitutions to replace the property
+    $searchExpression = '(?<Prefix>java-options=-Dcryptomator\.disableUpdateCheck)=false'
+    $replacementExpression = '${Prefix}=true'
+    $content = $content -replace $searchExpression,$replacementExpression
+
     # Write the modified content back
     Set-Content -Path $cfgFile -Value $content -NoNewline
-    
     Write-Host "Successfully updated $cfgFile"
     exit 0
 }

--- a/dist/win/contrib/patchUpdateCheck.ps1
+++ b/dist/win/contrib/patchUpdateCheck.ps1
@@ -1,18 +1,16 @@
 # PowerShell script to modify Cryptomator.cfg to set disableUpdateCheck property
 # This script is executed as a Custom Action during MSI installation
-# It reads the DISABLEUPDATECHECK property from the MSI and modifies the .cfg file accordingly
-# NOTE: This script only modifies the config, if the config already contains the cryptomator.disableUpdateCheck property!
+# If the DisableUpdateCheck parameter is set to true, it disables the update check in Cryptomator by modifying the Cryptomator.cfg file.
+# NOTE: This file must be located in the same directory as set in the MSI property INSTALLDIR
 
 param(
-    [Parameter(Mandatory)][string]$InstallDir,
     [Parameter(Mandatory)][string]$DisableUpdateCheck
 )
 
 try {
     # Log parameters for debugging (visible in MSI verbose logs)
-    Write-Host "InstallDir: $InstallDir"
     Write-Host "DisableUpdateCheck: $DisableUpdateCheck"
-    
+
     # Parse DisableUpdateCheck value (handle various input formats)
     $shouldDisable = $false
     if ($DisableUpdateCheck) {
@@ -22,21 +20,21 @@ try {
 
     Write-Host "Setting cryptomator.disableUpdateCheck to: $shouldDisable"
     if (-not $shouldDisable) {
-        Write-Host "Disable-Update-Check property is set to 'false'. Skipping config modification, nothing to do."
+        Write-Host "Disable-Update-Check property is by default 'false'. Skipping config modification."
         exit 0
     }
 
     # Determine the .cfg file path
-    $cfgFile = Join-Path $($InstallDir.Trim()) "app\Cryptomator.cfg"
+    $cfgFile = Join-Path $($PSScriptRoot) "app\Cryptomator.cfg"
 
     if (-not (Test-Path $cfgFile)) {
         Write-Error "Configuration file not found at: $cfgFile"
         exit 1
     }
-    
+
     # Read the current configuration
     $content = Get-Content $cfgFile -Raw
-       
+
     # Add the new option based on the property value
     # Use regular expressions substitutions to replace the property
     $searchExpression = '(?<Prefix>java-options=-Dcryptomator\.disableUpdateCheck)=false'

--- a/dist/win/contrib/patchUpdateCheck.ps1
+++ b/dist/win/contrib/patchUpdateCheck.ps1
@@ -1,0 +1,69 @@
+# PowerShell script to modify Cryptomator.cfg to set disableUpdateCheck property
+# This script is executed as a Custom Action during MSI installation
+# It reads the DISABLEUPDATECHECK property from the MSI and modifies the .cfg file accordingly
+
+param(
+    [string]$InstallDir = $env:INSTALLDIR,
+    [string]$DisableUpdateCheck = $env:DISABLEUPDATECHECK
+)
+
+try {
+    # Log parameters for debugging (visible in MSI verbose logs)
+    Write-Host "InstallDir: $InstallDir"
+    Write-Host "DisableUpdateCheck: $DisableUpdateCheck"
+    
+    # Determine the .cfg file path
+    $cfgFile = Join-Path $InstallDir "app\Cryptomator.cfg"
+    
+    if (-not (Test-Path $cfgFile)) {
+        Write-Error "Configuration file not found at: $cfgFile"
+        exit 1
+    }
+    
+    # Read the current configuration
+    $content = Get-Content $cfgFile -Raw
+    
+    # Parse DisableUpdateCheck value (handle various input formats)
+    $shouldDisable = $false
+    if ($DisableUpdateCheck) {
+        $DisableUpdateCheck = $DisableUpdateCheck.Trim().ToLower()
+        $shouldDisable = $DisableUpdateCheck -eq "true" -or $DisableUpdateCheck -eq "1" -or $DisableUpdateCheck -eq "yes"
+    }
+    
+    Write-Host "Setting cryptomator.disableUpdateCheck to: $shouldDisable"
+    
+    # Check if [JavaOptions] section exists
+    if ($content -notmatch '\[JavaOptions\]') {
+        Write-Error "[JavaOptions] section not found in configuration file"
+        exit 1
+    }
+    
+    # Remove any existing disableUpdateCheck option to avoid duplicates
+    $content = $content -replace 'java-options=-Dcryptomator\.disableUpdateCheck=(true|false)\r?\n', ''
+    
+    # Add the new option based on the property value
+    # We need to add it after [JavaOptions] but before [ArgOptions] or end of file
+    if ($shouldDisable) {
+        # Find the position to insert the new option
+        if ($content -match '(\[JavaOptions\])([\s\S]*?)(\[ArgOptions\]|\z)') {
+            $beforeSection = $matches[1]
+            $javaOptionsContent = $matches[2]
+            $afterSection = $matches[3]
+            
+            # Add our option at the end of JavaOptions section
+            $newOption = "java-options=-Dcryptomator.disableUpdateCheck=true`r`n"
+            $content = $beforeSection + $javaOptionsContent + $newOption + $afterSection
+        }
+    }
+    # If shouldDisable is false, we don't need to add anything (default behavior)
+    
+    # Write the modified content back
+    Set-Content -Path $cfgFile -Value $content -NoNewline
+    
+    Write-Host "Successfully updated $cfgFile"
+    exit 0
+}
+catch {
+    Write-Error "Error modifying configuration file: $_"
+    exit 1
+}

--- a/dist/win/resources/main.wxs
+++ b/dist/win/resources/main.wxs
@@ -126,16 +126,16 @@
 
     <ns0:Property Id="WixQuietExec64CmdTimeout" Value="20" />
     <!-- Note for custom actions: Immediate CAs run BEFORE the files are installed, hence if you depend on installed files, the CAs must be deferred.-->
-    
+
     <!-- Property for controlling update check behavior (can be set via command line) -->
     <ns0:Property Id="DISABLEUPDATECHECK" Secure="yes" />
-    
+
     <!-- WebDAV patches -->
     <ns0:SetProperty Id="PatchWebDAV" Value="&quot;[INSTALLDIR]patchWebDAV.bat&quot;" Sequence="execute" Before="PatchWebDAV" />
     <ns0:CustomAction Id="PatchWebDAV" BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)" DllEntry="WixQuietExec" Execute="deferred" Return="ignore" Impersonate="no"/>
-    
+
     <!-- Update check configuration -->
-    <ns0:SetProperty Id="PatchUpdateCheck" Value="&quot;[INSTALLDIR]patchUpdateCheck.bat&quot; &quot;[INSTALLDIR]&quot; &quot;[DISABLEUPDATECHECK]&quot;" Sequence="execute" Before="PatchUpdateCheck" />
+    <ns0:SetProperty Id="PatchUpdateCheck" Value="&quot;[INSTALLDIR]patchUpdateCheck.bat&quot; &quot;[DISABLEUPDATECHECK]&quot;" Sequence="execute" Before="PatchUpdateCheck" />
     <ns0:CustomAction Id="PatchUpdateCheck" BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)" DllEntry="WixQuietExec64" Execute="deferred" Return="ignore" Impersonate="no"/>
 
     <!-- Running App detection and exit -->

--- a/dist/win/resources/main.wxs
+++ b/dist/win/resources/main.wxs
@@ -126,9 +126,17 @@
 
     <ns0:Property Id="WixQuietExec64CmdTimeout" Value="20" />
     <!-- Note for custom actions: Immediate CAs run BEFORE the files are installed, hence if you depend on installed files, the CAs must be deferred.-->
+    
+    <!-- Property for controlling update check behavior (can be set via command line) -->
+    <ns0:Property Id="DISABLEUPDATECHECK" Secure="yes" />
+    
     <!-- WebDAV patches -->
     <ns0:SetProperty Id="PatchWebDAV" Value="&quot;[INSTALLDIR]patchWebDAV.bat&quot;" Sequence="execute" Before="PatchWebDAV" />
     <ns0:CustomAction Id="PatchWebDAV" BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)" DllEntry="WixQuietExec" Execute="deferred" Return="ignore" Impersonate="no"/>
+    
+    <!-- Update check configuration -->
+    <ns0:SetProperty Id="PatchUpdateCheck" Value="&quot;[INSTALLDIR]patchUpdateCheck.bat&quot; &quot;[INSTALLDIR]&quot; &quot;[DISABLEUPDATECHECK]&quot;" Sequence="execute" Before="PatchUpdateCheck" />
+    <ns0:CustomAction Id="PatchUpdateCheck" BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)" DllEntry="WixQuietExec64" Execute="deferred" Return="ignore" Impersonate="no"/>
 
     <!-- Running App detection and exit -->
     <ns0:Property Id="FOUNDRUNNINGAPP" Admin="yes"/>
@@ -181,6 +189,8 @@
       <!-- Skip action on uninstall -->
       <!-- TODO: don't skip action, but remove cryptomator alias from hosts file -->
       <ns0:Custom Action="PatchWebDAV" After="InstallFiles" Condition="NOT (Installed AND (NOT REINSTALL) AND (NOT UPGRADINGPRODUCTCODE) AND REMOVE)"/>
+      <!-- Configure update check setting if property is provided -->
+      <ns0:Custom Action="PatchUpdateCheck" After="PatchWebDAV" Condition="DISABLEUPDATECHECK AND NOT (Installed AND (NOT REINSTALL) AND (NOT UPGRADINGPRODUCTCODE) AND REMOVE)"/>
     </ns0:InstallExecuteSequence>
 
     <ns0:InstallUISequence>


### PR DESCRIPTION
I'd like to disclose that I have used an AI tool to generate this implementation. Since I'm a macOS user, I wasn't able to test it.

My intention of this implementation is allowing the Windows MSI installer to accept a command-line argument (`DISABLEUPDATECHECK`) that configures whether automatic update checks are disabled. This is particularly useful for enterprise deployments where administrators want to control update behavior centrally. And I guess it's also useful for package managers like Chocolatey.

## Usage

### Command Line Installation

#### Disable Update Checks (Silent Install)
```powershell
msiexec /i Cryptomator-x.y.z.msi DISABLEUPDATECHECK=true /qn
```

#### Disable Update Checks (With UI)
```powershell
msiexec /i Cryptomator-x.y.z.msi DISABLEUPDATECHECK=true
```

#### Default Installation (Update Checks Enabled)
```powershell
msiexec /i Cryptomator-x.y.z.msi
```

### Property Values

The `DISABLEUPDATECHECK` property accepts the following values:
- **Truthy values** (disable updates): `true`, `1`, `yes` (case-insensitive)
- **Falsy values** (enable updates): `false`, `0`, `no`, or omitted entirely
- **Default**: If not specified, update checks remain enabled