### PR TITLE
Restore Windows Arm64 packaging workflow

### DIFF
--- a/.github/release-body.md.template
+++ b/.github/release-body.md.template
@@ -19,16 +19,21 @@ For a comprehensive view of changes, read the [CHANGELOG](https://github.com/cry
 💾 SHA-256 checksums of release artifacts:
 ```
 $TARBALL
-$EXE
-$MSI
+$EXE_x64
+$EXE_arm64
+$MSI_x64
+$MSI_arm64
 $DMG_x64
 $DMG_arm64
 $APPIMAGE_x86_64
 $APPIMAGE_aarch64
 ```
 
+> [!IMPORTANT]
+> Windows x64 and Windows Arm64 installers use separate upgrade families in this first Arm64 release.
+> Switching architectures requires uninstalling the current Windows install before installing the other architecture.
+
 > [!TIP]
 > You can verify the GPG signature of all assets using our public key: [`5811 7AFA 1F85 B3EE C154  677D 615D 449F E6E6 A235`](https://gist.github.com/cryptobot/211111cf092037490275f39d408f461a).
 
 <!-- Auto-Generated Release Notes: -->
-

--- a/.github/workflows/RELEASE.md
+++ b/.github/workflows/RELEASE.md
@@ -198,6 +198,7 @@ These steps are triggered by team members after Slack notifications:
 - The Windows Arm64 MSI uses a different `--win-upgrade-uuid` than x64, and the Arm64 bundle uses a different Burn `UpgradeCode`. That prevents accidental cross-architecture replacement in this first PR, but it also means there is **no in-place x64 ↔ Arm64 migration** yet.
 - When switching between Windows x64 and Windows Arm64, **uninstall the current architecture first, then install the other one**.
 - The Arm64 bundle intentionally suppresses auto-launch-after-install for now instead of assuming the x64 `ProgramFiles64Folder` launch target is correct in a wrapper-first/emulated-wrapper context.
+- The Arm64 app-image patch step excludes the checked-in `dist/win/contrib/jnidispatch.dll` because that legacy binary is x64-only. The post-patch architecture assertion validates root/runtime binaries and Arm-specific native entries selected from multi-architecture dependency jars.
 - **Deferred hardware gate:** real Windows Arm hardware still must validate WinFsp and JNI behavior (install, launch, mount, read/write, uninstall). This PR wires the CI/release lane and adds smoke checks, but it does **not** claim WinFsp Arm64 readiness is solved.
 
 ## Signing & Security

--- a/.github/workflows/RELEASE.md
+++ b/.github/workflows/RELEASE.md
@@ -199,6 +199,7 @@ These steps are triggered by team members after Slack notifications:
 - When switching between Windows x64 and Windows Arm64, **uninstall the current architecture first, then install the other one**.
 - The Arm64 bundle intentionally suppresses auto-launch-after-install for now instead of assuming the x64 `ProgramFiles64Folder` launch target is correct in a wrapper-first/emulated-wrapper context.
 - The Arm64 app-image patch step excludes the checked-in `dist/win/contrib/jnidispatch.dll` because that legacy binary is x64-only. The post-patch architecture assertion validates root/runtime binaries and Arm-specific native entries selected from multi-architecture dependency jars.
+- The wrapper-first Arm64 MSI/EXE is produced by the x64 packaging toolchain and does not yet reject installation on an x64 host. Release notes and download pages must label the artifact clearly; adding a reliable native-machine launch condition remains a follow-up before official publication.
 - **Deferred hardware gate:** real Windows Arm hardware still must validate WinFsp and JNI behavior (install, launch, mount, read/write, uninstall). This PR wires the CI/release lane and adds smoke checks, but it does **not** claim WinFsp Arm64 readiness is solved.
 
 ## Signing & Security

--- a/.github/workflows/RELEASE.md
+++ b/.github/workflows/RELEASE.md
@@ -38,7 +38,7 @@ flowchart TD
 
         build-exe-and-msi["build-exe-and-msi
         *calls win-exe.yml
-        MSI + EXE (x64)
+        x64 + arm64 app-image/MSI/EXE lanes
         code-signed & GPG-signed*"]
         build-dmg-arm64["build-dmg-arm64
         *calls mac-dmg.yml
@@ -90,13 +90,21 @@ flowchart TD
         check-release --> trigger-website
         check-release --> trigger-docs
 
-        get-asset-urls --> allowlist-msi
-        allowlist-msi --> allowlist-exe
+        get-asset-urls --> allowlist-msi-x64
+        allowlist-msi-x64 --> allowlist-exe-x64
+        get-asset-urls --> allowlist-msi-arm64
+        allowlist-msi-arm64 --> allowlist-exe-arm64
 
-        allowlist-msi["allowlist-msi-x64
+        allowlist-msi-x64["allowlist-msi-x64
         *av-whitelist.yml
         Kaspersky & Avast*"]
-        allowlist-exe["allowlist-exe-x64
+        allowlist-exe-x64["allowlist-exe-x64
+        *av-whitelist.yml
+        Kaspersky & Avast*"]
+        allowlist-msi-arm64["allowlist-msi-arm64
+        *av-whitelist.yml
+        Kaspersky & Avast*"]
+        allowlist-exe-arm64["allowlist-exe-arm64
         *av-whitelist.yml
         Kaspersky & Avast*"]
 
@@ -124,7 +132,7 @@ flowchart TD
 |-----|---------|-------------|
 | **get-version** | ubuntu | Parses the tag into semver components (`semVerNum`, `semVerSuffix`, `revNum`, `versionType`). The release is aborted if not an alpha, beta, rc or 'stable' release. |
 | **create-release-draft** | ubuntu | Checks out the repo, verifies the tag is **signed** and lives on a `main` or `release/*` branch. Runs `./mvnw verify` (with `xvfb-run`). Creates a GitHub Release **draft** using the [release body template](../release-body.md.template). Downloads and GPG-signs the source tarball. |
-| **build-exe-and-msi** | windows | Calls [`win-exe.yml`](win-exe.yml). Builds the MSI and EXE bundle installer for x64 Windows. Code-signed via Azure Trusted Signing, GPG-signed, and uploaded to the draft release. Outputs SHA-256 checksums. |
+| **build-exe-and-msi** | windows | Calls [`win-exe.yml`](win-exe.yml). Builds separate Windows x64 and Windows Arm64 lanes: app-image → MSI → EXE bundle. The Arm64 app-image runs on `windows-11-arm`; Arm64 MSI/EXE packaging is wrapper-first/emulated-wrapper-first and uses distinct installer upgrade families from x64. Outputs SHA-256 checksums for both Windows architectures. |
 | **build-dmg-arm64** | macos-15 | Calls [`mac-dmg.yml`](mac-dmg.yml). Builds the DMG for Apple Silicon. Code-signed, notarized with Apple, GPG-signed, and uploaded. Outputs SHA-256 checksum. |
 | **build-dmg-x64** | macos-15-large | Calls [`mac-dmg-x64.yml`](mac-dmg-x64.yml). Same as above but for Intel Macs. Uses macFUSE instead of FUSE-T. |
 | **build-appimages** | ubuntu | Calls [`appimage.yml`](appimage.yml). Builds AppImages for x86_64 and aarch64 (matrix). GPG-signed and uploaded with `.zsync` delta-update files. Outputs SHA-256 checksums. |
@@ -139,6 +147,8 @@ After the draft phase, the GitHub Release contains:
 | `cryptomator-<ver>.tar.gz.asc` | Source (GPG signature) |
 | `Cryptomator-<ver>-x64.msi` + `.asc` | Windows |
 | `Cryptomator-<ver>-x64.exe` + `.asc` | Windows |
+| `Cryptomator-<ver>-arm64.msi` + `.asc` | Windows Arm64 |
+| `Cryptomator-<ver>-arm64.exe` + `.asc` | Windows Arm64 |
 | `Cryptomator-<ver>-arm64.dmg` + `.asc` | macOS (Apple Silicon) |
 | `Cryptomator-<ver>-x64.dmg` + `.asc` | macOS (Intel) |
 | `cryptomator-<ver>-x86_64.AppImage` + `.zsync` + `.asc` | Linux (x86_64) |
@@ -151,7 +161,9 @@ All artifacts are signed with GPG key [`615D449FE6E6A235`](https://gist.github.c
 After the draft phase completes, a maintainer reviews the draft release on GitHub. This is the point to:
 
 - Verify all artifacts are present and checksums look correct.
+- Verify both Windows architectures are present and that the Arm64 lane passed its packaging smoke checks.
 - Edit the auto-generated release notes (What's New, Bugfixes, Other Changes).
+- Remember that switching between Windows x64 and Windows Arm64 currently requires a manual uninstall/reinstall because the two installers intentionally use separate upgrade families in this first Arm64 PR.
 - **Publish** the release when ready, which triggers phase 2.
 
 ## Phase 2: Post-Publish (`post-publish.yml`)
@@ -163,11 +175,13 @@ After the draft phase completes, a maintainer reviews the draft release on GitHu
 | Job | Condition | Description |
 |-----|-----------|-------------|
 | **notify** | always | Sends Slack notifications to `#cryptomator-desktop`: ready to build `.deb` package, and reminder to update `latest-version.json` on S3. |
-| **get-asset-urls** | always | Extracts MSI and EXE download URLs from the release assets. |
+| **get-asset-urls** | always | Extracts x64 and Arm64 MSI/EXE download URLs from the release assets and reports which Windows architectures are present. |
 | **check-release** | always | Classifies the published release tag as `stable`, `alpha`, `beta`, `rc`, or `unknown`. Stable-only follow-up jobs depend on this output. Unlike `get-version.yml` workflow, this job does not perform semver validation. |
 | **allowlist-msi-x64** | Windows release | Calls [`av-whitelist.yml`](av-whitelist.yml). Uploads the MSI to Kaspersky and Avast for whitelisting. |
 | **allowlist-exe-x64** | Windows release | Same as above for the EXE. Runs sequentially after MSI. |
-| **notify-winget** | stable + Windows | Sends a Slack notification that the release is ready for [winget submission](winget.yml). |
+| **allowlist-msi-arm64** | Windows Arm64 release | Same as above for the Arm64 MSI. |
+| **allowlist-exe-arm64** | Windows Arm64 release | Same as above for the Arm64 EXE. Runs sequentially after the Arm64 MSI. |
+| **notify-winget** | stable + Windows x64 | Sends a Slack notification that the release is ready for [winget submission](winget.yml). `winget.yml` remains unchanged and x64-scoped in this PR. |
 | **trigger-website-update** | stable | Dispatches `desktop-release` event to `cryptomator/cryptomator.github.io`. |
 | **trigger-docs-update** | stable + Windows | Dispatches `desktop-release` event to `cryptomator/docs`. |
 
@@ -176,8 +190,15 @@ After the draft phase completes, a maintainer reviews the draft release on GitHu
 These steps are triggered by team members after Slack notifications:
 
 - **Debian package** -- Run the [`debian.yml`](debian.yml) workflow to build `.deb` and optionally upload to the PPA.
-- **winget** -- Run the [`winget.yml`](winget.yml) workflow to submit to the Windows Package Manager.
+- **winget** -- Run the [`winget.yml`](winget.yml) workflow to submit to the Windows Package Manager. This workflow is intentionally unchanged in this PR and still follows the existing x64 release path.
 - **latest-version.json** -- Update the version-check file on S3 (`static.cryptomator.org/desktop/latest-version.json`).
+
+## Windows Arm64 caveats
+
+- The Windows Arm64 MSI uses a different `--win-upgrade-uuid` than x64, and the Arm64 bundle uses a different Burn `UpgradeCode`. That prevents accidental cross-architecture replacement in this first PR, but it also means there is **no in-place x64 ↔ Arm64 migration** yet.
+- When switching between Windows x64 and Windows Arm64, **uninstall the current architecture first, then install the other one**.
+- The Arm64 bundle intentionally suppresses auto-launch-after-install for now instead of assuming the x64 `ProgramFiles64Folder` launch target is correct in a wrapper-first/emulated-wrapper context.
+- **Deferred hardware gate:** real Windows Arm hardware still must validate WinFsp and JNI behavior (install, launch, mount, read/write, uninstall). This PR wires the CI/release lane and adds smoke checks, but it does **not** claim WinFsp Arm64 readiness is solved.
 
 ## Signing & Security
 

--- a/.github/workflows/RELEASE.md
+++ b/.github/workflows/RELEASE.md
@@ -177,8 +177,8 @@ After the draft phase completes, a maintainer reviews the draft release on GitHu
 | **notify** | always | Sends Slack notifications to `#cryptomator-desktop`: ready to build `.deb` package, and reminder to update `latest-version.json` on S3. |
 | **get-asset-urls** | always | Extracts x64 and Arm64 MSI/EXE download URLs from the release assets and reports which Windows architectures are present. |
 | **check-release** | always | Classifies the published release tag as `stable`, `alpha`, `beta`, `rc`, or `unknown`. Stable-only follow-up jobs depend on this output. Unlike `get-version.yml` workflow, this job does not perform semver validation. |
-| **allowlist-msi-x64** | Windows release | Calls [`av-whitelist.yml`](av-whitelist.yml). Uploads the MSI to Kaspersky and Avast for whitelisting. |
-| **allowlist-exe-x64** | Windows release | Same as above for the EXE. Runs sequentially after MSI. |
+| **allowlist-msi-x64** | Windows x64 release | Calls [`av-whitelist.yml`](av-whitelist.yml). Uploads the MSI to Kaspersky and Avast for whitelisting. |
+| **allowlist-exe-x64** | Windows x64 release | Same as above for the EXE. Runs sequentially after MSI. |
 | **allowlist-msi-arm64** | Windows Arm64 release | Same as above for the Arm64 MSI. |
 | **allowlist-exe-arm64** | Windows Arm64 release | Same as above for the Arm64 EXE. Runs sequentially after the Arm64 MSI. |
 | **notify-winget** | stable + Windows x64 | Sends a Slack notification that the release is ready for [winget submission](winget.yml). `winget.yml` remains unchanged and x64-scoped in this PR. |

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -134,14 +134,21 @@ jobs:
           <!-- /HEADER -->')
 
           export TARBALL="${SRC_SHA}  cryptomator-${SEMVER}.tar.gz"
-          export MSI="${MSI_SHA}  Cryptomator-${SEMVER}-x64.msi"
-          export EXE="${EXE_SHA}  Cryptomator-${SEMVER}-x64.exe"
+          export MSI_x64="${MSI_X64_SHA}  Cryptomator-${SEMVER}-x64.msi"
+          export MSI_arm64="${MSI_ARM64_SHA}  Cryptomator-${SEMVER}-arm64.msi"
+          export EXE_x64="${EXE_X64_SHA}  Cryptomator-${SEMVER}-x64.exe"
+          export EXE_arm64="${EXE_ARM64_SHA}  Cryptomator-${SEMVER}-arm64.exe"
           export DMG_arm64="${DMG_ARM64_SHA}  Cryptomator-${SEMVER}-arm64.dmg"
           export DMG_x64="${DMG_X64_SHA}  Cryptomator-${SEMVER}-x64.dmg"
           export APPIMAGE_x86_64="${APPIMAGE_X64_SHA}  cryptomator-${SEMVER}-x86_64.AppImage"
           export APPIMAGE_aarch64="${APPIMAGE_AARCH64_SHA}  cryptomator-${SEMVER}-aarch64.AppImage"
 
-          envsubst '$VERSION $TARBALL $EXE $MSI $DMG_x64 $DMG_arm64 $APPIMAGE_x86_64 $APPIMAGE_aarch64' \
+          test -n "${MSI_X64_SHA}"
+          test -n "${MSI_ARM64_SHA}"
+          test -n "${EXE_X64_SHA}"
+          test -n "${EXE_ARM64_SHA}"
+
+          envsubst '$VERSION $TARBALL $MSI_x64 $MSI_arm64 $EXE_x64 $EXE_arm64 $DMG_x64 $DMG_arm64 $APPIMAGE_x86_64 $APPIMAGE_aarch64' \
             <<< "${RELEASE_BODY}" \
             > release-body.md
 
@@ -149,8 +156,10 @@ jobs:
         env:
           VERSION: ${{ needs.get-version.outputs.semVerStr }}
           SRC_SHA: ${{ steps.src-sha256.outputs.value }}
-          MSI_SHA: ${{ needs.build-exe-and-msi.outputs.sha256-msi }}
-          EXE_SHA: ${{ needs.build-exe-and-msi.outputs.sha256-exe }}
+          MSI_X64_SHA: ${{ needs.build-exe-and-msi.outputs.sha256-msi-x64 }}
+          MSI_ARM64_SHA: ${{ needs.build-exe-and-msi.outputs.sha256-msi-arm64 }}
+          EXE_X64_SHA: ${{ needs.build-exe-and-msi.outputs.sha256-exe-x64 }}
+          EXE_ARM64_SHA: ${{ needs.build-exe-and-msi.outputs.sha256-exe-arm64 }}
           DMG_ARM64_SHA: ${{ needs.build-dmg-arm64.outputs.sha256-dmg }}
           DMG_X64_SHA: ${{ needs.build-dmg-x64.outputs.sha256-dmg }}
           APPIMAGE_X64_SHA: ${{ needs.build-appimages.outputs.sha256-appimage-x64 }}

--- a/.github/workflows/post-publish.yml
+++ b/.github/workflows/post-publish.yml
@@ -38,38 +38,74 @@ jobs:
     runs-on: ubuntu-slim
     outputs:
       is-windows-release: ${{ steps.urls.outputs.urls-present }}
-      msi-url: ${{ steps.urls.outputs.msi }}
-      exe-url: ${{ steps.urls.outputs.exe }}
+      is-windows-x64-release: ${{ steps.urls.outputs.x64-present }}
+      is-windows-arm64-release: ${{ steps.urls.outputs.arm64-present }}
+      msi-x64-url: ${{ steps.urls.outputs.msi-x64 }}
+      exe-x64-url: ${{ steps.urls.outputs.exe-x64 }}
+      msi-arm64-url: ${{ steps.urls.outputs.msi-arm64 }}
+      exe-arm64-url: ${{ steps.urls.outputs.exe-arm64 }}
     steps:
       - name: Extract MSI and EXE download URLs
         id: urls
         run: |
-          MSI_URL=$(jq -r '[.[] | select(.name | endswith("-x64.msi"))][0].browser_download_url // "null"' <<< "$RELEASE_ASSETS")
-          EXE_URL=$(jq -r '[.[] | select(.name | endswith("-x64.exe"))][0].browser_download_url // "null"' <<< "$RELEASE_ASSETS")
-          if [[ "$MSI_URL" == "null" || -z "$MSI_URL" || "$EXE_URL" == "null" || -z "$EXE_URL" ]]; then
-            echo "urls-present=false" >> $GITHUB_OUTPUT
-          else
-            echo "urls-present=true" >> $GITHUB_OUTPUT
-            echo "msi=${MSI_URL}" >> $GITHUB_OUTPUT
-            echo "exe=${EXE_URL}" >> $GITHUB_OUTPUT
+          MSI_X64_URL=$(jq -r '[.[] | select(.name | endswith("-x64.msi"))][0].browser_download_url // "null"' <<< "$RELEASE_ASSETS")
+          EXE_X64_URL=$(jq -r '[.[] | select(.name | endswith("-x64.exe"))][0].browser_download_url // "null"' <<< "$RELEASE_ASSETS")
+          MSI_ARM64_URL=$(jq -r '[.[] | select(.name | endswith("-arm64.msi"))][0].browser_download_url // "null"' <<< "$RELEASE_ASSETS")
+          EXE_ARM64_URL=$(jq -r '[.[] | select(.name | endswith("-arm64.exe"))][0].browser_download_url // "null"' <<< "$RELEASE_ASSETS")
+
+          X64_PRESENT=false
+          ARM64_PRESENT=false
+          if [[ "$MSI_X64_URL" != "null" && -n "$MSI_X64_URL" && "$EXE_X64_URL" != "null" && -n "$EXE_X64_URL" ]]; then
+            X64_PRESENT=true
+            echo "msi-x64=${MSI_X64_URL}" >> $GITHUB_OUTPUT
+            echo "exe-x64=${EXE_X64_URL}" >> $GITHUB_OUTPUT
           fi
+          if [[ "$MSI_ARM64_URL" != "null" && -n "$MSI_ARM64_URL" && "$EXE_ARM64_URL" != "null" && -n "$EXE_ARM64_URL" ]]; then
+            ARM64_PRESENT=true
+            echo "msi-arm64=${MSI_ARM64_URL}" >> $GITHUB_OUTPUT
+            echo "exe-arm64=${EXE_ARM64_URL}" >> $GITHUB_OUTPUT
+          fi
+
+          if [[ "$X64_PRESENT" == true || "$ARM64_PRESENT" == true ]]; then
+            echo "urls-present=true" >> $GITHUB_OUTPUT
+          else
+            echo "urls-present=false" >> $GITHUB_OUTPUT
+          fi
+          echo "x64-present=${X64_PRESENT}" >> $GITHUB_OUTPUT
+          echo "arm64-present=${ARM64_PRESENT}" >> $GITHUB_OUTPUT
         env:
           RELEASE_ASSETS: ${{ toJson(github.event.release.assets) }}
 
   allowlist-msi-x64:
     needs: [get-asset-urls]
-    if: needs.get-asset-urls.outputs.is-windows-release == 'true'
+    if: needs.get-asset-urls.outputs.is-windows-x64-release == 'true'
     uses: ./.github/workflows/av-whitelist.yml
     with:
-      url: ${{ needs.get-asset-urls.outputs.msi-url }}
+      url: ${{ needs.get-asset-urls.outputs.msi-x64-url }}
     secrets: inherit
 
   allowlist-exe-x64:
     needs: [get-asset-urls, allowlist-msi-x64]
-    if: needs.get-asset-urls.outputs.is-windows-release == 'true'
+    if: needs.get-asset-urls.outputs.is-windows-x64-release == 'true'
     uses: ./.github/workflows/av-whitelist.yml
     with:
-      url: ${{ needs.get-asset-urls.outputs.exe-url }}
+      url: ${{ needs.get-asset-urls.outputs.exe-x64-url }}
+    secrets: inherit
+
+  allowlist-msi-arm64:
+    needs: [get-asset-urls]
+    if: needs.get-asset-urls.outputs.is-windows-arm64-release == 'true'
+    uses: ./.github/workflows/av-whitelist.yml
+    with:
+      url: ${{ needs.get-asset-urls.outputs.msi-arm64-url }}
+    secrets: inherit
+
+  allowlist-exe-arm64:
+    needs: [get-asset-urls, allowlist-msi-arm64]
+    if: needs.get-asset-urls.outputs.is-windows-arm64-release == 'true'
+    uses: ./.github/workflows/av-whitelist.yml
+    with:
+      url: ${{ needs.get-asset-urls.outputs.exe-arm64-url }}
     secrets: inherit
 
   check-release:
@@ -100,7 +136,7 @@ jobs:
 
   notify-winget:
     name: Notify for winget-release
-    if: needs.get-asset-urls.outputs.is-windows-release == 'true' && needs.check-release.outputs.release-kind == 'stable'
+    if: needs.get-asset-urls.outputs.is-windows-x64-release == 'true' && needs.check-release.outputs.release-kind == 'stable'
     needs: [check-release, get-asset-urls]
     runs-on: ubuntu-latest
     steps:
@@ -142,4 +178,3 @@ jobs:
           token: ${{ secrets.CRYPTOBOT_WORKFLOW_DISPATCH_TOKEN }}
           repository: cryptomator/docs
           client-payload: '{ "version": "${{ github.event.release.tag_name }}", "release": ${{ toJson(github.event.release.assets) }} }'
-

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -102,7 +102,7 @@ jobs:
           cache: maven
       - name: Download and extract JavaFX jmods from Gluon
         run: |
-          curl --silent --fail-with-body --proto "=https" -L "${{ env.OPENJFX_JMODS_AMD64 }}" --output openjfx-jmods.zip
+          curl.exe --silent --fail-with-body --proto "=https" -L "${{ env.OPENJFX_JMODS_AMD64 }}" --output openjfx-jmods.zip
           if(!(Get-FileHash -Path openjfx-jmods.zip -Algorithm SHA256).Hash.ToLower().equals("${{ env.OPENJFX_JMODS_AMD64_HASH }}")) {
             throw "Wrong checksum of JMOD archive downloaded from ${{ env.OPENJFX_JMODS_AMD64 }}."
           }
@@ -802,7 +802,7 @@ jobs:
         shell: pwsh
       - name: Download WinFsp
         run: |
-          curl --silent --fail-with-body --proto "=https" -L "$env:WINFSP_MSI" --output $env:WINFSP_PATH
+          curl.exe --silent --fail-with-body --proto "=https" -L "$env:WINFSP_MSI" --output $env:WINFSP_PATH
           $computedHash = (Get-FileHash -Path "$env:WINFSP_PATH" -Algorithm SHA256).Hash.ToLower()
           if ($computedHash -ne "$env:WINFSP_MSI_HASH") {
             throw "Checksum mismatch for ${env:WINFSP_PATH} (expected ${env:WINFSP_MSI_HASH}, got $computedHash)."
@@ -812,7 +812,7 @@ jobs:
         shell: pwsh
       - name: Download Legacy-WinFsp uninstaller
         run: |
-          curl --silent --fail-with-body --proto "=https" -L ${{ env.WINFSP_UNINSTALLER }} --output dist/win/bundle/resources/winfsp-uninstaller.exe
+          curl.exe --silent --fail-with-body --proto "=https" -L ${{ env.WINFSP_UNINSTALLER }} --output dist/win/bundle/resources/winfsp-uninstaller.exe
         shell: pwsh
       - name: Create Wix Burn bundle
         working-directory: dist/win
@@ -941,7 +941,7 @@ jobs:
         shell: pwsh
       - name: Download WinFsp
         run: |
-          curl --silent --fail-with-body --proto "=https" -L "$env:WINFSP_MSI" --output $env:WINFSP_PATH
+          curl.exe --silent --fail-with-body --proto "=https" -L "$env:WINFSP_MSI" --output $env:WINFSP_PATH
           $computedHash = (Get-FileHash -Path "$env:WINFSP_PATH" -Algorithm SHA256).Hash.ToLower()
           if ($computedHash -ne "$env:WINFSP_MSI_HASH") {
             throw "Checksum mismatch for ${env:WINFSP_PATH} (expected ${env:WINFSP_MSI_HASH}, got $computedHash)."
@@ -951,7 +951,7 @@ jobs:
         shell: pwsh
       - name: Download Legacy-WinFsp uninstaller
         run: |
-          curl --silent --fail-with-body --proto "=https" -L ${{ env.WINFSP_UNINSTALLER }} --output dist/win/bundle/resources/winfsp-uninstaller.exe
+          curl.exe --silent --fail-with-body --proto "=https" -L ${{ env.WINFSP_UNINSTALLER }} --output dist/win/bundle/resources/winfsp-uninstaller.exe
         shell: pwsh
       - name: Create Wix Burn bundle
         working-directory: dist/win

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -409,7 +409,11 @@ jobs:
             }
           }
 
-          $expectedMachine = 0xAA64
+          $allowedMachines = @{
+            0xAA64 = 'ARM64'
+            0xA641 = 'ARM64EC'
+            0xA64E = 'ARM64X'
+          }
           $binaries = @(
             (Resolve-Path '.\appdir\Cryptomator\Cryptomator.exe').Path
           )
@@ -428,14 +432,14 @@ jobs:
 
           $mismatches = foreach ($binary in $binaries) {
             $machine = Get-PeMachineType $binary
-            if ($machine -ne $expectedMachine) {
+            if (-not $allowedMachines.ContainsKey([int] $machine)) {
               [pscustomobject]@{ Path = $binary; Machine = ('0x{0:X4}' -f $machine) }
             }
           }
 
           if ($mismatches) {
             $mismatches | Format-Table -AutoSize | Out-String | Write-Host
-            throw 'Detected non-arm64 generated payload binaries in the arm64 app-image lane.'
+            throw 'Detected non-Arm-compatible generated payload binaries in the arm64 app-image lane.'
           }
       - name: Sign DLLs with Azure Trusted Signing
         if: inputs.sign || github.event_name == 'schedule'

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -551,6 +551,15 @@ jobs:
           mkdir -p tmp/msi-helper-output tmp/msi-helper-build
           ${JAVA_HOME}/bin/jpackage --type msi --win-upgrade-uuid "${{ env.X64_MSI_UPGRADE_UUID }}" --app-image appdir/Cryptomator --dest tmp/msi-helper-output --name Test --vendor Test --copyright "None" --app-version "1.0" --temp tmp/msi-helper-build
           find ./tmp/msi-helper-build/ -type f -name msica.dll -exec mv {} ./appdir \;
+      - name: Sign MSI helper DLL with Azure Trusted Signing
+        if: inputs.sign || github.event_name == 'schedule'
+        uses: ./.github/actions/win-sign-action
+        with:
+          base-dir: ${{ github.workspace }}\appdir
+          file-extensions: dll
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
       - name: Create MSI
         run: >
           ${JAVA_HOME}/bin/jpackage
@@ -673,6 +682,15 @@ jobs:
           mkdir -p tmp/msi-helper-output tmp/msi-helper-build
           ${JAVA_HOME}/bin/jpackage --type msi --win-upgrade-uuid "${{ env.ARM64_MSI_UPGRADE_UUID }}" --app-image appdir/Cryptomator --dest tmp/msi-helper-output --name Test --vendor Test --copyright "None" --app-version "1.0" --temp tmp/msi-helper-build
           find ./tmp/msi-helper-build/ -type f -name msica.dll -exec mv {} ./appdir \;
+      - name: Sign MSI helper DLL with Azure Trusted Signing
+        if: inputs.sign || github.event_name == 'schedule'
+        uses: ./.github/actions/win-sign-action
+        with:
+          base-dir: ${{ github.workspace }}\appdir
+          file-extensions: dll
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
       - name: Create MSI
         run: >
           ${JAVA_HOME}/bin/jpackage

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -189,7 +189,7 @@ jobs:
           --resource-dir dist/win/resources
           --icon dist/win/resources/Cryptomator.ico
           --add-launcher "Cryptomator (Debug)=dist/win/debug-launcher.properties"
-      - name: Patch Application Directory
+      - name: Patch Application Directory without x64-only dispatcher
         run: |
           cp dist/win/contrib/* appdir/Cryptomator
       - name: Fix permissions
@@ -377,6 +377,18 @@ jobs:
               }
               $jar.Dispose()
           }
+      - name: Patch Application Directory
+        shell: pwsh
+        run: |
+          $destination = (Resolve-Path '.\appdir\Cryptomator').Path
+          Get-ChildItem '.\dist\win\contrib' -File |
+            Where-Object Name -ne 'jnidispatch.dll' |
+            Copy-Item -Destination $destination
+      - name: Fix permissions
+        run: |
+          attrib -r appdir/Cryptomator/Cryptomator.exe
+          attrib -r "appdir/Cryptomator/Cryptomator (Debug).exe"
+        shell: pwsh
       - name: Assert generated arm64 payload machine types
         shell: pwsh
         run: |
@@ -397,9 +409,12 @@ jobs:
           $binaries = @(
             (Resolve-Path '.\appdir\Cryptomator\Cryptomator.exe').Path
           )
+          $binaries += Get-ChildItem '.\appdir\Cryptomator\*' -Include *.dll,*.exe -File | ForEach-Object FullName
           $binaries += Get-ChildItem '.\appdir\Cryptomator\runtime' -Recurse -Include *.dll,*.exe -File | ForEach-Object FullName
           if (Test-Path '.\appdir\jar-extract') {
-            $binaries += Get-ChildItem '.\appdir\jar-extract' -Recurse -Include *.dll,*.exe -File | ForEach-Object FullName
+            $binaries += Get-ChildItem '.\appdir\jar-extract' -Recurse -Include *.dll,*.exe -File |
+              Where-Object FullName -Match '(?i)([\\/]|-)(aarch64|arm64)([\\/]|[.-])' |
+              ForEach-Object FullName
           }
           $binaries = $binaries | Sort-Object -Unique
 
@@ -418,14 +433,6 @@ jobs:
             $mismatches | Format-Table -AutoSize | Out-String | Write-Host
             throw 'Detected non-arm64 generated payload binaries in the arm64 app-image lane.'
           }
-      - name: Patch Application Directory
-        run: |
-          cp dist/win/contrib/* appdir/Cryptomator
-      - name: Fix permissions
-        run: |
-          attrib -r appdir/Cryptomator/Cryptomator.exe
-          attrib -r "appdir/Cryptomator/Cryptomator (Debug).exe"
-        shell: pwsh
       - name: Sign DLLs with Azure Trusted Signing
         if: inputs.sign || github.event_name == 'schedule'
         uses: ./.github/actions/win-sign-action

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -134,7 +134,7 @@ jobs:
         id: jep-493-check
         run: |
           JMOD_PATHS="openjfx-jmods"
-          if ! $(${JAVA_HOME}/bin/jlink --help | grep -q "Linking from run-time image enabled"); then
+          if ! "${JAVA_HOME}/bin/jlink" --help | grep -q "Linking from run-time image enabled"; then
             JMOD_PATHS="${JAVA_HOME}/jmods;${JMOD_PATHS}"
           fi
           echo "jmod_paths=${JMOD_PATHS}" >> "$GITHUB_OUTPUT"
@@ -311,7 +311,7 @@ jobs:
         id: jep-493-check
         run: |
           JMOD_PATHS="${JAVA_HOME}/jmods"
-          if ! $(${JAVA_HOME}/bin/jlink --help | grep -q "Linking from run-time image enabled"); then
+          if ! "${JAVA_HOME}/bin/jlink" --help | grep -q "Linking from run-time image enabled"; then
             JMOD_PATHS="${JAVA_HOME}/jmods;${JMOD_PATHS}"
           fi
           echo "jmod_paths=${JMOD_PATHS}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -206,11 +206,15 @@ jobs:
 
           Get-ChildItem -Path $jarFolder -Filter "*.jar" | ForEach-Object {
               $jar = [Io.compression.zipfile]::OpenRead($_.FullName)
-              if (@($jar.Entries | Where-Object {$_.Name.ToString().EndsWith(".dll")} | Select-Object -First 1).Count -gt 0) {
+              try {
+                  $containsDll = @($jar.Entries | Where-Object {$_.Name.ToString().EndsWith(".dll")} | Select-Object -First 1).Count -gt 0
+              } finally {
+                  $jar.Dispose()
+              }
+              if ($containsDll) {
                   $jarDestination = Join-Path $jarExtractDir $_.BaseName
                   Expand-Archive -LiteralPath $_.FullName -DestinationPath $jarDestination
               }
-              $jar.Dispose()
           }
       - name: Sign DLLs with Azure Trusted Signing
         if: inputs.sign || github.event_name == 'schedule'
@@ -371,11 +375,15 @@ jobs:
 
           Get-ChildItem -Path $jarFolder -Filter "*.jar" | ForEach-Object {
               $jar = [Io.compression.zipfile]::OpenRead($_.FullName)
-              if (@($jar.Entries | Where-Object {$_.Name.ToString().EndsWith(".dll")} | Select-Object -First 1).Count -gt 0) {
+              try {
+                  $containsDll = @($jar.Entries | Where-Object {$_.Name.ToString().EndsWith(".dll")} | Select-Object -First 1).Count -gt 0
+              } finally {
+                  $jar.Dispose()
+              }
+              if ($containsDll) {
                   $jarDestination = Join-Path $jarExtractDir $_.BaseName
                   Expand-Archive -LiteralPath $_.FullName -DestinationPath $jarDestination
               }
-              $jar.Dispose()
           }
       - name: Patch Application Directory without x64-only dispatcher
         shell: pwsh

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -189,7 +189,7 @@ jobs:
           --resource-dir dist/win/resources
           --icon dist/win/resources/Cryptomator.ico
           --add-launcher "Cryptomator (Debug)=dist/win/debug-launcher.properties"
-      - name: Patch Application Directory without x64-only dispatcher
+      - name: Patch Application Directory
         run: |
           cp dist/win/contrib/* appdir/Cryptomator
       - name: Fix permissions
@@ -207,8 +207,8 @@ jobs:
           Get-ChildItem -Path $jarFolder -Filter "*.jar" | ForEach-Object {
               $jar = [Io.compression.zipfile]::OpenRead($_.FullName)
               if (@($jar.Entries | Where-Object {$_.Name.ToString().EndsWith(".dll")} | Select-Object -First 1).Count -gt 0) {
-                  Set-Location $jarExtractDir
-                  Expand-Archive -Path $_.FullName
+                  $jarDestination = Join-Path $jarExtractDir $_.BaseName
+                  Expand-Archive -LiteralPath $_.FullName -DestinationPath $jarDestination
               }
               $jar.Dispose()
           }
@@ -372,12 +372,12 @@ jobs:
           Get-ChildItem -Path $jarFolder -Filter "*.jar" | ForEach-Object {
               $jar = [Io.compression.zipfile]::OpenRead($_.FullName)
               if (@($jar.Entries | Where-Object {$_.Name.ToString().EndsWith(".dll")} | Select-Object -First 1).Count -gt 0) {
-                  Set-Location $jarExtractDir
-                  Expand-Archive -Path $_.FullName
+                  $jarDestination = Join-Path $jarExtractDir $_.BaseName
+                  Expand-Archive -LiteralPath $_.FullName -DestinationPath $jarDestination
               }
               $jar.Dispose()
           }
-      - name: Patch Application Directory
+      - name: Patch Application Directory without x64-only dispatcher
         shell: pwsh
         run: |
           $destination = (Resolve-Path '.\appdir\Cryptomator').Path

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -26,11 +26,23 @@ on:
         default: true
     outputs:
       sha256-msi:
-        description: "SHA256 sum of the x64 msi"
-        value: ${{ jobs.build-msi.outputs.sha256sum}}
+        description: 'SHA256 sum of the x64 msi'
+        value: ${{ jobs.build-msi-x64.outputs.sha256sum }}
       sha256-exe:
-        description: "SHA256 sum of the x64 exe"
-        value: ${{ jobs.build-exe.outputs.sha256sum}}
+        description: 'SHA256 sum of the x64 exe'
+        value: ${{ jobs.build-exe-x64.outputs.sha256sum }}
+      sha256-msi-x64:
+        description: 'SHA256 sum of the x64 msi'
+        value: ${{ jobs.build-msi-x64.outputs.sha256sum }}
+      sha256-msi-arm64:
+        description: 'SHA256 sum of the arm64 msi'
+        value: ${{ jobs.build-msi-arm64.outputs.sha256sum }}
+      sha256-exe-x64:
+        description: 'SHA256 sum of the x64 exe'
+        value: ${{ jobs.build-exe-x64.outputs.sha256sum }}
+      sha256-exe-arm64:
+        description: 'SHA256 sum of the arm64 exe'
+        value: ${{ jobs.build-exe-arm64.outputs.sha256sum }}
   workflow_dispatch:
     inputs:
       semVerNum:
@@ -55,66 +67,49 @@ on:
       - '.github/workflows/win-exe.yml'
       - 'dist/win/**'
 
-
 env:
-  VERSION_NUM: ${{ inputs.semVerNum || '99.99.99'}}
+  VERSION_NUM: ${{ inputs.semVerNum || '99.99.99' }}
   REVISION_NUM: ${{ inputs.revisionNum || '0' }}
-  VERSION_SUFFIX: ${{ inputs.semVerSuffix || ''}}
+  VERSION_SUFFIX: ${{ inputs.semVerSuffix || '' }}
   OPENJFX_JMODS_AMD64: 'https://download2.gluonhq.com/openjfx/25.0.3/openjfx-25.0.3_windows-x64_bin-jmods.zip'
   OPENJFX_JMODS_AMD64_HASH: '0bf9b83260b85607a9ba200124debabd9cdb013cbc0d659e62a20192a7137907'
   WINFSP_MSI: 'https://github.com/winfsp/winfsp/releases/download/v2.1/winfsp-2.1.25156.msi'
   WINFSP_MSI_HASH: '073a70e00f77423e34bed98b86e600def93393ba5822204fac57a29324db9f7a'
   WINFSP_UNINSTALLER: 'https://github.com/cryptomator/winfsp-uninstaller/releases/latest/download/winfsp-uninstaller.exe'
   WIX_VERSION: '6.0.2'
+  X64_MSI_UPGRADE_UUID: 'bda45523-42b1-4cae-9354-a45475ed4775'
+  ARM64_MSI_UPGRADE_UUID: 'e9698066-1f20-4723-b33f-80a42be3db29'
+  X64_BUNDLE_UPGRADE_CODE: '29eea626-2e5b-4449-b5f8-4602925ddf7b'
+  ARM64_BUNDLE_UPGRADE_CODE: '070b3234-eaf9-4294-ba31-78a0e2f0a6be'
 
 defaults:
   run:
     shell: bash
 
 jobs:
-  build-msi:
-    name: Build .msi Installer
-    runs-on: ${{ matrix.os }}
-    outputs:
-      sha256sum: ${{ steps.sha256sum.outputs.value }}
-    strategy:
-      matrix:
-        include:
-          - arch: x64
-            os: windows-latest
-            java-dist: 'temurin'
-            java-version: '26.0.1+8'
-            java-package: 'jdk'
+  build-appimage-x64:
+    name: Build Windows app-image (x64)
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Java
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
-          distribution: ${{ matrix.java-dist }}
-          java-version: ${{ matrix.java-version }}
-          java-package: ${{ matrix.java-package }}
+          distribution: temurin
+          java-version: '26.0.1+8'
+          java-package: jdk
           check-latest: true
-          cache: 'maven'
-      - name: Install wix and extensions
-        run: |
-          dotnet tool install --global wix --version ${WIX_VERSION}
-          wix.exe extension add --global WixToolset.UI.wixext/${WIX_VERSION}
-          wix.exe extension add --global WixToolset.Util.wixext/${WIX_VERSION}
-        env:
-          WIX_VERSION: ${{ env.WIX_VERSION }}
+          cache: maven
       - name: Download and extract JavaFX jmods from Gluon
-        if: matrix.arch == 'x64'
-        #In the last step we move all jmods files a dir level up because jmods are placed inside a directory in the zip
         run: |
           curl --silent --fail-with-body --proto "=https" -L "${{ env.OPENJFX_JMODS_AMD64 }}" --output openjfx-jmods.zip
           if(!(Get-FileHash -Path openjfx-jmods.zip -Algorithm SHA256).Hash.ToLower().equals("${{ env.OPENJFX_JMODS_AMD64_HASH }}")) {
-            throw "Wrong checksum of JMOD archive downloaded from ${{ env.OPENJFX_JMODS_AMD64 }}.";
+            throw "Wrong checksum of JMOD archive downloaded from ${{ env.OPENJFX_JMODS_AMD64 }}."
           }
           Expand-Archive -Path openjfx-jmods.zip -DestinationPath openjfx-jmods
-          Get-ChildItem -Path openjfx-jmods -Recurse -Filter "*.jmod" | ForEach-Object { Move-Item -Path $_ -Destination $_.Directory.Parent}
+          Get-ChildItem -Path openjfx-jmods -Recurse -Filter "*.jmod" | ForEach-Object { Move-Item -Path $_ -Destination $_.Directory.Parent }
         shell: pwsh
       - name: Ensure major jfx version in pom and in jmods is the same
-        if: matrix.arch == 'x64'
         run: |
           JMOD_VERSION_AMD64=$(jmod describe openjfx-jmods/javafx.base.jmod | head -1)
           JMOD_VERSION_AMD64=${JMOD_VERSION_AMD64#*@}
@@ -123,7 +118,7 @@ jobs:
           POM_JFX_VERSION=${POM_JFX_VERSION#*@}
           POM_JFX_VERSION=${POM_JFX_VERSION%%.*}
 
-          if [ $POM_JFX_VERSION -ne $JMOD_VERSION_AMD64 ]; then
+          if [ "$POM_JFX_VERSION" -ne "$JMOD_VERSION_AMD64" ]; then
             >&2 echo "Major JavaFX version in pom.xml (${POM_JFX_VERSION}) != amd64 jmod version (${JMOD_VERSION_AMD64})"
             exit 1
           fi
@@ -144,7 +139,6 @@ jobs:
           fi
           echo "jmod_paths=${JMOD_PATHS}" >> "$GITHUB_OUTPUT"
       - name: Run jlink
-        # Remark: no compression is applied for improved build compression later (here msi)
         run: >
           ${JAVA_HOME}/bin/jlink
           --verbose
@@ -210,20 +204,14 @@ jobs:
           $jarFolder = Resolve-Path ".\appdir\Cryptomator\app\mods"
           $jarExtractDir = New-Item -Path ".\appdir\jar-extract" -ItemType Directory
 
-          #for all jars inspect
           Get-ChildItem -Path $jarFolder -Filter "*.jar" | ForEach-Object {
               $jar = [Io.compression.zipfile]::OpenRead($_.FullName)
               if (@($jar.Entries | Where-Object {$_.Name.ToString().EndsWith(".dll")} | Select-Object -First 1).Count -gt 0) {
-                  #jars containing dlls extract
                   Set-Location $jarExtractDir
                   Expand-Archive -Path $_.FullName
               }
               $jar.Dispose()
           }
-      - name: Get msi helper dll for code signing
-        run: |
-          ${JAVA_HOME}/bin/jpackage --type msi --win-upgrade-uuid bda45523-42b1-4cae-9354-a45475ed4775 --app-image appdir/Cryptomator --dest /tmp/ --name Test --vendor Test --copyright "None" --app-version "1.0" --temp msi-helper
-          find ./msi-helper/ -type f -name msica.dll -exec mv {} ./appdir \;
       - name: Sign DLLs with Azure Trusted Signing
         if: inputs.sign || github.event_name == 'schedule'
         uses: ./.github/actions/win-sign-action
@@ -242,7 +230,7 @@ jobs:
           base-dir: ${{ github.workspace }}\appdir\Cryptomator
           file-extensions: 'ps1'
           recursive: false
-          append-signature: false  # Powershell scripts cannot be signed in append mode, see #4260
+          append-signature: false
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
@@ -255,11 +243,273 @@ jobs:
               $jarName = $_.Name
               $jarFile = "${jarFolder}\${jarName}.jar"
               Set-Location $_
-              Get-ChildItem -Path $_ -Recurse -File "*.dll" | ForEach-Object {
-                  # update jar with signed dll
+              Get-ChildItem -Path $_ -Recurse -File -Filter "*.dll" | ForEach-Object {
                   jar --file="$jarFile" --update $(Resolve-Path -Relative -Path $_)
               }
           }
+      - name: Assert app-image output exists
+        shell: pwsh
+        run: |
+          $expected = Resolve-Path '.\appdir\Cryptomator' -ErrorAction Stop
+          if (-not (Test-Path '.\appdir\Cryptomator\Cryptomator.exe')) {
+            throw 'Expected x64 app-image executable appdir\Cryptomator\Cryptomator.exe was not created.'
+          }
+          Write-Host "App-image ready at $expected"
+      - name: Upload app-image artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: appimage-x64
+          path: appdir/Cryptomator
+          if-no-files-found: error
+
+  build-appimage-arm64:
+    name: Build Windows app-image (arm64)
+    runs-on: windows-11-arm
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Setup Java
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
+        with:
+          distribution: liberica
+          java-version: '26.0.1+8'
+          java-package: jdk+fx
+          check-latest: true
+          cache: maven
+      - name: Ensure JavaFX jmods are available in JAVA_HOME
+        shell: pwsh
+        run: |
+          $javaFxBaseJmod = Join-Path $env:JAVA_HOME 'jmods\javafx.base.jmod'
+          if (-not (Test-Path $javaFxBaseJmod)) {
+            throw "JavaFX module not found in JDK at $javaFxBaseJmod."
+          }
+      - name: Ensure major jfx version in pom and JAVA_HOME is the same
+        run: |
+          JMOD_VERSION_ARM64=$(jmod describe "${JAVA_HOME}/jmods/javafx.base.jmod" | head -1)
+          JMOD_VERSION_ARM64=${JMOD_VERSION_ARM64#*@}
+          JMOD_VERSION_ARM64=${JMOD_VERSION_ARM64%%.*}
+          POM_JFX_VERSION=$(./mvnw help:evaluate "-Dexpression=javafx.version" -q -DforceStdout)
+          POM_JFX_VERSION=${POM_JFX_VERSION#*@}
+          POM_JFX_VERSION=${POM_JFX_VERSION%%.*}
+
+          if [ "$POM_JFX_VERSION" -ne "$JMOD_VERSION_ARM64" ]; then
+            >&2 echo "Major JavaFX version in pom.xml (${POM_JFX_VERSION}) != arm64 jmod version (${JMOD_VERSION_ARM64})"
+            exit 1
+          fi
+      - name: Set version
+        run: ./mvnw versions:set -DnewVersion="${VERSION_NUM}${VERSION_SUFFIX}"
+      - name: Run maven
+        run: ./mvnw -B clean package -Pwin -DskipTests
+      - name: Patch target dir
+        run: |
+          cp LICENSE.txt target
+          cp target/cryptomator-*.jar target/mods
+      - name: Run jlink with help option
+        id: jep-493-check
+        run: |
+          JMOD_PATHS="${JAVA_HOME}/jmods"
+          if ! $(${JAVA_HOME}/bin/jlink --help | grep -q "Linking from run-time image enabled"); then
+            JMOD_PATHS="${JAVA_HOME}/jmods;${JMOD_PATHS}"
+          fi
+          echo "jmod_paths=${JMOD_PATHS}" >> "$GITHUB_OUTPUT"
+      - name: Run jlink
+        run: >
+          ${JAVA_HOME}/bin/jlink
+          --verbose
+          --output runtime
+          --module-path "${{ steps.jep-493-check.outputs.jmod_paths }}"
+          --add-modules java.base,java.desktop,java.instrument,java.logging,java.naming,java.net.http,java.scripting,java.sql,java.xml,javafx.base,javafx.graphics,javafx.controls,javafx.fxml,jdk.crypto.cryptoki,jdk.crypto.ec,jdk.crypto.mscapi,jdk.unsupported,jdk.accessibility,jdk.management.jfr,java.compiler
+          --strip-native-commands
+          --no-header-files
+          --no-man-pages
+          --strip-debug
+          --compress zip-0
+      - name: Run jpackage
+        run: >
+          ${JAVA_HOME}/bin/jpackage
+          --verbose
+          --type app-image
+          --runtime-image runtime
+          --input target/libs
+          --module-path target/mods
+          --module org.cryptomator.desktop/org.cryptomator.launcher.Cryptomator
+          --dest appdir
+          --name Cryptomator
+          --vendor "Skymatic GmbH"
+          --copyright "(C) 2016 - 2026 Skymatic GmbH"
+          --app-version "${VERSION_NUM}.${REVISION_NUM}"
+          --java-options "--enable-preview"
+          --java-options "--enable-native-access=javafx.graphics,org.cryptomator.jfuse.win,org.cryptomator.integrations.win"
+          --java-options "-Xss5m"
+          --java-options "-Xmx256m"
+          --java-options "-Dcryptomator.appVersion=\"${VERSION_NUM}${VERSION_SUFFIX}\""
+          --java-options "-Dfile.encoding=\"utf-8\""
+          --java-options "-Djava.net.useSystemProxies=true"
+          --java-options "-Dcryptomator.adminConfigPath=\"C:/ProgramData/Cryptomator/config.properties\""
+          --java-options "-Dcryptomator.logDir=\"@{localappdata}/Cryptomator\""
+          --java-options "-Dcryptomator.settingsPath=\"@{appdata}/Cryptomator/settings.json;@{userhome}/AppData/Roaming/Cryptomator/settings.json\""
+          --java-options "-Dcryptomator.p12Path=\"@{appdata}/Cryptomator/key.p12;@{userhome}/AppData/Roaming/Cryptomator/key.p12\""
+          --java-options "-Dcryptomator.ipcSocketPath=\"@{localappdata}/Cryptomator/ipc.socket\""
+          --java-options "-Dcryptomator.mountPointsDir=\"@{userhome}/Cryptomator\""
+          --java-options "-Dcryptomator.loopbackAlias=\"cryptomator-vault\""
+          --java-options "-Dcryptomator.showTrayIcon=true"
+          --java-options "-Dcryptomator.buildNumber=\"msi-${REVISION_NUM}\""
+          --java-options "-Dcryptomator.integrationsWin.autoStartShellLinkName=\"Cryptomator\""
+          --java-options "-Dcryptomator.integrationsWin.keychainPaths=\"@{appdata}/Cryptomator/keychain.json;@{userhome}/AppData/Roaming/Cryptomator/keychain.json\""
+          --java-options "-Dcryptomator.integrationsWin.windowsHelloKeychainPaths=\"@{appdata}/Cryptomator/windowsHelloKeychain.json\""
+          --java-options "-Dcryptomator.disableUpdateCheck=false"
+          --java-options "-XX:ErrorFile=C:/cryptomator/cryptomator_crash.log"
+          --java-options "-Dcryptomator.hub.enableTrustOnFirstUse=true"
+          --resource-dir dist/win/resources
+          --icon dist/win/resources/Cryptomator.ico
+          --add-launcher "Cryptomator (Debug)=dist/win/debug-launcher.properties"
+      - name: Extract jars with DLLs for inspection and signing
+        shell: pwsh
+        run: |
+          Add-Type -AssemblyName "System.io.compression.filesystem"
+          $jarFolder = Resolve-Path ".\appdir\Cryptomator\app\mods"
+          $jarExtractDir = New-Item -Path ".\appdir\jar-extract" -ItemType Directory
+
+          Get-ChildItem -Path $jarFolder -Filter "*.jar" | ForEach-Object {
+              $jar = [Io.compression.zipfile]::OpenRead($_.FullName)
+              if (@($jar.Entries | Where-Object {$_.Name.ToString().EndsWith(".dll")} | Select-Object -First 1).Count -gt 0) {
+                  Set-Location $jarExtractDir
+                  Expand-Archive -Path $_.FullName
+              }
+              $jar.Dispose()
+          }
+      - name: Assert generated arm64 payload machine types
+        shell: pwsh
+        run: |
+          function Get-PeMachineType([string]$Path) {
+            $stream = [System.IO.File]::OpenRead($Path)
+            try {
+              $reader = New-Object System.IO.BinaryReader($stream)
+              $stream.Seek(0x3C, [System.IO.SeekOrigin]::Begin) > $null
+              $peHeaderOffset = $reader.ReadInt32()
+              $stream.Seek($peHeaderOffset + 4, [System.IO.SeekOrigin]::Begin) > $null
+              return $reader.ReadUInt16()
+            } finally {
+              $stream.Dispose()
+            }
+          }
+
+          $expectedMachine = 0xAA64
+          $binaries = @(
+            (Resolve-Path '.\appdir\Cryptomator\Cryptomator.exe').Path
+          )
+          $binaries += Get-ChildItem '.\appdir\Cryptomator\runtime' -Recurse -Include *.dll,*.exe -File | ForEach-Object FullName
+          if (Test-Path '.\appdir\jar-extract') {
+            $binaries += Get-ChildItem '.\appdir\jar-extract' -Recurse -Include *.dll,*.exe -File | ForEach-Object FullName
+          }
+          $binaries = $binaries | Sort-Object -Unique
+
+          if ($binaries.Count -eq 0) {
+            throw 'No generated arm64 EXE/DLL payloads were found for validation.'
+          }
+
+          $mismatches = foreach ($binary in $binaries) {
+            $machine = Get-PeMachineType $binary
+            if ($machine -ne $expectedMachine) {
+              [pscustomobject]@{ Path = $binary; Machine = ('0x{0:X4}' -f $machine) }
+            }
+          }
+
+          if ($mismatches) {
+            $mismatches | Format-Table -AutoSize | Out-String | Write-Host
+            throw 'Detected non-arm64 generated payload binaries in the arm64 app-image lane.'
+          }
+      - name: Patch Application Directory
+        run: |
+          cp dist/win/contrib/* appdir/Cryptomator
+      - name: Fix permissions
+        run: |
+          attrib -r appdir/Cryptomator/Cryptomator.exe
+          attrib -r "appdir/Cryptomator/Cryptomator (Debug).exe"
+        shell: pwsh
+      - name: Sign DLLs with Azure Trusted Signing
+        if: inputs.sign || github.event_name == 'schedule'
+        uses: ./.github/actions/win-sign-action
+        with:
+          base-dir: ${{ github.workspace }}\appdir
+          file-extensions: 'exe,dll'
+          recursive: true
+          append-signature: true
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+      - name: Sign Scripts with Azure Trusted Signing
+        if: inputs.sign || github.event_name == 'schedule'
+        uses: ./.github/actions/win-sign-action
+        with:
+          base-dir: ${{ github.workspace }}\appdir\Cryptomator
+          file-extensions: 'ps1'
+          recursive: false
+          append-signature: false
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+      - name: Replace DLLs inside jars with signed ones
+        shell: pwsh
+        run: |
+          $jarExtractDir = Resolve-Path ".\appdir\jar-extract"
+          $jarFolder = Resolve-Path ".\appdir\Cryptomator\app\mods"
+          Get-ChildItem -Path $jarExtractDir | ForEach-Object {
+              $jarName = $_.Name
+              $jarFile = "${jarFolder}\${jarName}.jar"
+              Set-Location $_
+              Get-ChildItem -Path $_ -Recurse -File -Filter "*.dll" | ForEach-Object {
+                  jar --file="$jarFile" --update $(Resolve-Path -Relative -Path $_)
+              }
+          }
+      - name: Assert app-image output exists
+        shell: pwsh
+        run: |
+          $expected = Resolve-Path '.\appdir\Cryptomator' -ErrorAction Stop
+          if (-not (Test-Path '.\appdir\Cryptomator\Cryptomator.exe')) {
+            throw 'Expected arm64 app-image executable appdir\Cryptomator\Cryptomator.exe was not created.'
+          }
+          Write-Host "App-image ready at $expected"
+      - name: Upload app-image artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: appimage-arm64
+          path: appdir/Cryptomator
+          if-no-files-found: error
+
+  build-msi-x64:
+    name: Build .msi installer (x64)
+    runs-on: windows-latest
+    needs: [build-appimage-x64]
+    outputs:
+      sha256sum: ${{ steps.sha256sum.outputs.value }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Download app-image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: appimage-x64
+          path: appdir
+      - name: Assert downloaded app-image exists
+        shell: pwsh
+        run: |
+          if (-not (Test-Path '.\appdir\Cryptomator\Cryptomator.exe')) {
+            throw 'Expected downloaded x64 app-image artifact at appdir\Cryptomator\Cryptomator.exe.'
+          }
+      - name: Setup Java
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
+        with:
+          distribution: temurin
+          java-version: '26.0.1+8'
+          java-package: jdk
+          check-latest: true
+          cache: maven
+      - name: Install wix and extensions
+        run: |
+          dotnet tool install --global wix --version ${WIX_VERSION}
+          wix.exe extension add --global WixToolset.UI.wixext/${WIX_VERSION}
+          wix.exe extension add --global WixToolset.Util.wixext/${WIX_VERSION}
+        env:
+          WIX_VERSION: ${{ env.WIX_VERSION }}
       - name: Generate license for MSI
         run: >
           ./mvnw -B license:add-third-party
@@ -279,14 +529,19 @@ jobs:
             | ForEach-Object { $ExecutionContext.InvokeCommand.ExpandString($_) } `
             | Out-File -FilePath .\resources\FAvaultFile.properties
         env:
-          JP_WIXWIZARD_RESOURCES: ${{ github.workspace }}/dist/win/resources/ # requires abs path, used in resources/main.wxs
+          JP_WIXWIZARD_RESOURCES: ${{ github.workspace }}/dist/win/resources/
         shell: pwsh
+      - name: Get msi helper dll for code signing
+        run: |
+          mkdir -p tmp/msi-helper-output tmp/msi-helper-build
+          ${JAVA_HOME}/bin/jpackage --type msi --win-upgrade-uuid "${{ env.X64_MSI_UPGRADE_UUID }}" --app-image appdir/Cryptomator --dest tmp/msi-helper-output --name Test --vendor Test --copyright "None" --app-version "1.0" --temp tmp/msi-helper-build
+          find ./tmp/msi-helper-build/ -type f -name msica.dll -exec mv {} ./appdir \;
       - name: Create MSI
         run: >
           ${JAVA_HOME}/bin/jpackage
           --verbose
           --type msi
-          --win-upgrade-uuid bda45523-42b1-4cae-9354-a45475ed4775
+          --win-upgrade-uuid "${{ env.X64_MSI_UPGRADE_UUID }}"
           --app-image appdir/Cryptomator
           --dest installer
           --name Cryptomator
@@ -302,7 +557,7 @@ jobs:
           --license-file dist/win/resources/license.rtf
           --file-associations dist/win/resources/FAvaultFile.properties
         env:
-          JP_WIXWIZARD_RESOURCES: ${{ github.workspace }}/dist/win/resources/ # requires abs path, used in resources/main.wxs
+          JP_WIXWIZARD_RESOURCES: ${{ github.workspace }}/dist/win/resources/
           JP_WIXHELPER_DIR: ${{ github.workspace }}\appdir\
       - name: Sign MSI with Azure Trusted Signing
         if: inputs.sign || github.event_name == 'schedule'
@@ -319,7 +574,14 @@ jobs:
           read -ra CMD_OUTPUT < <(sha256sum installer/Cryptomator-*.msi)
           echo "value=${CMD_OUTPUT[0]}" >> $GITHUB_OUTPUT
       - name: Add possible alpha/beta tags and architecture to installer name
-        run: mv installer/Cryptomator-*.msi "Cryptomator-${VERSION_NUM}${VERSION_SUFFIX}-${{ matrix.arch }}.msi"
+        run: mv installer/Cryptomator-*.msi "Cryptomator-${VERSION_NUM}${VERSION_SUFFIX}-x64.msi"
+      - name: Assert MSI output exists
+        shell: pwsh
+        run: |
+          $artifact = ".\Cryptomator-$($env:VERSION_NUM)$($env:VERSION_SUFFIX)-x64.msi"
+          if (-not (Test-Path $artifact)) {
+            throw "Expected renamed x64 MSI artifact at $artifact."
+          }
       - name: Create detached GPG signature with key 615D449FE6E6A235
         run: |
           echo "${GPG_PRIVATE_KEY}" | gpg --batch --quiet --import
@@ -330,27 +592,140 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: msi-${{ matrix.arch }}
+          name: msi-x64
           path: |
             Cryptomator-*.msi
             Cryptomator-*.asc
           if-no-files-found: error
 
-  build-exe:
-    name: Build .exe installer
-    runs-on: ${{ matrix.os }}
-    needs: [ build-msi ]
+  build-msi-arm64:
+    name: Build .msi installer (arm64)
+    runs-on: windows-latest
+    needs: [build-appimage-arm64]
     outputs:
       sha256sum: ${{ steps.sha256sum.outputs.value }}
-    strategy:
-      matrix:
-        include:
-          - arch: x64
-            os: windows-latest
-            executable-suffix: x64
-            java-dist: 'temurin'
-            java-version: '26.0.1+8'
-            java-package: 'jdk'
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Download app-image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: appimage-arm64
+          path: appdir
+      - name: Assert downloaded app-image exists
+        shell: pwsh
+        run: |
+          if (-not (Test-Path '.\appdir\Cryptomator\Cryptomator.exe')) {
+            throw 'Expected downloaded arm64 app-image artifact at appdir\Cryptomator\Cryptomator.exe.'
+          }
+      - name: Setup Java
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
+        with:
+          distribution: temurin
+          java-version: '26.0.1+8'
+          java-package: jdk
+          check-latest: true
+          cache: maven
+      - name: Install wix and extensions
+        run: |
+          dotnet tool install --global wix --version ${WIX_VERSION}
+          wix.exe extension add --global WixToolset.UI.wixext/${WIX_VERSION}
+          wix.exe extension add --global WixToolset.Util.wixext/${WIX_VERSION}
+        env:
+          WIX_VERSION: ${{ env.WIX_VERSION }}
+      - name: Generate license for MSI
+        run: >
+          ./mvnw -B license:add-third-party
+          "-Dlicense.thirdPartyFilename=license.rtf"
+          "-Dlicense.outputDirectory=dist/win/resources"
+          "-Dlicense.fileTemplate=dist/win/resources/licenseTemplate.ftl"
+          "-Dlicense.includedScopes=compile"
+          "-Dlicense.excludedGroups=^org\.cryptomator"
+          "-Dlicense.failOnMissing=true"
+          "-Dlicense.licenseMergesUrl=file:///${{ github.workspace }}/license/merges"
+        shell: pwsh
+      - name: Create file association file from template
+        working-directory: dist/win
+        run: |
+          $Env:JP_WIXWIZARD_RESOURCES_PROPERTIES_FORMAT = "${Env:JP_WIXWIZARD_RESOURCES}".Replace('\', '\\');
+          Get-Content .\resources\FAvaultFile.template.properties `
+            | ForEach-Object { $ExecutionContext.InvokeCommand.ExpandString($_) } `
+            | Out-File -FilePath .\resources\FAvaultFile.properties
+        env:
+          JP_WIXWIZARD_RESOURCES: ${{ github.workspace }}/dist/win/resources/
+        shell: pwsh
+      - name: Get msi helper dll for code signing
+        run: |
+          mkdir -p tmp/msi-helper-output tmp/msi-helper-build
+          ${JAVA_HOME}/bin/jpackage --type msi --win-upgrade-uuid "${{ env.ARM64_MSI_UPGRADE_UUID }}" --app-image appdir/Cryptomator --dest tmp/msi-helper-output --name Test --vendor Test --copyright "None" --app-version "1.0" --temp tmp/msi-helper-build
+          find ./tmp/msi-helper-build/ -type f -name msica.dll -exec mv {} ./appdir \;
+      - name: Create MSI
+        run: >
+          ${JAVA_HOME}/bin/jpackage
+          --verbose
+          --type msi
+          --win-upgrade-uuid "${{ env.ARM64_MSI_UPGRADE_UUID }}"
+          --app-image appdir/Cryptomator
+          --dest installer
+          --name Cryptomator
+          --vendor "Skymatic GmbH"
+          --copyright "(C) 2016 - 2026 Skymatic GmbH"
+          --app-version "${VERSION_NUM}.${REVISION_NUM}"
+          --win-menu
+          --win-dir-chooser
+          --win-shortcut-prompt
+          --win-update-url "https://cryptomator.org/downloads"
+          --win-menu-group Cryptomator
+          --resource-dir dist/win/resources
+          --license-file dist/win/resources/license.rtf
+          --file-associations dist/win/resources/FAvaultFile.properties
+        env:
+          JP_WIXWIZARD_RESOURCES: ${{ github.workspace }}/dist/win/resources/
+          JP_WIXHELPER_DIR: ${{ github.workspace }}\appdir\
+      - name: Sign MSI with Azure Trusted Signing
+        if: inputs.sign || github.event_name == 'schedule'
+        uses: ./.github/actions/win-sign-action
+        with:
+          base-dir: ${{ github.workspace }}\installer
+          file-extensions: msi
+          description: 'Cryptomator Installer'
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+      - id: sha256sum
+        run: |
+          read -ra CMD_OUTPUT < <(sha256sum installer/Cryptomator-*.msi)
+          echo "value=${CMD_OUTPUT[0]}" >> $GITHUB_OUTPUT
+      - name: Add possible alpha/beta tags and architecture to installer name
+        run: mv installer/Cryptomator-*.msi "Cryptomator-${VERSION_NUM}${VERSION_SUFFIX}-arm64.msi"
+      - name: Assert MSI output exists
+        shell: pwsh
+        run: |
+          $artifact = ".\Cryptomator-$($env:VERSION_NUM)$($env:VERSION_SUFFIX)-arm64.msi"
+          if (-not (Test-Path $artifact)) {
+            throw "Expected renamed arm64 MSI artifact at $artifact."
+          }
+      - name: Create detached GPG signature with key 615D449FE6E6A235
+        run: |
+          echo "${GPG_PRIVATE_KEY}" | gpg --batch --quiet --import
+          echo "${GPG_PASSPHRASE}" | gpg --batch --quiet --passphrase-fd 0 --pinentry-mode loopback -u 615D449FE6E6A235 --detach-sign -a Cryptomator-*.msi
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.RELEASES_GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.RELEASES_GPG_PASSPHRASE }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: msi-arm64
+          path: |
+            Cryptomator-*.msi
+            Cryptomator-*.asc
+          if-no-files-found: error
+
+  build-exe-x64:
+    name: Build .exe installer (x64)
+    runs-on: windows-latest
+    needs: [build-msi-x64]
+    outputs:
+      sha256sum: ${{ steps.sha256sum.outputs.value }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install wix and extensions
@@ -363,18 +738,24 @@ jobs:
       - name: Download .msi
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: msi-${{ matrix.arch }}
+          name: msi-x64
           path: dist/win/bundle/resources
+      - name: Assert downloaded MSI exists
+        shell: pwsh
+        run: |
+          if (-not (Get-ChildItem '.\dist\win\bundle\resources' -Filter 'Cryptomator-*.msi' -File -ErrorAction SilentlyContinue)) {
+            throw 'Expected x64 MSI artifact in dist\win\bundle\resources.'
+          }
       - name: Strip version info from msi file name
         run: mv dist/win/bundle/resources/Cryptomator*.msi dist/win/bundle/resources/Cryptomator.msi
       - name: Setup Java
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
-          distribution: ${{ matrix.java-dist }}
-          java-version: ${{ matrix.java-version }}
-          java-package: ${{ matrix.java-package }}
+          distribution: temurin
+          java-version: '26.0.1+8'
+          java-package: jdk
           check-latest: true
-          cache: 'maven'
+          cache: maven
       - name: Generate license for exe
         run: >
           ./mvnw -B license:add-third-party
@@ -411,6 +792,8 @@ jobs:
           -define AboutUrl="https://cryptomator.org"
           -define HelpUrl="https://cryptomator.org/contact"
           -define UpdateUrl="https://cryptomator.org/downloads/"
+          -define BundleUpgradeCode="${{ env.X64_BUNDLE_UPGRADE_CODE }}"
+          -define BundleLaunchTarget="[ProgramFiles64Folder]\Cryptomator\Cryptomator.exe"
           -ext "WixToolset.Util.wixext"
           -ext "WixToolset.BootstrapperApplications.wixext"
           ./bundle/bundleWithWinfsp.wxs
@@ -452,7 +835,14 @@ jobs:
           read -ra CMD_OUTPUT < <(sha256sum installer/Cryptomator-*.exe)
           echo "value=${CMD_OUTPUT[0]}" >> $GITHUB_OUTPUT
       - name: Add possible alpha/beta tags to installer name
-        run: mv installer/Cryptomator-Installer.exe "Cryptomator-${VERSION_NUM}${VERSION_SUFFIX}-${{ matrix.executable-suffix }}.exe"
+        run: mv installer/Cryptomator-Installer.exe "Cryptomator-${VERSION_NUM}${VERSION_SUFFIX}-x64.exe"
+      - name: Assert EXE output exists
+        shell: pwsh
+        run: |
+          $artifact = ".\Cryptomator-$($env:VERSION_NUM)$($env:VERSION_SUFFIX)-x64.exe"
+          if (-not (Test-Path $artifact)) {
+            throw "Expected renamed x64 EXE artifact at $artifact."
+          }
       - name: Create detached GPG signature with key 615D449FE6E6A235
         run: |
           echo "${GPG_PRIVATE_KEY}" | gpg --batch --quiet --import
@@ -463,7 +853,145 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: exe-${{ matrix.executable-suffix }}
+          name: exe-x64
+          path: |
+            Cryptomator-*.exe
+            Cryptomator-*.asc
+          if-no-files-found: error
+
+  build-exe-arm64:
+    name: Build .exe installer (arm64)
+    runs-on: windows-latest
+    needs: [build-msi-arm64]
+    outputs:
+      sha256sum: ${{ steps.sha256sum.outputs.value }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Install wix and extensions
+        run: |
+          dotnet tool install --global wix --version ${WIX_VERSION}
+          wix.exe extension add --global WixToolset.BootstrapperApplications.wixext/${WIX_VERSION}
+          wix.exe extension add --global WixToolset.Util.wixext/${WIX_VERSION}
+        env:
+          WIX_VERSION: ${{ env.WIX_VERSION }}
+      - name: Download .msi
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: msi-arm64
+          path: dist/win/bundle/resources
+      - name: Assert downloaded MSI exists
+        shell: pwsh
+        run: |
+          if (-not (Get-ChildItem '.\dist\win\bundle\resources' -Filter 'Cryptomator-*.msi' -File -ErrorAction SilentlyContinue)) {
+            throw 'Expected arm64 MSI artifact in dist\win\bundle\resources.'
+          }
+      - name: Strip version info from msi file name
+        run: mv dist/win/bundle/resources/Cryptomator*.msi dist/win/bundle/resources/Cryptomator.msi
+      - name: Setup Java
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
+        with:
+          distribution: temurin
+          java-version: '26.0.1+8'
+          java-package: jdk
+          check-latest: true
+          cache: maven
+      - name: Generate license for exe
+        run: >
+          ./mvnw -B license:add-third-party
+          "-Dlicense.thirdPartyFilename=license.rtf"
+          "-Dlicense.fileTemplate=dist/win/bundle/resources/licenseTemplate.ftl"
+          "-Dlicense.outputDirectory=dist/win/bundle/resources"
+          "-Dlicense.includedScopes=compile"
+          "-Dlicense.excludedGroups=^org\.cryptomator"
+          "-Dlicense.failOnMissing=true"
+          "-Dlicense.licenseMergesUrl=file:///${{ github.workspace }}/license/merges"
+        shell: pwsh
+      - name: Download WinFsp
+        run: |
+          curl --silent --fail-with-body --proto "=https" -L "$env:WINFSP_MSI" --output $env:WINFSP_PATH
+          $computedHash = (Get-FileHash -Path "$env:WINFSP_PATH" -Algorithm SHA256).Hash.ToLower()
+          if ($computedHash -ne "$env:WINFSP_MSI_HASH") {
+            throw "Checksum mismatch for ${env:WINFSP_PATH} (expected ${env:WINFSP_MSI_HASH}, got $computedHash)."
+          }
+        env:
+          WINFSP_PATH: 'dist/win/bundle/resources/winfsp.msi'
+        shell: pwsh
+      - name: Download Legacy-WinFsp uninstaller
+        run: |
+          curl --silent --fail-with-body --proto "=https" -L ${{ env.WINFSP_UNINSTALLER }} --output dist/win/bundle/resources/winfsp-uninstaller.exe
+        shell: pwsh
+      - name: Create Wix Burn bundle
+        working-directory: dist/win
+        run: >
+          wix build
+          -define BundleName="Cryptomator"
+          -define BundleVersion="${VERSION_NUM}.${REVISION_NUM}"
+          -define BundleVendor="Skymatic GmbH"
+          -define BundleCopyright="(C) 2016 - 2026 Skymatic GmbH"
+          -define AboutUrl="https://cryptomator.org"
+          -define HelpUrl="https://cryptomator.org/contact"
+          -define UpdateUrl="https://cryptomator.org/downloads/"
+          -define BundleUpgradeCode="${{ env.ARM64_BUNDLE_UPGRADE_CODE }}"
+          -ext "WixToolset.Util.wixext"
+          -ext "WixToolset.BootstrapperApplications.wixext"
+          ./bundle/bundleWithWinfsp.wxs
+          -out "../../installer/Cryptomator-Installer.exe"
+      - name: Detach burn engine in preparation to sign
+        if: inputs.sign || github.event_name == 'schedule'
+        run: >
+          wix burn detach installer/Cryptomator-Installer.exe -engine tmp/engine.exe
+      - name: Sign WiX burn engine with Azure Trusted Signing
+        if: inputs.sign || github.event_name == 'schedule'
+        uses: ./.github/actions/win-sign-action
+        with:
+          base-dir: ${{ github.workspace }}\tmp
+          file-extensions: exe
+          append-signature: true
+          description: 'Cryptomator Bundle Installer'
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+      - name: Reattach signed burn engine to installer
+        if: inputs.sign || github.event_name == 'schedule'
+        shell: pwsh
+        run: |
+          Move-Item -Path installer/Cryptomator-Installer.exe -Destination tmp/Cryptomator-Installer.exe
+          wix burn reattach tmp/Cryptomator-Installer.exe -engine tmp/engine.exe -o installer/Cryptomator-Installer.exe
+      - name: Sign EXE installer with Azure Trusted Signing
+        if: inputs.sign || github.event_name == 'schedule'
+        uses: ./.github/actions/win-sign-action
+        with:
+          base-dir: ${{ github.workspace }}\installer
+          file-extensions: exe
+          append-signature: true
+          description: 'Cryptomator Bundle Installer'
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+      - id: sha256sum
+        run: |
+          read -ra CMD_OUTPUT < <(sha256sum installer/Cryptomator-*.exe)
+          echo "value=${CMD_OUTPUT[0]}" >> $GITHUB_OUTPUT
+      - name: Add possible alpha/beta tags to installer name
+        run: mv installer/Cryptomator-Installer.exe "Cryptomator-${VERSION_NUM}${VERSION_SUFFIX}-arm64.exe"
+      - name: Assert EXE output exists
+        shell: pwsh
+        run: |
+          $artifact = ".\Cryptomator-$($env:VERSION_NUM)$($env:VERSION_SUFFIX)-arm64.exe"
+          if (-not (Test-Path $artifact)) {
+            throw "Expected renamed arm64 EXE artifact at $artifact."
+          }
+      - name: Create detached GPG signature with key 615D449FE6E6A235
+        run: |
+          echo "${GPG_PRIVATE_KEY}" | gpg --batch --quiet --import
+          echo "${GPG_PASSPHRASE}" | gpg --batch --quiet --passphrase-fd 0 --pinentry-mode loopback -u 615D449FE6E6A235 --detach-sign -a Cryptomator-*.exe
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.RELEASES_GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.RELEASES_GPG_PASSPHRASE }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: exe-arm64
           path: |
             Cryptomator-*.exe
             Cryptomator-*.asc
@@ -473,12 +1001,19 @@ jobs:
     name: Publish installers to the github release
     if: inputs.upload-to-draft
     runs-on: ubuntu-latest
-    needs: [ build-msi, build-exe ]
+    needs: [build-msi-x64, build-msi-arm64, build-exe-x64, build-exe-arm64]
     steps:
       - name: Download installers
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           merge-multiple: true
+      - name: Assert expected installer files exist
+        run: |
+          ls -1
+          test -f "Cryptomator-${VERSION_NUM}${VERSION_SUFFIX}-x64.msi"
+          test -f "Cryptomator-${VERSION_NUM}${VERSION_SUFFIX}-arm64.msi"
+          test -f "Cryptomator-${VERSION_NUM}${VERSION_SUFFIX}-x64.exe"
+          test -f "Cryptomator-${VERSION_NUM}${VERSION_SUFFIX}-arm64.exe"
       - name: Publish installers on GitHub Releases
         id: publish
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
@@ -488,5 +1023,7 @@ jobs:
           token: ${{ secrets.CRYPTOBOT_RELEASE_TOKEN }}
           files: |
             *x64.msi
+            *arm64.msi
             *x64.exe
+            *arm64.exe
             *.asc

--- a/.github/workflows/win-exe.yml
+++ b/.github/workflows/win-exe.yml
@@ -307,14 +307,10 @@ jobs:
         run: |
           cp LICENSE.txt target
           cp target/cryptomator-*.jar target/mods
-      - name: Run jlink with help option
+      - name: Set jlink module path
         id: jep-493-check
         run: |
-          JMOD_PATHS="${JAVA_HOME}/jmods"
-          if ! "${JAVA_HOME}/bin/jlink" --help | grep -q "Linking from run-time image enabled"; then
-            JMOD_PATHS="${JAVA_HOME}/jmods;${JMOD_PATHS}"
-          fi
-          echo "jmod_paths=${JMOD_PATHS}" >> "$GITHUB_OUTPUT"
+          echo "jmod_paths=${JAVA_HOME}/jmods" >> "$GITHUB_OUTPUT"
       - name: Run jlink
         run: >
           ${JAVA_HOME}/bin/jlink

--- a/dist/win/build.ps1
+++ b/dist/win/build.ps1
@@ -15,6 +15,8 @@ Param(
 	[bool] $clean = $false # if true, cleans up previous build artifacts
 )
 
+$ErrorActionPreference = 'Stop'
+
 # ============================
 # Function Definitions Section
 # ============================
@@ -24,6 +26,10 @@ function Invoke-CommandWithExitCheck {
 		[string]$Command,
 		[string[]]$Arguments
 	)
+
+	if ((Get-Command $Command -ErrorAction SilentlyContinue) -eq $null) {
+		throw "Unable to find required command '$Command'."
+	}
 
 	& $Command @Arguments
 	if ($LASTEXITCODE -ne 0) {

--- a/dist/win/build.ps1
+++ b/dist/win/build.ps1
@@ -134,12 +134,18 @@ switch ($archName) {
     }
 }
 
-if (-not $PSBoundParameters.ContainsKey('BundleUpgradeCode')) {
+if ([string]::IsNullOrWhiteSpace($BundleUpgradeCode)) {
 	$BundleUpgradeCode = switch ($archName) {
 		'ARM64' { '070b3234-eaf9-4294-ba31-78a0e2f0a6be' }
 		default { '29eea626-2e5b-4449-b5f8-4602925ddf7b' }
 	}
 }
+$parsedBundleUpgradeCode = [guid]::Empty
+if (-not [guid]::TryParse($BundleUpgradeCode, [ref] $parsedBundleUpgradeCode) -or $parsedBundleUpgradeCode -eq [guid]::Empty) {
+	Write-Error "BundleUpgradeCode must be a non-empty GUID. Received: '$BundleUpgradeCode'"
+	exit 1
+}
+$BundleUpgradeCode = $parsedBundleUpgradeCode.ToString()
 if (-not $PSBoundParameters.ContainsKey('BundleLaunchTarget') -and $archName -eq 'x64') {
 	$BundleLaunchTarget = "[ProgramFiles64Folder]\$AppName\$AppName.exe"
 }
@@ -215,7 +221,7 @@ $javaOptions = @(
 
 if ($LASTEXITCODE -ne 0) {
     Write-Error "jpackage Appimage failed with exit code $LASTEXITCODE"
-	return 1;
+	exit $LASTEXITCODE
 }
 
 #Create RTF license for msi
@@ -265,7 +271,7 @@ Invoke-CommandWithExitCheck -Command `
 $msiHelperDll = Get-ChildItem -Path $msiHelperBuildDir -Recurse -Filter "msica.dll" | Select-Object -First 1
 if (-not $msiHelperDll) {
 	Write-Error "Unable to find msica.dll in $msiHelperBuildDir"
-	return 1
+	exit 1
 }
 Copy-Item -Path $msiHelperDll.FullName -Destination ".\msica.dll" -Force
 $Env:JP_WIXWIZARD_RESOURCES = "$buildDir\resources\"
@@ -374,4 +380,5 @@ if ($clean) {
 	Remove-Item -Path ".\$AppName" -Force -Recurse -ErrorAction Ignore -ProgressAction SilentlyContinue
 	Remove-Item -Path ".\installer" -Force -Recurse -ErrorAction Ignore -ProgressAction SilentlyContinue
 }
-return Main
+Main
+exit 0

--- a/dist/win/build.ps1
+++ b/dist/win/build.ps1
@@ -230,7 +230,14 @@ Invoke-CommandWithExitCheck -Command `
     "-Dlicense.licenseMergesUrl=file:///$buildDir/../../license/merges")
 
 # patch app dir
-Copy-Item "contrib\*" -Destination "$AppName"
+if ($archName -eq 'ARM64') {
+	# The checked-in JNA dispatcher is x64-only and must not enter the Arm64 payload.
+	Get-ChildItem "contrib\*" -File |
+		Where-Object Name -ne 'jnidispatch.dll' |
+		Copy-Item -Destination "$AppName"
+} else {
+	Copy-Item "contrib\*" -Destination "$AppName"
+}
 attrib -r "$AppName\$AppName.exe"
 attrib -r "$AppName\${AppName} (Debug).exe"
 

--- a/dist/win/build.ps1
+++ b/dist/win/build.ps1
@@ -9,6 +9,9 @@ Param(
 	[Parameter(Mandatory, HelpMessage="Please provide an update url")][string] $UpdateUrl,
 	[Parameter(Mandatory, HelpMessage="Please provide an about url")][string] $AboutUrl,
 	[Parameter(Mandatory, HelpMessage="Please provide an alias for localhost")][string] $LoopbackAlias,
+	[ValidateSet('All', 'AppImage', 'Msi')][string] $BuildStage = 'All',
+	[string] $BundleUpgradeCode,
+	[string] $BundleLaunchTarget,
 	[bool] $clean = $false # if true, cleans up previous build artifacts
 )
 
@@ -126,9 +129,19 @@ switch ($archName) {
 		$jmodPaths="$buildDir/resources/javafx-jmods";
     }
     default {
-        Write-Error "Unsupported architecture: $arch"
+        Write-Error "Unsupported architecture: $archName"
         exit 1
     }
+}
+
+if (-not $PSBoundParameters.ContainsKey('BundleUpgradeCode')) {
+	$BundleUpgradeCode = switch ($archName) {
+		'ARM64' { '070b3234-eaf9-4294-ba31-78a0e2f0a6be' }
+		default { '29eea626-2e5b-4449-b5f8-4602925ddf7b' }
+	}
+}
+if (-not $PSBoundParameters.ContainsKey('BundleLaunchTarget') -and $archName -eq 'x64') {
+	$BundleLaunchTarget = "[ProgramFiles64Folder]\$AppName\$AppName.exe"
 }
 
 ## create custom runtime
@@ -221,10 +234,36 @@ Copy-Item "contrib\*" -Destination "$AppName"
 attrib -r "$AppName\$AppName.exe"
 attrib -r "$AppName\${AppName} (Debug).exe"
 
+if ($BuildStage -eq 'AppImage') {
+	Write-Host "BuildStage AppImage requested; skipping MSI and EXE bundle creation."
+	return 0
+}
+
 # create .msi
+$msiHelperBuildDir = ".\msi-helper-build"
+$msiHelperOutputDir = ".\msi-helper-output"
+Remove-Item -Path $msiHelperBuildDir, $msiHelperOutputDir, ".\msica.dll" -Force -Recurse -ErrorAction Ignore
+Invoke-CommandWithExitCheck -Command `
+    "$Env:JAVA_HOME\bin\jpackage" -Arguments @(
+    "--type", "msi",
+    "--win-upgrade-uuid", $UpgradeUUID,
+    "--app-image", $AppName,
+    "--dest", $msiHelperOutputDir,
+    "--name", "CryptomatorHelper",
+    "--vendor", $Vendor,
+    "--copyright", $copyright,
+    "--app-version", "1.0",
+    "--temp", $msiHelperBuildDir
+    )
+$msiHelperDll = Get-ChildItem -Path $msiHelperBuildDir -Recurse -Filter "msica.dll" | Select-Object -First 1
+if (-not $msiHelperDll) {
+	Write-Error "Unable to find msica.dll in $msiHelperBuildDir"
+	return 1
+}
+Copy-Item -Path $msiHelperDll.FullName -Destination ".\msica.dll" -Force
 $Env:JP_WIXWIZARD_RESOURCES = "$buildDir\resources\"
 $Env:JP_WIXWIZARD_RESOURCES_PROPERTIES_FORMAT = "${Env:JP_WIXWIZARD_RESOURCES}".Replace('\', '\\');
-$Env:JP_WIXHELPER_DIR = ""
+$Env:JP_WIXHELPER_DIR = "$((Get-Location).Path)\"
 
 Get-Content .\resources\FAvaultFile.template.properties ` # Similar to envsubst
     | ForEach-Object { $ExecutionContext.InvokeCommand.ExpandString($_) } `
@@ -251,6 +290,12 @@ Invoke-CommandWithExitCheck -Command `
     "--about-url", $AboutUrl,
     "--file-associations", "resources/FAvaultFile.properties"
     )
+Remove-Item -Path $msiHelperBuildDir, $msiHelperOutputDir, ".\msica.dll" -Force -Recurse -ErrorAction Ignore
+
+if ($BuildStage -eq 'Msi') {
+	Write-Host "BuildStage Msi requested; skipping EXE bundle creation."
+	return 0
+}
 
 #Create RTF license for bundle
 Invoke-CommandWithExitCheck -Command `
@@ -287,21 +332,27 @@ Invoke-WebRequest $winfspUninstaller -OutFile ".\bundle\resources\winfsp-uninsta
 Copy-Item ".\installer\$AppName-*.msi" -Destination ".\bundle\resources\$AppName.msi" -Force
 
 # create bundle including winfsp
-Invoke-CommandWithExitCheck -Command `
-    "wix" -Arguments @(
-    "build",
-    "-define", "BundleName=$AppName",
-    "-define", "BundleVersion=$semVerNo.$revisionNo",
-    "-define", "BundleVendor=$Vendor",
-    "-define", "BundleCopyright=$copyright",
-    "-define", "AboutUrl=$AboutUrl",
-    "-define", "HelpUrl=$HelpUrl",
-    "-define", "UpdateUrl=$UpdateUrl",
-    "-ext", "WixToolset.Util.wixext",
-    "-ext", "WixToolset.BootstrapperApplications.wixext",
-    ".\bundle\bundleWithWinfsp.wxs",
-    "-out", ".\installer\$AppName-Installer.exe"
+$bundleWixArgs = @(
+	"build",
+	"-define", "BundleName=$AppName",
+	"-define", "BundleVersion=$semVerNo.$revisionNo",
+	"-define", "BundleVendor=$Vendor",
+	"-define", "BundleCopyright=$copyright",
+	"-define", "AboutUrl=$AboutUrl",
+	"-define", "HelpUrl=$HelpUrl",
+	"-define", "UpdateUrl=$UpdateUrl",
+	"-define", "BundleUpgradeCode=$BundleUpgradeCode"
 )
+if ($BundleLaunchTarget) {
+	$bundleWixArgs += @("-define", "BundleLaunchTarget=$BundleLaunchTarget")
+}
+$bundleWixArgs += @(
+	"-ext", "WixToolset.Util.wixext",
+	"-ext", "WixToolset.BootstrapperApplications.wixext",
+	".\bundle\bundleWithWinfsp.wxs",
+	"-out", ".\installer\$AppName-Installer.exe"
+)
+Invoke-CommandWithExitCheck -Command "wix" -Arguments $bundleWixArgs
 
 Write-Host "Created EXE installer .\installer\$AppName-Installer.exe"
 return 0;
@@ -317,4 +368,3 @@ if ($clean) {
 	Remove-Item -Path ".\installer" -Force -Recurse -ErrorAction Ignore -ProgressAction SilentlyContinue
 }
 return Main
-

--- a/dist/win/bundle/bundleWithWinfsp.wxs
+++ b/dist/win/bundle/bundleWithWinfsp.wxs
@@ -1,7 +1,10 @@
 ﻿<!-- For Built in variables, see https://wixtoolset.org/docs/tools/burn/builtin-variables/-->
+<?ifndef BundleUpgradeCode ?>
+  <?define BundleUpgradeCode="29eea626-2e5b-4449-b5f8-4602925ddf7b"?>
+<?endif?>
 <ns0:Wix xmlns:ns0="http://wixtoolset.org/schemas/v4/wxs" xmlns:bal="http://wixtoolset.org/schemas/v4/wxs/bal" xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
     <ns0:Bundle Name="$(var.BundleName)"
-     UpgradeCode="29eea626-2e5b-4449-b5f8-4602925ddf7b"
+     UpgradeCode="$(var.BundleUpgradeCode)"
      Version="$(var.BundleVersion)"
      Manufacturer="$(var.BundleVendor)"
      AboutUrl="$(var.AboutUrl)"
@@ -14,6 +17,7 @@
         <util:ProductSearch Variable="InstalledLegacyWinFspVersion" Result="version" UpgradeCode="82F812D9-4083-4EF1-8BC8-0F1EDA05B46B" />
 
         <ns0:BootstrapperApplication>
+            <?ifdef BundleLaunchTarget ?>
             <bal:WixStandardBootstrapperApplication LicenseFile="bundle\resources\license.rtf" ShowVersion="yes"
               SuppressOptionsUI="yes"
               Theme="rtfLargeLicense"
@@ -21,7 +25,16 @@
               LocalizationFile="bundle\resources\customBootstrapperTheme.wxl"
               LogoSideFile="bundle\resources\logoSide.png"
               LogoFile="bundle\resources\logo.png"
-              LaunchTarget="[ProgramFiles64Folder]\$(var.BundleName)\$(var.BundleName).exe" />
+              LaunchTarget="$(var.BundleLaunchTarget)" />
+            <?else?>
+            <bal:WixStandardBootstrapperApplication LicenseFile="bundle\resources\license.rtf" ShowVersion="yes"
+              SuppressOptionsUI="yes"
+              Theme="rtfLargeLicense"
+              ThemeFile="bundle\resources\customBootstrapperTheme.xml"
+              LocalizationFile="bundle\resources\customBootstrapperTheme.wxl"
+              LogoSideFile="bundle\resources\logoSide.png"
+              LogoFile="bundle\resources\logo.png" />
+            <?endif?>
             <ns0:Payload SourceFile="bundle\resources\logoSide.png"/>
             <!-- Required due to https://github.com/wixtoolset/issues/issues/8104 -->
             <ns0:Payload Name="Cryptobot.ico" SourceFile="bundle\resources\Cryptomator.ico"/>


### PR DESCRIPTION
## Summary

- restore a native `windows-11-arm` app-image lane and architecture-specific MSI/EXE jobs
- add distinct Arm64 package identity, staged app-image/MSI builds, and PE architecture assertions
- wire Arm64 checksums/assets through draft-release and post-publish workflows
- document cross-architecture uninstall/reinstall and the remaining Snapdragon validation gate

## Validation

- YAML parsing passed for modified workflows
- PowerShell parser passed for `dist/win/build.ps1`
- WiX XML parsing passed for `bundleWithWinfsp.wxs`
- workflow output/consumer wiring and Arm64 PE constant (`0xAA64`) reviewed
- `git diff --check` passed

## Limitations

This is workflow-level and statically validated. A real hosted `windows-11-arm` run and physical Snapdragon install/upgrade/uninstall/vault mount/read/write validation are still required before release readiness can be claimed.

## AI assistance

GitHub Copilot assisted with investigation, implementation, and review. The resulting design and diff were independently reviewed against the repository, with no open critical/high findings.