### PR TITLE
Show the button to forget the password from a locked keychain on Linux

### DIFF
--- a/src/main/java/org/cryptomator/ui/vaultoptions/MasterkeyOptionsController.java
+++ b/src/main/java/org/cryptomator/ui/vaultoptions/MasterkeyOptionsController.java
@@ -40,7 +40,7 @@ public class MasterkeyOptionsController implements FxController {
 		this.recoveryKeyWindow = recoveryKeyWindow;
 		this.forgetPasswordWindow = forgetPasswordWindow;
 		this.keychain = keychain;
-		if (keychain.isSupported() && !keychain.isLocked()) {
+		if (keychain.isSupported()) {
 			this.passwordSaved = keychain.getPassphraseStoredProperty(vault.getId()).orElse(false);
 		} else {
 			this.passwordSaved = new SimpleBooleanProperty(false);


### PR DESCRIPTION
This PR fixes the problem described in https://github.com/cryptomator/cryptomator/issues/2920#issuecomment-5386811492.

The PR is tested for `kwallet6` and `gnome-keyring`.