### PR TITLE
Fix : Shortcut doesn’t close SimpleDialogs

### DIFF
--- a/src/main/java/org/cryptomator/ui/dialogs/Dialogs.java
+++ b/src/main/java/org/cryptomator/ui/dialogs/Dialogs.java
@@ -2,6 +2,7 @@ package org.cryptomator.ui.dialogs;
 
 import org.cryptomator.common.settings.Settings;
 import org.cryptomator.common.vaults.Vault;
+import org.cryptomator.ui.common.DefaultSceneFactory;
 import org.cryptomator.ui.common.StageFactory;
 import org.cryptomator.ui.controls.FontAwesome5Icon;
 import org.cryptomator.ui.fxapp.FxApplicationScoped;
@@ -19,19 +20,21 @@ public class Dialogs {
 
 	private final ResourceBundle resourceBundle;
 	private final StageFactory stageFactory;
+	private final DefaultSceneFactory sceneFactory;
 
 	private static final String BUTTON_KEY_CLOSE = "generic.button.close";
 
 	@Inject
-	public Dialogs(ResourceBundle resourceBundle, StageFactory stageFactory) {
+	public Dialogs(ResourceBundle resourceBundle, StageFactory stageFactory, DefaultSceneFactory sceneFactory) {
 		this.resourceBundle = resourceBundle;
 		this.stageFactory = stageFactory;
+		this.sceneFactory = sceneFactory;
 	}
 
 	private static final Logger LOG = LoggerFactory.getLogger(Dialogs.class);
 
 	private SimpleDialog.Builder createDialogBuilder() {
-		return new SimpleDialog.Builder(resourceBundle, stageFactory);
+		return new SimpleDialog.Builder(resourceBundle, stageFactory, sceneFactory);
 	}
 
 	public SimpleDialog.Builder prepareRemoveVaultDialog(Stage window, Vault vault, ObservableList<Vault> vaults) {

--- a/src/main/java/org/cryptomator/ui/dialogs/SimpleDialog.java
+++ b/src/main/java/org/cryptomator/ui/dialogs/SimpleDialog.java
@@ -1,5 +1,6 @@
 package org.cryptomator.ui.dialogs;
 
+import org.cryptomator.ui.common.DefaultSceneFactory;
 import org.cryptomator.ui.common.FxmlFile;
 import org.cryptomator.ui.common.FxmlLoaderFactory;
 import org.cryptomator.ui.common.StageFactory;
@@ -36,9 +37,9 @@ public class SimpleDialog {
 						builder.cancelButtonKey != null ? resolveText(builder.cancelButtonKey, null) : null, //
 						() -> builder.okAction.accept(dialogStage), //
 						() -> builder.cancelAction.accept(dialogStage)), //
-				Scene::new, builder.resourceBundle);
+				builder.sceneFactory, builder.resourceBundle);
 
-		dialogStage.setScene(new Scene(loaderFactory.load(FxmlFile.SIMPLE_DIALOG.getRessourcePathString()).getRoot()));
+		dialogStage.setScene(loaderFactory.createScene(FxmlFile.SIMPLE_DIALOG));
 	}
 
 	public void showAndWait() {
@@ -62,6 +63,7 @@ public class SimpleDialog {
 		private Stage owner;
 		private final ResourceBundle resourceBundle;
 		private final StageFactory stageFactory;
+		private final DefaultSceneFactory sceneFactory;
 		private String titleKey;
 		private String[] titleArgs;
 		private String messageKey;
@@ -73,9 +75,10 @@ public class SimpleDialog {
 		private Consumer<Stage> okAction = Stage::close;
 		private Consumer<Stage> cancelAction = Stage::close;
 
-		public Builder(ResourceBundle resourceBundle, StageFactory stageFactory) {
+		public Builder(ResourceBundle resourceBundle, StageFactory stageFactory, DefaultSceneFactory sceneFactory) {
 			this.resourceBundle = resourceBundle;
 			this.stageFactory = stageFactory;
+			this.sceneFactory = sceneFactory;
 		}
 
 		public Builder setOwner(Stage owner) {


### PR DESCRIPTION
# Fix : Shortcut doesn’t close SimpleDialogs
This PR is going to fix the [issue](https://github.com/cryptomator/cryptomator/issues/4017) - Shortcut doesn’t close SimpleDialogs
I have tested it in my MBP, please review it and let me know if there is any problem.

Also, this is my first PR submmited in Github. 
