### PR TITLE
Disable loading of user defined config for MSI

### DIFF
--- a/dist/win/contrib/disableUserConfig.bat
+++ b/dist/win/contrib/disableUserConfig.bat
@@ -1,0 +1,12 @@
+@echo off
+:: Batch wrapper for PowerShell script to disable user configuration in Cryptomator
+:: This is executed as a Custom Action during MSI installation
+:: This file must be located in the INSTALLDIR
+
+:: Change to INSTALLDIR
+cd %~dp0
+:: Execute the PowerShell script
+powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -File ".\disableUserConfig.ps1"
+
+:: Return the exit code from PowerShell
+exit /b %ERRORLEVEL%

--- a/dist/win/contrib/disableUserConfig.ps1
+++ b/dist/win/contrib/disableUserConfig.ps1
@@ -1,0 +1,24 @@
+# PowerShell script to disable user configuration
+# This script is executed as a Custom Action during MSI installation
+# It deletes the file .package, effectively disabling user specific jpackage configuration.
+# NOTE: This file must be located in the same directory as set in the MSI property INSTALLDIR
+
+try {
+
+    # Determine  file path
+    $packageFile = Join-Path $PSScriptRoot 'app\.package'
+
+    #check if file exists
+    if (Test-Path -Path $packageFile) {
+        Write-Host "Deleting file: $packageFile"
+        Remove-Item -Path $packageFile -Force -ErrorAction Stop
+    } else {
+        Write-Host "File not found: $packageFile. Skipping deletion."
+    }
+
+    exit 0
+}
+catch {
+    Write-Error "Error deleting package file: $_"
+    exit 1
+}

--- a/dist/win/resources/main.wxs
+++ b/dist/win/resources/main.wxs
@@ -132,6 +132,10 @@
     <!-- Property for controlling update check behavior (can be set via command line) -->
     <ns0:Property Id="DISABLEUPDATECHECK" Secure="yes" />
 
+    <!-- Disable user config -->
+    <ns0:SetProperty Id="DisableUserConfig" Value="&quot;[INSTALLDIR]disableUserConfig.bat&quot;" Sequence="execute" Before="DisableUserConfig" />
+    <ns0:CustomAction Id="DisableUserConfig" BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)" DllEntry="WixQuietExec" Execute="deferred" Return="ignore" Impersonate="no"/>
+
     <!-- WebDAV patches -->
     <ns0:SetProperty Id="PatchWebDAV" Value="&quot;[INSTALLDIR]patchWebDAV.bat&quot; &quot;$(var.LoopbackAlias)&quot;" Sequence="execute" Before="PatchWebDAV" />
     <ns0:CustomAction Id="PatchWebDAV" BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)" DllEntry="WixQuietExec" Execute="deferred" Return="ignore" Impersonate="no"/>
@@ -188,9 +192,10 @@
       <ns0:Custom Action="FailOnRunningApp" After="Wix4CloseApplications_$(sys.BUILDARCHSHORT)" Condition="FOUNDRUNNINGAPP" />
 
       <ns0:RemoveExistingProducts After="InstallValidate"/> <!-- Moved from CostInitialize, due to Wix4CloseApplications_* -->
+      <ns0:Custom Action="DisableUserConfig" After="InstallFiles" Condition="NOT (Installed AND (NOT REINSTALL) AND (NOT UPGRADINGPRODUCTCODE) AND REMOVE)"/>
       <!-- Skip action on uninstall -->
       <!-- TODO: don't skip action, but remove cryptomator alias from hosts file -->
-      <ns0:Custom Action="PatchWebDAV" After="InstallFiles" Condition="NOT (Installed AND (NOT REINSTALL) AND (NOT UPGRADINGPRODUCTCODE) AND REMOVE)"/>
+      <ns0:Custom Action="PatchWebDAV" After="DisableUserConfig" Condition="NOT (Installed AND (NOT REINSTALL) AND (NOT UPGRADINGPRODUCTCODE) AND REMOVE)"/>
       <!-- Configure update check setting if property is provided -->
       <ns0:Custom Action="PatchUpdateCheck" After="PatchWebDAV" Condition="DISABLEUPDATECHECK AND NOT (Installed AND (NOT REINSTALL) AND (NOT UPGRADINGPRODUCTCODE) AND REMOVE)"/>
     </ns0:InstallExecuteSequence>


### PR DESCRIPTION
This PR disables loading of a user defined start config.

## Motivation

Cryptomator is built with `jpackage`. The tool creates system specific binaries to start the JVM and the app. For the starting process, it defines a config file (`Cryptomator.cfg`), which specifies initial JVM properties (i.e. `file.encoding` or `java.net.useSystemProxies`).

Since JDK 19 and https://bugs.openjdk.org/browse/JDK-8287060 jpackage allows users to define their own, custom config. It is only considered, if the OS specific distribution (MSI, DMG, DEB, etc) is also built with jpackage. For Cryptomator, only the MSI is built with jpackage, all other distributions are custom built.

In order to ensure Cryptomator behaves consistently over all OS, the loading of custom configs should be disabled. Additionally, it increases security due to making properties like the app version read-only, prevent tampering and manipulating app state.

## Implementation

Looking into the JDK Feature PR showed, that for Windows a custom config is only considered, if the file `[INSTALLDIR]\app\.package` exists. Hence, the MSI installer is extended to delete this file at the end of the installation.

The file remove operation is implemented similar to #3118, i.e. a signed PowerShell script execution. The script will stay in the installation directory.


Note: This changes relies on undocumented behaviour and might not work in the future!
