### PR TITLE
Recovery Key Validation – Enable wrapped labels and replace filler text to stabilize layout

### DIFF
--- a/src/main/resources/fxml/recoverykey_validate.fxml
+++ b/src/main/resources/fxml/recoverykey_validate.fxml
@@ -17,22 +17,22 @@
 
 		<TextArea wrapText="true" prefRowCount="4" fx:id="textarea" textFormatter="${controller.recoveryKeyTextFormatter}" onKeyPressed="#onKeyPressed"/>
 		<VBox>
-			<Label text="Just some Filler" visible="false" managed="${textarea.text.empty}" graphicTextGap="6">
+			<Label text="%recoveryKey.recover.wrongKey" visible="false" managed="${textarea.text.empty}" graphicTextGap="6" wrapText="true" >
 				<graphic>
 					<FontAwesome5IconView glyph="ANCHOR"/>
 				</graphic>
 			</Label>
-			<Label text="%recoveryKey.recover.correctKey" graphicTextGap="6" visible="${(!textarea.text.empty) &amp;&amp; controller.recoveryKeyCorrect}" managed="${(!textarea.text.empty) &amp;&amp; controller.recoveryKeyCorrect}">
+			<Label text="%recoveryKey.recover.correctKey" graphicTextGap="6" wrapText="true" visible="${(!textarea.text.empty) &amp;&amp; controller.recoveryKeyCorrect}" managed="${(!textarea.text.empty) &amp;&amp; controller.recoveryKeyCorrect}">
 				<graphic>
 					<FontAwesome5IconView glyph="CHECK"/>
 				</graphic>
 			</Label>
-			<Label text="%recoveryKey.recover.wrongKey" graphicTextGap="6"  visible="${(!textarea.text.empty) &amp;&amp; controller.recoveryKeyWrong}" managed="${(!textarea.text.empty) &amp;&amp; controller.recoveryKeyWrong}">
+			<Label text="%recoveryKey.recover.wrongKey" graphicTextGap="6" wrapText="true" visible="${(!textarea.text.empty) &amp;&amp; controller.recoveryKeyWrong}" managed="${(!textarea.text.empty) &amp;&amp; controller.recoveryKeyWrong}">
 				<graphic>
 					<FontAwesome5IconView glyph="TIMES" styleClass="glyph-icon-red"/>
 				</graphic>
 			</Label>
-			<Label text="%recoveryKey.recover.invalidKey" graphicTextGap="6"  visible="${(!textarea.text.empty) &amp;&amp; controller.recoveryKeyInvalid}" managed="${(!textarea.text.empty) &amp;&amp; controller.recoveryKeyInvalid}">
+			<Label text="%recoveryKey.recover.invalidKey" graphicTextGap="6" wrapText="true" visible="${(!textarea.text.empty) &amp;&amp; controller.recoveryKeyInvalid}" managed="${(!textarea.text.empty) &amp;&amp; controller.recoveryKeyInvalid}">
 				<graphic>
 					<FontAwesome5IconView glyph="TIMES" styleClass="glyph-icon-red"/>
 				</graphic>


### PR DESCRIPTION
This PR improves the layout behaviour of the Recovery Key Validation window.

All status labels now use wrapText="true" to ensure long localised texts reliably wrap to the next line instead of being truncated or expanding the dialog unexpectedly.

In addition, the temporary filler text "Just some Filler" was replaced with %recoveryKey.recover.wrongKey, which represents the longest possible validation message.
This ensures that the maximum required label height is already reserved when the window is loaded, even before a recovery key is entered, preventing layout jumps during validation state changes.

No functional behaviour was changed; this is a purely UI/layout improvement.

Before:
<img width="512" height="382" alt="Bildschirmfoto 2026-01-30 um 14 16 16" src="https://github.com/user-attachments/assets/c4bfd52b-db21-4385-bbee-738f4f9f9016" />

After:
<img width="512" height="399" alt="Bildschirmfoto 2026-01-30 um 14 17 07" src="https://github.com/user-attachments/assets/43349d8f-1c71-40a3-a0ad-cf2db61a64c3" />
