### PR TITLE
Feature: Fix locate encrypted file on Linux

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 		<cryptomator.integrations.version>1.9.0</cryptomator.integrations.version>
 		<cryptomator.integrations.win.version>1.6.1</cryptomator.integrations.win.version>
 		<cryptomator.integrations.mac.version>1.5.0</cryptomator.integrations.mac.version>
-		<cryptomator.integrations.linux.version>1.7.0</cryptomator.integrations.linux.version>
+		<cryptomator.integrations.linux.version>1.8.0-beta1</cryptomator.integrations.linux.version>
 		<cryptomator.fuse.version>6.0.1</cryptomator.fuse.version>
 		<cryptomator.webdav.version>3.0.2</cryptomator.webdav.version>
 		<cryptomator.webdav-servlet.version>1.2.12</cryptomator.webdav-servlet.version>

--- a/src/main/java/org/cryptomator/ui/fxapp/JfxRevealPathService.java
+++ b/src/main/java/org/cryptomator/ui/fxapp/JfxRevealPathService.java
@@ -23,10 +23,11 @@ public class JfxRevealPathService implements RevealPathService {
 
 	@Override
 	public void reveal(Path p) throws RevealFailedException {
+		var absPath = p.toAbsolutePath();
 		var fxApp = FxApplication.INSTANCE.get();
 		if (fxApp != null) {
 			// showDocument() launches the default app for a regular file, so reveal its parent directory instead
-			var target = Files.isRegularFile(p) ? p.getParent() : p;
+			var target = Files.isRegularFile(absPath) ? absPath.getParent() : absPath;
 			fxApp.getHostServices().showDocument(target.toUri().toString());
 		} else {
 			throw new RevealFailedException("JavaFX Application not initialized");

--- a/src/main/java/org/cryptomator/ui/fxapp/JfxRevealPathService.java
+++ b/src/main/java/org/cryptomator/ui/fxapp/JfxRevealPathService.java
@@ -6,6 +6,7 @@ import org.cryptomator.integrations.common.Priority;
 import org.cryptomator.integrations.revealpath.RevealFailedException;
 import org.cryptomator.integrations.revealpath.RevealPathService;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
@@ -17,14 +18,16 @@ import java.nio.file.Path;
  */
 @DisplayName("JavaFX HostServices (GTK)")
 @OperatingSystem(OperatingSystem.Value.LINUX)
-@Priority(10)
+@Priority(Priority.FALLBACK)
 public class JfxRevealPathService implements RevealPathService {
 
 	@Override
 	public void reveal(Path p) throws RevealFailedException {
 		var fxApp = FxApplication.INSTANCE.get();
 		if (fxApp != null) {
-			fxApp.getHostServices().showDocument(p.toUri().toString());
+			// showDocument() launches the default app for a regular file, so reveal its parent directory instead
+			var target = Files.isRegularFile(p) ? p.getParent() : p;
+			fxApp.getHostServices().showDocument(target.toUri().toString());
 		} else {
 			throw new RevealFailedException("JavaFX Application not initialized");
 		}


### PR DESCRIPTION
This PR fixes #4272 .

The `JfxRevealPathService is demoted to `FALLBACK` priority. Additionally, it is fixed to actually reveal the files (not open then). The integration-linux bump contains the `DBusSendRevealPathService` with a new non-default priority.