### PR TITLE
fix(ui): make vault options mounting tab scrollable

### DIFF
--- a/src/main/resources/fxml/vault_options_mount.fxml
+++ b/src/main/resources/fxml/vault_options_mount.fxml
@@ -9,90 +9,94 @@
 <?import javafx.scene.control.Hyperlink?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.RadioButton?>
+<?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.control.ToggleGroup?>
 <?import javafx.scene.control.Tooltip?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
-<VBox xmlns:fx="http://javafx.com/fxml"
-	  xmlns="http://javafx.com/javafx"
-	  fx:controller="org.cryptomator.ui.vaultoptions.MountOptionsController"
-	  spacing="6">
-	<fx:define>
-		<ToggleGroup fx:id="mountPointToggleGroup"/>
-	</fx:define>
-	<padding>
-		<Insets topRightBottomLeft="12"/>
-	</padding>
-	<children>
-		<HBox spacing="12" alignment="CENTER_LEFT">
-			<Label text="%vaultOptions.mount.volume.type" labelFor="$vaultVolumeTypeChoiceBox"/>
-			<ChoiceBox fx:id="vaultVolumeTypeChoiceBox"/>
-			<Hyperlink contentDisplay="GRAPHIC_ONLY" onAction="#openVolumePreferences" visible="${controller.defaultMountServiceSelected}" managed="${controller.defaultMountServiceSelected}" accessibleText="%vaultOptions.mount.info">
-				<graphic>
-					<FontAwesome5IconView glyph="COGS" styleClass="glyph-icon-muted"/>
-				</graphic>
-				<tooltip>
-					<Tooltip text="%vaultOptions.mount.info" showDelay="100ms"/>
-				</tooltip>
-			</Hyperlink>
-			<Hyperlink contentDisplay="GRAPHIC_ONLY" onAction="#openDocs" visible="${!controller.defaultMountServiceSelected}" managed="${!controller.defaultMountServiceSelected}" accessibleText="%preferences.volume.docsTooltip">
-				<graphic>
-					<FontAwesome5IconView glyph="QUESTION_CIRCLE" styleClass="glyph-icon-muted"/>
-				</graphic>
-				<tooltip>
-					<Tooltip text="%preferences.volume.docsTooltip" showDelay="100ms"/>
-				</tooltip>
-			</Hyperlink>
-		</HBox>
-
-		<Label styleClass="label-red" text="%vaultOptions.mount.volumeType.restartRequired" visible="${controller.selectedMountServiceRequiresRestart}" managed="${controller.selectedMountServiceRequiresRestart}"/>
-
-		<HBox spacing="12" alignment="CENTER_LEFT" visible="${controller.loopbackPortChangeable}" managed="${controller.loopbackPortChangeable}">
-			<Label text="%vaultOptions.mount.volume.tcp.port" labelFor="$vaultLoopbackPortField"/>
-			<NumericTextField fx:id="vaultLoopbackPortField"/>
-			<Button text="%generic.button.apply" fx:id="vaultLoopbackPortApplyButton" onAction="#doChangeLoopbackPort"/>
-		</HBox>
-
-		<CheckBox fx:id="readOnlyCheckbox" text="%vaultOptions.mount.readonly" visible="${controller.readOnlyOptionAllowed}" managed="${controller.readOnlyOptionAllowed}"/>
-
-		<VBox visible="${controller.mountFlagsSupported}" managed="${controller.mountFlagsSupported}">
-			<CheckBox fx:id="customMountFlagsCheckbox" text="%vaultOptions.mount.customMountFlags" onAction="#toggleUseCustomMountFlags"/>
-			<TextField fx:id="mountFlagsField" HBox.hgrow="ALWAYS" maxWidth="Infinity" accessibleText="%vaultOptions.mount.customMountFlags">
-				<VBox.margin>
-					<Insets left="24"/>
-				</VBox.margin>
-			</TextField>
-		</VBox>
-
-		<Label text="%vaultOptions.mount.mountPoint">
-			<VBox.margin>
-				<Insets top="9"/>
-			</VBox.margin>
-		</Label>
-
-		<RadioButton toggleGroup="${mountPointToggleGroup}" fx:id="mountPointAutoBtn" text="%vaultOptions.mount.mountPoint.auto"/>
-
-		<HBox spacing="6" visible="${controller.mountpointDriveLetterSupported}" managed="${controller.mountpointDriveLetterSupported}">
-			<RadioButton toggleGroup="${mountPointToggleGroup}" fx:id="mountPointDriveLetterBtn" text="%vaultOptions.mount.mountPoint.driveLetter"/>
-			<ChoiceBox fx:id="driveLetterSelection" disable="${!mountPointDriveLetterBtn.selected}" accessibleText="%vaultOptions.mount.mountPoint.driveLetter"/>
-		</HBox>
-
-		<VBox spacing="6" visible="${controller.mountpointDirSupported}" managed="${controller.mountpointDirSupported}">
-			<HBox spacing="6" alignment="CENTER_LEFT">
-				<RadioButton toggleGroup="${mountPointToggleGroup}" fx:id="mountPointDirBtn" text="%vaultOptions.mount.mountPoint.custom"/>
-				<Button text="%vaultOptions.mount.mountPoint.directoryPickerButton" onAction="#chooseCustomMountPoint" contentDisplay="LEFT" disable="${!mountPointDirBtn.selected}">
+<ScrollPane xmlns:fx="http://javafx.com/fxml"
+			xmlns="http://javafx.com/javafx"
+			fx:controller="org.cryptomator.ui.vaultoptions.MountOptionsController"
+			fitToWidth="true"
+			hbarPolicy="NEVER">
+	<VBox spacing="6">
+		<fx:define>
+			<ToggleGroup fx:id="mountPointToggleGroup"/>
+		</fx:define>
+		<padding>
+			<Insets topRightBottomLeft="12"/>
+		</padding>
+		<children>
+			<HBox spacing="12" alignment="CENTER_LEFT">
+				<Label text="%vaultOptions.mount.volume.type" labelFor="$vaultVolumeTypeChoiceBox"/>
+				<ChoiceBox fx:id="vaultVolumeTypeChoiceBox"/>
+				<Hyperlink contentDisplay="GRAPHIC_ONLY" onAction="#openVolumePreferences" visible="${controller.defaultMountServiceSelected}" managed="${controller.defaultMountServiceSelected}" accessibleText="%vaultOptions.mount.info">
 					<graphic>
