### PR TITLE
Feature: Monthly distribution builds

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -3,6 +3,8 @@ name: Build AppImage
 on:
   release:
     types: [published]
+  schedule:
+    - cron: '0 23 20 * *'
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -1,6 +1,8 @@
 name: Build Debian Package
 
 on:
+  schedule:
+    - cron: '0 22 20 * *'
   workflow_dispatch:
     inputs:
       semver:

--- a/.github/workflows/linux-makepkg.yml
+++ b/.github/workflows/linux-makepkg.yml
@@ -3,6 +3,8 @@ name: Build Arch package
 on:
   release:
     types: [published]
+  schedule:
+    - cron: '0 21 20 * *'
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/mac-dmg-x64.yml
+++ b/.github/workflows/mac-dmg-x64.yml
@@ -251,7 +251,7 @@ jobs:
         env:
           CODESIGN_IDENTITY: ${{ secrets.MACOS_CODESIGN_IDENTITY }}
       - name: Notarize .dmg
-        if: startsWith(github.ref, 'refs/tags/') || inputs.notarize
+        if: startsWith(github.ref, 'refs/tags/') || inputs.notarize || github.event_name == 'schedule'
         uses: cocoalibs/xcode-notarization-action@5cf433d494b6fa26504b574c591f4dd120388846 # v1.0.3
         with:
           app-path: 'Cryptomator-*.dmg'

--- a/.github/workflows/mac-dmg-x64.yml
+++ b/.github/workflows/mac-dmg-x64.yml
@@ -11,6 +11,8 @@ name: Build macOS .dmg for x64
 on:
   release:
     types: [published]
+  schedule:
+    - cron: '0 20 20 * *'
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/mac-dmg.yml
+++ b/.github/workflows/mac-dmg.yml
@@ -3,6 +3,8 @@ name: Build macOS .dmg for arm64
 on:
   release:
     types: [published]
+  schedule:
+    - cron: '0 20 20 * *'
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/mac-dmg.yml
+++ b/.github/workflows/mac-dmg.yml
@@ -250,7 +250,7 @@ jobs:
         env:
           CODESIGN_IDENTITY: ${{ secrets.MACOS_CODESIGN_IDENTITY }}
       - name: Notarize .dmg
-        if: startsWith(github.ref, 'refs/tags/') || inputs.notarize
+        if: startsWith(github.ref, 'refs/tags/') || inputs.notarize || github.event_name == 'schedule'
         uses: cocoalibs/xcode-notarization-action@5cf433d494b6fa26504b574c591f4dd120388846 # v1.0.3
         with:
           app-path: 'Cryptomator-*.dmg'

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -195,7 +195,7 @@ jobs:
           & $env:JAVA_HOME\bin\jmod.exe extract --dir jpackage-jmod "${env:JAVA_HOME}\jmods\jdk.jpackage.jmod"
           Get-ChildItem -Recurse -Path "jpackage-jmod" -File wixhelper.dll | Select-Object -Last 1 | Copy-Item -Destination "appdir"
       - name: Sign DLLs with Azure Trusted Signing
-        if: inputs.sign || github.event_name == 'release'
+        if: inputs.sign || github.event_name == 'release' || github.event_name == 'schedule'
         uses: ./.github/actions/win-sign-action
         with:
           base-dir: ${{ github.workspace }}\appdir
@@ -253,7 +253,7 @@ jobs:
           JP_WIXWIZARD_RESOURCES: ${{ github.workspace }}/dist/win/resources # requires abs path, used in resources/main.wxs
           JP_WIXHELPER_DIR: ${{ github.workspace }}\appdir
       - name: Sign MSI with Azure Trusted Signing
-        if: inputs.sign || github.event_name == 'release'
+        if: inputs.sign || github.event_name == 'release' || github.event_name == 'schedule'
         uses: ./.github/actions/win-sign-action
         with:
           base-dir: ${{ github.workspace }}\installer
@@ -361,7 +361,7 @@ jobs:
         run: >
           wix burn detach installer/unsigned/Cryptomator-Installer.exe -engine tmp/engine.exe
       - name: Sign WiX burn engine with Azure Trusted Signing
-        if: inputs.sign || github.event_name == 'release'
+        if: inputs.sign || github.event_name == 'release' || github.event_name == 'schedule'
         uses: ./.github/actions/win-sign-action
         with:
           base-dir: ${{ github.workspace }}\tmp
@@ -375,7 +375,7 @@ jobs:
         run: >
           wix burn reattach installer/unsigned/Cryptomator-Installer.exe -engine tmp/engine.exe -o installer/Cryptomator-Installer.exe
       - name: Sign EXE installer with Azure Trusted Signing
-        if: inputs.sign || github.event_name == 'release'
+        if: inputs.sign || github.event_name == 'release' || github.event_name == 'schedule'
         uses: ./.github/actions/win-sign-action
         with:
           base-dir: ${{ github.workspace }}\installer

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -3,6 +3,8 @@ name: Build Windows Installer
 on:
   release:
     types: [published]
+  schedule:
+    - cron: '0 19 20 * *'
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
This PR implements a monthly build of the Cryptomator distribution artifacts.

To get notified early about failing build pipelines due to changed GitHub runners, removed features, etc..., the distribution builds run on a monthly basis, including the signing step.

The distribution workflows are updated to run on the `schedule` event every 20th day of the month.