### PR TITLE
Change pwssword in the locked keychain as well, once it is changed for the vault on Linux

### DIFF
--- a/src/main/java/org/cryptomator/ui/changepassword/ChangePasswordController.java
+++ b/src/main/java/org/cryptomator/ui/changepassword/ChangePasswordController.java
@@ -96,7 +96,7 @@ public class ChangePasswordController implements FxController {
 	}
 
 	private void updatePasswordInSystemkeychain() {
-		if (keychain.isSupported() && !keychain.isLocked()) {
+		if (keychain.isSupported()) {
 			try {
 				keychain.changePassphrase(vault.getId(), vault.getDisplayName(), newPasswordController.passwordField.getCharacters());
 				LOG.info("Successfully updated password in system keychain for {}", vault.getDisplayName());


### PR DESCRIPTION
This PR fixes the problem described in https://github.com/cryptomator/cryptomator/issues/2920#issuecomment-5386811492.

The PR is tested for `kwallet6` and `gnome-keyring`.


