### PR TITLE
Automatically activate os specific maven profiles

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Set version
         run : ./mvnw versions:set -DnewVersion="${VERSION_NUM}${VERSION_SUFFIX}"
       - name: Run maven
-        run: ./mvnw -B clean package -Plinux -DskipTests
+        run: ./mvnw -B clean package -DskipTests
       - name: Patch target dir
         run: |
           cp LICENSE.txt target

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -70,7 +70,7 @@ jobs:
           check-latest: true
           cache: 'maven'
       - name: Run maven
-        run: ./mvnw -B clean package -Plinux -DskipTests
+        run: ./mvnw -B clean package -DskipTests
       - name: Download OpenJFX jmods
         id: download-jmods
         run: |

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -38,7 +38,7 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           cache: 'maven'
       - name: Build and Test
-        run: xvfb-run ./mvnw -B verify -Plinux
+        run: xvfb-run ./mvnw -B verify
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
       - name: Draft a release

--- a/README.md
+++ b/README.md
@@ -84,9 +84,6 @@ For more information on the security details visit [cryptomator.org](https://doc
 
 ```
 ./mvnw clean install
-# or ./mvnw clean install -Pwin
-# or ./mvnw clean install -Pmac
-# or ./mvnw clean install -Plinux
 ```
 
 This will build all the jars and bundle them together with their OS-specific dependencies under `target`. This can now be used to build native packages.

--- a/dist/linux/appimage/build.sh
+++ b/dist/linux/appimage/build.sh
@@ -19,7 +19,7 @@ if [[ ! "${CPU_ARCH}" =~ x86_64|aarch64 ]]; then echo "Platform ${CPU_ARCH} not 
 ../../../mvnw -f ../../../pom.xml versions:set -DnewVersion=${SEMVER_STR}
 
 # compile
-../../../mvnw -B -f ../../../pom.xml clean package -Plinux -DskipTests
+../../../mvnw -B -f ../../../pom.xml clean package -DskipTests
 cp ../../../LICENSE.txt ../../../target
 cp ../../../target/cryptomator-*.jar ../../../target/mods
 

--- a/dist/linux/flatpak/org.cryptomator.Cryptomator.TEMPLATE.yaml
+++ b/dist/linux/flatpak/org.cryptomator.Cryptomator.TEMPLATE.yaml
@@ -94,7 +94,7 @@ modules:
       - mkdir maven
       - tar xf maven.tar.gz --strip-components=1 --exclude=jansi-native --directory=maven
       # Build project
-      - maven/bin/mvn clean package -DskipTests -P"linux-$(uname -m)"
+      - maven/bin/mvn clean package -DskipTests
       - cp target/cryptomator-*.jar target/mods
       - cd target
       - $JAVA_HOME/bin/jlink

--- a/dist/linux/makepkg/PKGBUILD.template
+++ b/dist/linux/makepkg/PKGBUILD.template
@@ -47,7 +47,7 @@ build() {
 
   cd "${srcdir}/${_src_app_dir}"
 
-  mvn -B clean package -DskipTests -Plinux
+  mvn -B clean package -DskipTests
 
   cp LICENSE.txt target
   cp target/cryptomator-*.jar target/mods

--- a/pom.xml
+++ b/pom.xml
@@ -502,9 +502,6 @@
 				<os>
 					<family>mac</family>
 				</os>
-				<property>
-					<name>idea.version</name>
-				</property>
 			</activation>
 			<dependencies>
 				<dependency>
@@ -520,12 +517,9 @@
 			<activation>
 				<os>
 					<family>unix</family>
-					<name>Linux</name>
+					<name>linux</name>
 					<arch>aarch64</arch>
 				</os>
-				<property>
-					<name>idea.version</name>
-				</property>
 			</activation>
 			<dependencies>
 				<dependency>
@@ -565,12 +559,9 @@
 			<activation>
 				<os>
 					<family>unix</family>
-					<name>Linux</name>
+					<name>linux</name>
 					<arch>amd64</arch>
 				</os>
-				<property>
-					<name>idea.version</name>
-				</property>
 			</activation>
 			<dependencies>
 				<dependency>
@@ -587,9 +578,6 @@
 				<os>
 					<family>windows</family>
 				</os>
-				<property>
-					<name>idea.version</name>
-				</property>
 			</activation>
 			<dependencies>
 				<dependency>


### PR DESCRIPTION
This PR removes and additional condition from the os-specific maven profiles. Additionally, all -Plinux flags are removed from maven builds.

This fixes arch-dependent linux builds.

The problem was, that due to wrong profile name ("linux"), the linux specific library integrations-linux was not included in the resulting artifact.