### PR TITLE
README: Update JDK version from 25 to 26

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For more information on the security details visit [cryptomator.org](https://doc
 
 ### Dependencies
 
-* JDK 25 (e.g. temurin, zulu)
+* JDK 26 (e.g. temurin, zulu)
 
 ### Run Maven
 


### PR DESCRIPTION
You're using 26, after all: https://github.com/cryptomator/cryptomator/blob/56e655c5a9294a8bb57530ff36d43dc3bfa7f7fc/pom.xml#L29