### PR TITLE
Sign Powershell scripts (again)

### DIFF
--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -242,7 +242,7 @@ jobs:
           base-dir: ${{ github.workspace }}\appdir\Cryptomator
           file-extensions: 'ps1'
           recursive: false
-          append-signature: true
+          append-signature: false
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -229,7 +229,19 @@ jobs:
         uses: ./.github/actions/win-sign-action
         with:
           base-dir: ${{ github.workspace }}\appdir
+          file-extensions: 'exe,dll'
           recursive: true
+          append-signature: true
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+      - name: Sign Scripts with Azure Trusted Signing
+        if: inputs.sign || github.event_name == 'schedule'
+        uses: ./.github/actions/win-sign-action
+        with:
+          base-dir: ${{ github.workspace }}\appdir\Cryptomator
+          file-extensions: 'ps1'
+          recursive: false
           append-signature: true
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -234,17 +234,6 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
-      - name: Sign DLLs with Actalis CodeSigner
-        if: inputs.sign || github.event_name == 'release'
-        uses: skymatic/workflows/.github/actions/win-sign-action@957d3c2c08c56855fdac41e5afb9a7aca8c30dd9 # no specific version
-        with:
-          base-dir: 'appdir'
-          file-extensions: 'dll,exe,ps1'
-          recursive: true
-          sign-description: 'Cryptomator'
-          sign-url: 'https://cryptomator.org'
-          username: ${{ secrets.WIN_CODESIGN_USERNAME }}
-          password: ${{ secrets.WIN_CODESIGN_PW }}
       - name: Replace DLLs inside jars with signed ones
         shell: pwsh
         run: |
@@ -429,16 +418,6 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
-      - name: Sign burn engine with Actalis CodeSigner
-        if: inputs.sign || github.event_name == 'release'
-        uses: skymatic/workflows/.github/actions/win-sign-action@957d3c2c08c56855fdac41e5afb9a7aca8c30dd9 # no specific version
-        with:
-          base-dir: 'tmp'
-          file-extensions: 'exe'
-          sign-description: 'Cryptomator Bundle Installer'
-          sign-url: 'https://cryptomator.org'
-          username: ${{ secrets.WIN_CODESIGN_USERNAME }}
-          password: ${{ secrets.WIN_CODESIGN_PW }}
       - name: Reattach signed burn engine to installer
         if: inputs.sign || github.event_name == 'schedule'
         shell: pwsh
@@ -456,16 +435,6 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
-      - name: Sign installer with Actalis CodeSigner
-        if: inputs.sign || github.event_name == 'release'
-        uses: skymatic/workflows/.github/actions/win-sign-action@957d3c2c08c56855fdac41e5afb9a7aca8c30dd9 # no specific version
-        with:
-          base-dir: 'installer'
-          file-extensions: 'exe'
-          sign-description: 'Cryptomator Bundle Installer'
-          sign-url: 'https://cryptomator.org'
-          username: ${{ secrets.WIN_CODESIGN_USERNAME }}
-          password: ${{ secrets.WIN_CODESIGN_PW }}
       - id: sha256sum
         run: |
           read -ra CMD_OUTPUT < <(sha256sum installer/Cryptomator-*.exe)

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -242,17 +242,10 @@ jobs:
           base-dir: ${{ github.workspace }}\appdir\Cryptomator
           file-extensions: 'ps1'
           recursive: false
-          append-signature: false
+          append-signature: false  # Powershell scripts cannot be signed in append mode, see #4260
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
-      - name: Upload artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ps1-${{ matrix.arch }}
-          path: |
-            appdir/Cryptomator/*.ps1
-          if-no-files-found: error
       - name: Replace DLLs inside jars with signed ones
         shell: pwsh
         run: |

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -234,6 +234,13 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ps1-${{ matrix.arch }}
+          path: |
+            appdir/Cryptomator/*.ps1
+          if-no-files-found: error
       - name: Replace DLLs inside jars with signed ones
         shell: pwsh
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changes to prior versions can be found on the [Github release page](https://gith
 * Refactored release pipeline to allow immutable releases ([#4205](https://github.com/cryptomator/cryptomator/pull/4205))
 * Updated to JDK 26.0.1 ([#4244](https://github.com/cryptomator/cryptomator/pull/4244))
 * Updated to JavaFX 25.0.3 ([#4255](https://github.com/cryptomator/cryptomator/pull/4255))
+* Drop signing with Actalis issued certificate ([#4169](https://github.com/cryptomator/cryptomator/pull/4169), [#4262](https://github.com/cryptomator/cryptomator/pull/4262))
 * Updated dependencies:
   - `org.cryptomator:webdav-nio-adapter` from 3.0.1 to 3.0.2
   - `org.cryptomator:integrations-api` from 1.8.0 to 1.9.0


### PR DESCRIPTION
This PR fixes #4260.

The [azure/artifact-signing-action](https://github.com/Azure/artifact-signing-action) does not sign Powershell files, if it is set to append signatures. In general, appending is desired to not remove any existing, valid signature or fail because the file is already signed.

Changes:
* Remove actalis code signing again
* add additional signing step for powershell scripts
* Update Changlog

Relates to #4169