### PR TITLE
Move recovery I/O to background thread

### DIFF
--- a/src/main/java/org/cryptomator/ui/recoverykey/RecoveryKeyCreationController.java
+++ b/src/main/java/org/cryptomator/ui/recoverykey/RecoveryKeyCreationController.java
@@ -138,7 +138,7 @@ public class RecoveryKeyCreationController implements FxController {
 
 	@FXML
 	public void restoreWithPasswordAsync() {
-		Task<Void> task = createTask(this::restoreWithPassword);
+		Task<Void> task = RecoveryKeyTasks.createTask(this::restoreWithPassword);
 
 		task.setOnScheduled(_ -> {
 			LOG.debug("Restoring vault configuration with password for {}.", vault.getDisplayablePath());
@@ -194,21 +194,6 @@ public class RecoveryKeyCreationController implements FxController {
 	@FXML
 	public void close() {
 		window.close();
-	}
-
-	@FunctionalInterface
-	private interface TaskAction {
-		void run() throws Exception;
-	}
-
-	private Task<Void> createTask(TaskAction action) {
-		return new Task<Void>() {
-			@Override
-			protected Void call() throws Exception {
-				action.run();
-				return null;
-			}
-		};
 	}
 
 	private class RecoveryKeyCreationTask extends Task<String> {

--- a/src/main/java/org/cryptomator/ui/recoverykey/RecoveryKeyResetPasswordController.java
+++ b/src/main/java/org/cryptomator/ui/recoverykey/RecoveryKeyResetPasswordController.java
@@ -125,7 +125,7 @@ public class RecoveryKeyResetPasswordController implements FxController {
 
 	@FXML
 	public void restorePasswordAsync() {
-		Task<Void> task = createTask(this::restorePassword);
+		Task<Void> task = RecoveryKeyTasks.createTask(this::restorePassword);
 
 		task.setOnScheduled(_ -> {
 			LOG.debug("Restoring vault configuration for {}.", vault.getDisplayablePath());
@@ -194,21 +194,6 @@ public class RecoveryKeyResetPasswordController implements FxController {
 		});
 
 		executor.submit(task);
-	}
-
-	@FunctionalInterface
-	private interface TaskAction {
-		void run() throws Exception;
-	}
-
-	private Task<Void> createTask(TaskAction action) {
-		return new Task<Void>() {
-			@Override
-			protected Void call() throws Exception {
-				action.run();
-				return null;
-			}
-		};
 	}
 
 	private class ResetPasswordTask extends Task<Void> {

--- a/src/main/java/org/cryptomator/ui/recoverykey/RecoveryKeyTasks.java
+++ b/src/main/java/org/cryptomator/ui/recoverykey/RecoveryKeyTasks.java
@@ -1,0 +1,25 @@
+package org.cryptomator.ui.recoverykey;
+
+import javafx.concurrent.Task;
+
+final class RecoveryKeyTasks {
+
+	private RecoveryKeyTasks() {
+	}
+
+	@FunctionalInterface
+	interface TaskAction {
+		void run() throws Exception;
+	}
+
+	static Task<Void> createTask(TaskAction action) {
+		return new Task<Void>() {
+			@Override
+			protected Void call() throws Exception {
+				action.run();
+				return null;
+			}
+		};
+	}
+
+}


### PR DESCRIPTION
Recovery controllers now run heavy I/O operations in a background thread instead of the JavaFX Application Thread. This prevents UI freezes during recovery.

Changes:
- RecoveryKeyResetPasswordController.restorePassword() now uses RestorePasswordTask
- RecoveryKeyCreationController.restoreWithPassword() now uses RestoreWithPasswordTask

Both follow the existing pattern used by resetPassword() and createRecoveryKey().

Fixes #4104  