### PR TITLE
Refactor Recovery Key Logic into Common

### DIFF
--- a/src/main/java/org/cryptomator/common/recovery/MasterkeyService.java
+++ b/src/main/java/org/cryptomator/common/recovery/MasterkeyService.java
@@ -6,7 +6,6 @@ import org.cryptomator.cryptolib.api.Cryptor;
 import org.cryptomator.cryptolib.api.CryptorProvider;
 import org.cryptomator.cryptolib.api.Masterkey;
 import org.cryptomator.cryptolib.common.MasterkeyFileAccess;
-import org.cryptomator.ui.recoverykey.RecoveryKeyFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/cryptomator/common/recovery/RecoveryKeyFactory.java
+++ b/src/main/java/org/cryptomator/common/recovery/RecoveryKeyFactory.java
@@ -1,4 +1,4 @@
-package org.cryptomator.ui.recoverykey;
+package org.cryptomator.common.recovery;
 
 import com.google.common.base.Preconditions;
 import com.google.common.hash.Hashing;

--- a/src/main/java/org/cryptomator/common/recovery/WordEncoder.java
+++ b/src/main/java/org/cryptomator/common/recovery/WordEncoder.java
@@ -1,4 +1,4 @@
-package org.cryptomator.ui.recoverykey;
+package org.cryptomator.common.recovery;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;

--- a/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultPasswordController.java
+++ b/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultPasswordController.java
@@ -16,7 +16,7 @@ import org.cryptomator.ui.common.FxmlFile;
 import org.cryptomator.ui.common.FxmlScene;
 import org.cryptomator.ui.common.Tasks;
 import org.cryptomator.ui.fxapp.FxApplicationWindows;
-import org.cryptomator.ui.recoverykey.RecoveryKeyFactory;
+import org.cryptomator.common.recovery.RecoveryKeyFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/cryptomator/ui/convertvault/ConvertVaultModule.java
+++ b/src/main/java/org/cryptomator/ui/convertvault/ConvertVaultModule.java
@@ -17,7 +17,7 @@ import org.cryptomator.ui.common.FxmlFile;
 import org.cryptomator.ui.common.FxmlLoaderFactory;
 import org.cryptomator.ui.common.FxmlScene;
 import org.cryptomator.ui.common.StageFactory;
-import org.cryptomator.ui.recoverykey.RecoveryKeyFactory;
+import org.cryptomator.common.recovery.RecoveryKeyFactory;
 import org.cryptomator.ui.recoverykey.RecoveryKeyValidateController;
 
 import javax.inject.Named;

--- a/src/main/java/org/cryptomator/ui/convertvault/HubToPasswordConvertController.java
+++ b/src/main/java/org/cryptomator/ui/convertvault/HubToPasswordConvertController.java
@@ -16,7 +16,7 @@ import org.cryptomator.ui.common.FxmlFile;
 import org.cryptomator.ui.common.FxmlScene;
 import org.cryptomator.ui.fxapp.FxApplicationWindows;
 import org.cryptomator.ui.keyloading.masterkeyfile.MasterkeyFileLoadingStrategy;
-import org.cryptomator.ui.recoverykey.RecoveryKeyFactory;
+import org.cryptomator.common.recovery.RecoveryKeyFactory;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/cryptomator/ui/recoverykey/RecoveryKeyCreationController.java
+++ b/src/main/java/org/cryptomator/ui/recoverykey/RecoveryKeyCreationController.java
@@ -2,6 +2,7 @@ package org.cryptomator.ui.recoverykey;
 
 import dagger.Lazy;
 import org.cryptomator.common.recovery.CryptoFsInitializer;
+import org.cryptomator.common.recovery.RecoveryKeyFactory;
 import org.cryptomator.common.recovery.MasterkeyService;
 import org.cryptomator.common.recovery.RecoveryActionType;
 import org.cryptomator.common.recovery.RecoveryDirectory;

