### PR TITLE
Hide "lock vaults" warning when no update is available

### DIFF
--- a/src/main/java/org/cryptomator/ui/preferences/UpdatesPreferencesController.java
+++ b/src/main/java/org/cryptomator/ui/preferences/UpdatesPreferencesController.java
@@ -260,7 +260,7 @@ public class UpdatesPreferencesController implements FxController {
 
 	public boolean isProhibitUpdateWhileUnlocked() {
 		// If the result of the last update check was from the fallback mechanism, we don't need to show the warning
-		return !unlockedVaults.isEmpty() && !FallbackUpdateInfo.class.isInstance(updateChecker.getUpdate());
+		return !unlockedVaults.isEmpty() && updateChecker.getUpdate() != null && !FallbackUpdateInfo.class.isInstance(updateChecker.getUpdate());
 	}
 
 	public BooleanBinding prohibitUpdateWhileUnlockedProperty() {

--- a/src/main/java/org/cryptomator/ui/preferences/UpdatesPreferencesController.java
+++ b/src/main/java/org/cryptomator/ui/preferences/UpdatesPreferencesController.java
@@ -260,7 +260,7 @@ public class UpdatesPreferencesController implements FxController {
 
 	public boolean isProhibitUpdateWhileUnlocked() {
 		// If the result of the last update check was from the fallback mechanism, we don't need to show the warning
-		return !unlockedVaults.isEmpty() && updateChecker.getUpdate() != null && !FallbackUpdateInfo.class.isInstance(updateChecker.getUpdate());
+		return !unlockedVaults.isEmpty() && updateChecker.isUpdateAvailable() && !FallbackUpdateInfo.class.isInstance(updateChecker.getUpdate());
 	}
 
 	public BooleanBinding prohibitUpdateWhileUnlockedProperty() {


### PR DESCRIPTION
The "lock your vaults" warning in the preferences updates tab could appear even when no update had been checked yet. Added an explicit null check to ensure the warning is only shown when an update is actually available.