-						<FontAwesome5IconView glyph="FOLDER_OPEN" glyphSize="15"/>
+						<FontAwesome5IconView glyph="COGS" styleClass="glyph-icon-muted"/>
 					</graphic>
-				</Button>
+					<tooltip>
+						<Tooltip text="%vaultOptions.mount.info" showDelay="100ms"/>
+					</tooltip>
+				</Hyperlink>
+				<Hyperlink contentDisplay="GRAPHIC_ONLY" onAction="#openDocs" visible="${!controller.defaultMountServiceSelected}" managed="${!controller.defaultMountServiceSelected}" accessibleText="%preferences.volume.docsTooltip">
+					<graphic>
+						<FontAwesome5IconView glyph="QUESTION_CIRCLE" styleClass="glyph-icon-muted"/>
+					</graphic>
+					<tooltip>
+						<Tooltip text="%preferences.volume.docsTooltip" showDelay="100ms"/>
+					</tooltip>
+				</Hyperlink>
 			</HBox>
-			<TextField fx:id="directoryPathField" text="${controller.directoryPath}" visible="${mountPointDirBtn.selected}" managed="${mountPointDirBtn.managed}" maxWidth="Infinity" editable="false" accessibleText="%vaultOptions.mount.mountPoint.custom">
-				<VBox.margin>
-					<Insets left="24"/>
-				</VBox.margin>
-			</TextField>
-		</VBox>
-	</children>
 
-</VBox>
+			<Label styleClass="label-red" text="%vaultOptions.mount.volumeType.restartRequired" visible="${controller.selectedMountServiceRequiresRestart}" managed="${controller.selectedMountServiceRequiresRestart}"/>
+
+			<HBox spacing="12" alignment="CENTER_LEFT" visible="${controller.loopbackPortChangeable}" managed="${controller.loopbackPortChangeable}">
+				<Label text="%vaultOptions.mount.volume.tcp.port" labelFor="$vaultLoopbackPortField"/>
+				<NumericTextField fx:id="vaultLoopbackPortField"/>
+				<Button text="%generic.button.apply" fx:id="vaultLoopbackPortApplyButton" onAction="#doChangeLoopbackPort"/>
+			</HBox>
+
+			<CheckBox fx:id="readOnlyCheckbox" text="%vaultOptions.mount.readonly" visible="${controller.readOnlyOptionAllowed}" managed="${controller.readOnlyOptionAllowed}"/>
+
+			<VBox visible="${controller.mountFlagsSupported}" managed="${controller.mountFlagsSupported}">
+				<CheckBox fx:id="customMountFlagsCheckbox" text="%vaultOptions.mount.customMountFlags" onAction="#toggleUseCustomMountFlags"/>
+				<TextField fx:id="mountFlagsField" HBox.hgrow="ALWAYS" maxWidth="Infinity" accessibleText="%vaultOptions.mount.customMountFlags">
+					<VBox.margin>
+						<Insets left="24"/>
+					</VBox.margin>
+				</TextField>
+			</VBox>
+
+			<Label text="%vaultOptions.mount.mountPoint">
+				<VBox.margin>
+					<Insets top="9"/>
+				</VBox.margin>
+			</Label>
+
+			<RadioButton toggleGroup="${mountPointToggleGroup}" fx:id="mountPointAutoBtn" text="%vaultOptions.mount.mountPoint.auto"/>
+
+			<HBox spacing="6" visible="${controller.mountpointDriveLetterSupported}" managed="${controller.mountpointDriveLetterSupported}">
+				<RadioButton toggleGroup="${mountPointToggleGroup}" fx:id="mountPointDriveLetterBtn" text="%vaultOptions.mount.mountPoint.driveLetter"/>
+				<ChoiceBox fx:id="driveLetterSelection" disable="${!mountPointDriveLetterBtn.selected}" accessibleText="%vaultOptions.mount.mountPoint.driveLetter"/>
+			</HBox>
+
+			<VBox spacing="6" visible="${controller.mountpointDirSupported}" managed="${controller.mountpointDirSupported}">
+				<HBox spacing="6" alignment="CENTER_LEFT">
+					<RadioButton toggleGroup="${mountPointToggleGroup}" fx:id="mountPointDirBtn" text="%vaultOptions.mount.mountPoint.custom"/>
+					<Button text="%vaultOptions.mount.mountPoint.directoryPickerButton" onAction="#chooseCustomMountPoint" contentDisplay="LEFT" disable="${!mountPointDirBtn.selected}">
+						<graphic>
+							<FontAwesome5IconView glyph="FOLDER_OPEN" glyphSize="15"/>
+						</graphic>
+					</Button>
+				</HBox>
+				<TextField fx:id="directoryPathField" text="${controller.directoryPath}" visible="${mountPointDirBtn.selected}" managed="${mountPointDirBtn.managed}" maxWidth="Infinity" editable="false" accessibleText="%vaultOptions.mount.mountPoint.custom">
+					<VBox.margin>
+						<Insets left="24"/>
+					</VBox.margin>
+				</TextField>
+			</VBox>
+		</children>
+
+	</VBox>
+</ScrollPane>