--- a/src/main/java/org/cryptomator/ui/recoverykey/RecoveryKeyModule.java
+++ b/src/main/java/org/cryptomator/ui/recoverykey/RecoveryKeyModule.java
@@ -6,6 +6,7 @@ import dagger.Provides;
 import dagger.multibindings.IntoMap;
 import org.cryptomator.common.Nullable;
 import org.cryptomator.common.recovery.RecoveryActionType;
+import org.cryptomator.common.recovery.RecoveryKeyFactory;
 import org.cryptomator.common.vaults.Vault;
 import org.cryptomator.cryptofs.VaultConfig;
 import org.cryptomator.cryptolib.api.CryptorProvider;

--- a/src/main/java/org/cryptomator/ui/recoverykey/RecoveryKeyResetPasswordController.java
+++ b/src/main/java/org/cryptomator/ui/recoverykey/RecoveryKeyResetPasswordController.java
@@ -2,6 +2,7 @@ package org.cryptomator.ui.recoverykey;
 
 import dagger.Lazy;
 import org.cryptomator.common.recovery.CryptoFsInitializer;
+import org.cryptomator.common.recovery.RecoveryKeyFactory;
 import org.cryptomator.common.recovery.MasterkeyService;
 import org.cryptomator.common.recovery.RecoveryActionType;
 import org.cryptomator.common.recovery.RecoveryDirectory;

--- a/src/main/java/org/cryptomator/ui/recoverykey/RecoveryKeyValidateController.java
+++ b/src/main/java/org/cryptomator/ui/recoverykey/RecoveryKeyValidateController.java
@@ -3,6 +3,7 @@ package org.cryptomator.ui.recoverykey;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Strings;
 import org.cryptomator.common.Nullable;
+import org.cryptomator.common.recovery.RecoveryKeyFactory;
 import org.cryptomator.common.ObservableUtil;
 import org.cryptomator.common.recovery.MasterkeyService;
 import org.cryptomator.common.recovery.RecoveryActionType;

--- a/src/test/java/org/cryptomator/common/recovery/RecoveryKeyFactoryTest.java
+++ b/src/test/java/org/cryptomator/common/recovery/RecoveryKeyFactoryTest.java
@@ -1,4 +1,4 @@
-package org.cryptomator.ui.recoverykey;
+package org.cryptomator.common.recovery;
 
 import com.google.common.base.Splitter;
 import org.cryptomator.cryptolib.api.CryptoException;

--- a/src/test/java/org/cryptomator/common/recovery/WordEncoderTest.java
+++ b/src/test/java/org/cryptomator/common/recovery/WordEncoderTest.java
@@ -1,4 +1,4 @@
-package org.cryptomator.ui.recoverykey;
+package org.cryptomator.common.recovery;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;

--- a/src/test/java/org/cryptomator/ui/convertvault/HubToPasswordConvertControllerTest.java
+++ b/src/test/java/org/cryptomator/ui/convertvault/HubToPasswordConvertControllerTest.java
@@ -12,7 +12,7 @@ import org.cryptomator.cryptolib.api.MasterkeyLoadingFailedException;
 import org.cryptomator.cryptolib.common.MasterkeyFileAccess;
 import org.cryptomator.ui.changepassword.NewPasswordController;
 import org.cryptomator.ui.fxapp.FxApplicationWindows;
-import org.cryptomator.ui.recoverykey.RecoveryKeyFactory;
+import org.cryptomator.common.recovery.RecoveryKeyFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
This PR refactors the placement of recovery key–related utilities to improve layer separation.

### Summary
- Moved RecoveryKeyFactory and WordEncoder (including tests) from org.cryptomator.ui.recoverykey to org.cryptomator.common.recovery
- Updated imports in affected UI and conversion modules
- Fixed an architectural violation where MasterkeyService (common layer) depended on UI-layer classes

Related to: #4118 