### PR TITLE
Refactor misspelled local variable names

### DIFF
--- a/src/main/java/org/cryptomator/ui/health/CheckDetailController.java
+++ b/src/main/java/org/cryptomator/ui/health/CheckDetailController.java
@@ -84,7 +84,7 @@ public class CheckDetailController implements FxController {
 		this.checkFinished = checkSucceeded.or(checkFailed).or(checkCancelled);
 		this.countOfWarnSeverity = results.reduce(countSeverity(Severity.WARN));
 		this.countOfCritSeverity = results.reduce(countSeverity(Severity.CRITICAL));
-		this.warnOrCritsExist = EasyBind.combine(checkSucceeded, countOfWarnSeverity, countOfCritSeverity, (suceeded, warns, crits) -> suceeded && (warns.longValue() > 0 || crits.longValue() > 0));
+		this.warnOrCritsExist = EasyBind.combine(checkSucceeded, countOfWarnSeverity, countOfCritSeverity, (succeeded, warns, crits) -> succeeded && (warns.longValue() > 0 || crits.longValue() > 0));
 		this.fixAllInfoResultsExecuted = new SimpleBooleanProperty(false);
 		this.fixAllInfoResultsPossible = Bindings.createBooleanBinding(() -> results.stream().anyMatch(this::isFixableInfoResult), results) //
 				.and(fixAllInfoResultsExecuted.not());

--- a/src/main/java/org/cryptomator/ui/unlock/UnlockInvalidMountPointController.java
+++ b/src/main/java/org/cryptomator/ui/unlock/UnlockInvalidMountPointController.java
@@ -51,7 +51,7 @@ public class UnlockInvalidMountPointController implements FxController {
 		this.exceptionType = illegalMountPointException.map(this::getExceptionType);
 		this.exceptionPath = illegalMountPointException.map(IllegalMountPointException::getMountpoint);
 		this.exceptionMessage = illegalMountPointException.map(IllegalMountPointException::getMessage);
-		this.hideawayPath = illegalMountPointException.map(e -> e instanceof HideawayNotDirectoryException haeExc ? haeExc.getHideaway() : null);
+		this.hideawayPath = illegalMountPointException.map(e -> e instanceof HideawayNotDirectoryException hideawayException ? hideawayException.getHideaway() : null);
 
 		this.format = ObservableUtil.mapWithDefault(exceptionType, type -> resourceBundle.getString(type.translationKey), "");
 		this.showPreferences = ObservableUtil.mapWithDefault(exceptionType, type -> type.action == ButtonAction.SHOW_PREFERENCES, false);


### PR DESCRIPTION
Rename two misspelled local variables to make their purpose immediately clear:

- `haeExc` becomes `hideawayException` in the health check controller;
- `suceeded` becomes `succeeded` in the invalid mount-point controller.

Both variables are method-local, so this does not alter APIs or runtime behavior. `git diff --check` passes.