### PR DESCRIPTION
## Problem
On the **Vault Options → Mounting** tab, switching the **Volume Type** can make additional configuration rows appear (drive-letter selector, custom mount-point radio + path picker, custom mount flags, etc.). Because the tab content is laid out as a plain `VBox` inside a `TabPane` whose hosting Stage has a `setMinHeight(300)` floor, the newly-revealed rows extend beyond the tab's viewport with no way to scroll. The user has to manually drag the bottom edge of the window down to see them — which is not discoverable, and on Windows 11 with WinFsp (Local Drive) selected it cuts the path text field literally in half.

Fixes #3150

<img width="613" height="346" alt="cryptomator-bugfix" src="https://github.com/user-attachments/assets/e8119b90-d1bc-4bfc-9c07-888a17ad45e0" />


## Steps to reproduce
1. Open Cryptomator with at least one vault configured.
2. Select a vault and click **Show Vault Options**.
3. Open the **Mounting** tab.
4. Resize the window down to its minimum height.
5. Switch **Volume Type** between options that expose different mount-point capabilities (e.g. WinFsp Local Drive on Windows, FUSE on Linux/macOS).
6. The path text field / drive-letter row that becomes visible cannot be reached without enlarging the window — there is no scrollbar.

## Failure mode
Clipped, non-scrollable content. Functional impact is minor (the controls still work once the window is enlarged) but discoverability is poor — for a user who does not know to resize, the option appears missing.

## Two solutions considered

**Option A — wrap the tab in a `ScrollPane` (chosen).** Adds a vertical scrollbar that appears only when the content overflows the viewport. Mirrors the pattern already used in `addvault_new_location.fxml`. Smallest diff, no controller or layout logic changes, no impact on other tabs.

**Option B — listen for `selectedMountService` / capability changes and programmatically resize the Stage to fit the new content.** Requires plumbing a layout listener into `MountOptionsController`, recomputing preferred height across font/locale/DPI variations, and deciding what to do if the user has manually resized the window. More moving parts and more edge cases; a worse fit for an FXML-only fit-and-finish issue.

Option A was chosen for minimal blast radius and consistency with existing FXML patterns in the repo.

## Fix
`src/main/resources/fxml/vault_options_mount.fxml`: wrap the existing `<VBox>` in `<ScrollPane fitToWidth="true" hbarPolicy="NEVER">`. Move `fx:controller` to the new root. All `fx:id`s, bindings, padding and content unchanged — only the wrapping element and the indent level of the inner block.

## Test plan
- [x] `mvn -DskipTests package` succeeds.
- [x] `mvn test` — 308 passed, 4 skipped (OS-gated), 0 failures.
- [x] App launches; main window opens; settings persist.
- [x] Manual: opened Vault Options → Mounting, shrank the window to minimum, switched Volume Type — vertical scrollbar appears and reaches all revealed rows. Other Vault Options tabs (General, Masterkey, Hub) unchanged.
- [ ] Cross-OS verification (Windows + WinFsp Local Drive, macOS + FUSE-T) welcomed from reviewers.