### PR TITLE
Feature: Sign files with Azure trusted signing

### DIFF
--- a/.github/actions/win-sign-action/action.yml
+++ b/.github/actions/win-sign-action/action.yml
@@ -48,7 +48,7 @@ runs:
         echo "client-secret=${{ inputs.client-secret }}" >> "$GITHUB_OUTPUT"
       shell: bash
     - name: Sign DLLs with Azure Trusted Signing
-      uses: azure/trusted-signing-action@fc390cf8ed0f14e248a542af1d838388a47c7a7c #  v0.5.10
+      uses: azure/trusted-signing-action@fc390cf8ed0f14e248a542af1d838388a47c7a7c # v0.5.10
       with:
         files-folder: ${{ inputs.base-dir }}
         files-folder-filter: ${{ inputs.file-extensions }}

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -27,8 +27,6 @@ env:
   WINFSP_MSI: 'https://github.com/winfsp/winfsp/releases/download/v2.1/winfsp-2.1.25156.msi'
   WINFSP_MSI_HASH: '073a70e00f77423e34bed98b86e600def93393ba5822204fac57a29324db9f7a'
   WINFSP_UNINSTALLER: 'https://github.com/cryptomator/winfsp-uninstaller/releases/latest/download/winfsp-uninstaller.exe'
-  AZURE_TRUSTED_SIGNING_ACCOUNT: 'skymatic'
-  AZURE_CERT_PROFILE: 'SkymaticProduction'
 
 defaults:
   run:


### PR DESCRIPTION
Closes #3994.

This PR refactors signing again to use [Azure Trusted Signing](https://learn.microsoft.com/en-us/azure/trusted-signing/overview).

The files are signed via the [azure/trusted-signing-action](https://github.com/Azure/trusted-signing-action). Actalis code signing is kept as backup and to increase cert reputation.

The actual signing is moved into its own repo-private action to dedup code. (`./.github/actions/win-sign-action`).

The MSI is only signed via Azure Trusted signing, because MSI's don't support multiple signatures.